### PR TITLE
[Hold] Update and harmonize org settings; enable parallel test runs

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -116,7 +116,12 @@ tasks:
         class_path: cumulusci.tasks.sfdx.SFDXOrgTask
         options:
             command: 'force:apex:test:run --codecoverage --testlevel RunLocalTests --resultformat human'
-
+    run_tests:
+        options:
+            retry_failures:
+                - "unable to obtain exclusive access to this record"
+                - "UNABLE_TO_LOCK_ROW"
+            retry_always: True
     dx:
         group: 'Salesforce DX'
         description: 'Calls a sfdx task with the cci Org User specificed.  Enter the sfdx task with the command option'

--- a/orgs/beta.json
+++ b/orgs/beta.json
@@ -1,10 +1,18 @@
 {
   "orgName": "Program Management Data Model - Beta Test Org",
   "edition": "Developer",
+  "features": [
+    "ContactsToMultipleAccounts"
+  ],
   "settings": {
-    "orgPreferenceSettings": {
-      "s1DesktopEnabled": true
-      , "chatterEnabled": true
+    "lightningExperienceSettings": {
+      "enableS1DesktopEnabled": true
+    },
+    "chatterSettings": {
+      "enableChatter": true
+    },
+    "enhancedNotesSettings": {
+      "enableEnhancedNotes": true
     }
   }
 }

--- a/orgs/beta_prerelease.json
+++ b/orgs/beta_prerelease.json
@@ -2,10 +2,18 @@
   "orgName": "Program Management Data Model - Prerelease Beta Test Org",
   "edition": "Developer",
   "instance": "cs46",
+  "features": [
+    "ContactsToMultipleAccounts"
+  ],
   "settings": {
-    "orgPreferenceSettings": {
-      "s1DesktopEnabled": true
-      , "chatterEnabled": true
+    "lightningExperienceSettings": {
+      "enableS1DesktopEnabled": true
+    },
+    "chatterSettings": {
+      "enableChatter": true
+    },
+    "enhancedNotesSettings": {
+      "enableEnhancedNotes": true
     }
   }
 }

--- a/orgs/dev.json
+++ b/orgs/dev.json
@@ -5,12 +5,20 @@
     "ContactsToMultipleAccounts"
   ],
   "settings": {
-    "orgPreferenceSettings": {
-        "chatterEnabled": true, 
-        "notesReservedPref01" : true,
-        "s1DesktopEnabled": true, 
-        "translation": true,
-        "s1EncryptedStoragePref2": false
+    "lightningExperienceSettings": {
+      "enableS1DesktopEnabled": true
+    },
+    "chatterSettings": {
+      "enableChatter": true
+    },
+    "languageSettings": {
+      "enableTranslationWorkbench": true
+    },
+    "mobileSettings": {
+      "enableS1EncryptedStoragePref2": false
+    },
+    "enhancedNotesSettings": {
+      "enableEnhancedNotes": true
     }
   }
 }

--- a/orgs/feature.json
+++ b/orgs/feature.json
@@ -1,11 +1,21 @@
 {
   "orgName": "Program Management Data Model - Feature Test Org",
   "edition": "Developer",
+  "features": [
+    "ContactsToMultipleAccounts"
+  ],
   "settings": {
-    "orgPreferenceSettings": {
-      "s1DesktopEnabled": true
-      , "chatterEnabled": true
-      , "translation": true 
+    "lightningExperienceSettings": {
+      "enableS1DesktopEnabled": true
+    },
+    "chatterSettings": {
+      "enableChatter": true
+    },
+    "languageSettings": {
+      "enableTranslationWorkbench": true
+    },
+    "enhancedNotesSettings": {
+      "enableEnhancedNotes": true
     }
   }
 }

--- a/orgs/npsp.json
+++ b/orgs/npsp.json
@@ -5,16 +5,20 @@
     "ContactsToMultipleAccounts"
   ],
   "settings": {
-    "orgPreferenceSettings": {
-        "chatterEnabled": true, 
-        "notesReservedPref01" : true,
-        "s1DesktopEnabled": true, 
-        "translation": true,
-        "s1EncryptedStoragePref2": false
+    "lightningExperienceSettings": {
+      "enableS1DesktopEnabled": true
     },
-    "accountSettings": {
-      "enableAccountTeams": true,
-      "showViewHierarchyLink": true
+    "chatterSettings": {
+      "enableChatter": true
+    },
+    "languageSettings": {
+      "enableTranslationWorkbench": true
+    },
+    "mobileSettings": {
+      "enableS1EncryptedStoragePref2": false
+    },
+    "enhancedNotesSettings": {
+      "enableEnhancedNotes": true
     }
   }
 }

--- a/orgs/prerelease.json
+++ b/orgs/prerelease.json
@@ -2,11 +2,21 @@
   "orgName": "Program Management Data Model - Prerelease Dev Org",
   "edition": "Developer",
   "instance": "cs46",
+  "features": [
+    "ContactsToMultipleAccounts"
+  ],
   "settings": {
-    "orgPreferenceSettings": {
-      "s1DesktopEnabled": true
-      , "chatterEnabled": true
-      , "translation": true 
+    "lightningExperienceSettings": {
+      "enableS1DesktopEnabled": true
+    },
+    "chatterSettings": {
+      "enableChatter": true
+    },
+    "languageSettings": {
+      "enableTranslationWorkbench": true
+    },
+    "enhancedNotesSettings": {
+      "enableEnhancedNotes": true
     }
   }
 }

--- a/orgs/release.json
+++ b/orgs/release.json
@@ -1,10 +1,18 @@
 {
   "orgName": "Program Management Data Model - Release Test Org",
   "edition": "Enterprise",
+  "features": [
+    "ContactsToMultipleAccounts"
+  ],
   "settings": {
-    "orgPreferenceSettings": {
-      "s1DesktopEnabled": true
-      , "chatterEnabled": true
+    "lightningExperienceSettings": {
+      "enableS1DesktopEnabled": true
+    },
+    "chatterSettings": {
+      "enableChatter": true
+    },
+    "enhancedNotesSettings": {
+      "enableEnhancedNotes": true
     }
   }
 }


### PR DESCRIPTION
This PR updates the org settings format in all .json files. It also turns on automated retry of row locking errors for Apex tests.

PMDM's existing Org Settings were inconsistent across builds. This PR attempts to harmonize them; please review the chosen settings for correctness.

# Critical Changes

# Changes

# Issues Closed
