### PR TITLE
qa_org flow uses config_qa

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -1,11 +1,11 @@
 minimum_cumulusci_version: "2.5.9"
 project:
-  name: pmdm
-  package:
-    name: Program Management Data Model
-    namespace: pmdm0
-    api_version: "46.0"
-  source_format: sfdx
+    name: pmdm
+    package:
+        name: Program Management Data Model
+        namespace: pmdm0
+        api_version: "46.0"
+    source_format: sfdx
 
 orgs:
     scratch:
@@ -37,10 +37,8 @@ orgs:
             config_file: orgs/npsp.json
             days: 7
             namespaced: True
-           
 
 tasks:
-
     cache_namespaces_in_org_config:
         description: Caches namespaces information in org_config
         class_path: tasks.namespaces.CacheNamespaces
@@ -58,9 +56,9 @@ tasks:
                 outputdir: robot/pmdm/results
 
     robot_testdoc:
-      options:
-        path: robot/pmdm/tests
-        output: robot/pmdm/doc/pmdm_tests.html
+        options:
+            path: robot/pmdm/tests
+            output: robot/pmdm/doc/pmdm_tests.html
 
     update_admin_profile:
         options:
@@ -90,7 +88,7 @@ tasks:
                   default: true
                 - record_type: Campaign.Default
                   default: true
-    
+
     update_admin_profile_caseman_npsp:
         class_path: cumulusci.tasks.salesforce.UpdateAdminProfile
         options:
@@ -111,11 +109,11 @@ tasks:
                 - record_type: Case.None
 
     run_all_local_tests:
-        group: 'Tests'
-        description: 'Runs all local Apex Tests including code coverage'
+        group: "Tests"
+        description: "Runs all local Apex Tests including code coverage"
         class_path: cumulusci.tasks.sfdx.SFDXOrgTask
         options:
-            command: 'force:apex:test:run --codecoverage --testlevel RunLocalTests --resultformat human'
+            command: "force:apex:test:run --codecoverage --testlevel RunLocalTests --resultformat human"
     run_tests:
         options:
             retry_failures:
@@ -123,20 +121,20 @@ tasks:
                 - "UNABLE_TO_LOCK_ROW"
             retry_always: True
     dx:
-      group: "Salesforce DX"
-      description: "Calls a sfdx task with the cci Org User specificed.  Enter the sfdx task with the command option"
-      class_path: cumulusci.tasks.sfdx.SFDXOrgTask
+        group: "Salesforce DX"
+        description: "Calls a sfdx task with the cci Org User specificed.  Enter the sfdx task with the command option"
+        class_path: cumulusci.tasks.sfdx.SFDXOrgTask
 
     dx_status:
-      group: "Salesforce DX"
-      description: "Calls sfdx force:source:status for cci Org User"
-      class_path: cumulusci.tasks.sfdx.SFDXOrgTask
-      options:
-        command: "force:source:status"
+        group: "Salesforce DX"
+        description: "Calls sfdx force:source:status for cci Org User"
+        class_path: cumulusci.tasks.sfdx.SFDXOrgTask
+        options:
+            command: "force:source:status"
 
     activate_flows:
-      description: This task activates all the process builder processes in the org
-      class_path: tasks.ActivateProcessBuilders.ActivateProcessBuilderProcesses
+        description: This task activates all the process builder processes in the org
+        class_path: tasks.ActivateProcessBuilders.ActivateProcessBuilderProcesses
 
     add_caseman_dependency:
         group: Impact Engineering
@@ -201,9 +199,9 @@ tasks:
         class_path: "tasks.UploadClientPhotos.UploadClientPhotos"
         options:
             directory_path: "data/bulk/client-photos"
-    
+
     deploy_dev_config:
-        group: 'pmdm: Config'
+        group: "pmdm: Config"
         description: Deploys the post-install configuration for an unmanaged DE org
         class_path: cumulusci.tasks.salesforce.Deploy
         options:
@@ -236,7 +234,7 @@ flows:
                     path: "data/scripts/npsp/de-duplicate_npsp_relationships.apex"
                     namespace: npsp
                 when: "'npsp' in org_config.namespaces"
-                
+
     npsp_pre_insert_bulk_data:
         steps:
             010:
@@ -268,13 +266,13 @@ flows:
             10:
                 task: update_admin_profile_caseman
                 when: "'npsp' not in org_config.namespaces and 'caseman' in org_config.namespaces"
-            20: 
+            20:
                 task: update_admin_profile_npsp
                 when: "'npsp' in org_config.namespaces and 'caseman' not in org_config.namespaces"
-            30: 
+            30:
                 task: update_admin_profile_caseman_npsp
                 when: "'npsp' in org_config.namespaces and 'caseman' in org_config.namespaces"
-            40: 
+            40:
                 task: update_admin_profile
                 when: "'npsp' not in org_config.namespaces and 'caseman' not in org_config.namespaces"
 
@@ -293,7 +291,7 @@ flows:
                 flow: dev_org_namespaced
 
     config_unmanaged:
-        steps:           
+        steps:
             100:
                 flow: update_admin_profile
             101:
@@ -317,12 +315,11 @@ flows:
                 flow: insert_data
 
     config_qa:
-        100:
-            task: deploy_qa_config
-        110:
-            task: activate_flows
-        200:
-            flow: config_unmanaged
+        steps:
+            100:
+                task: activate_flows
+            200:
+                flow: config_unmanaged
 
     config_dev:
         steps:
@@ -346,4 +343,3 @@ flows:
                 flow: config_dev_namespaced
             4:
                 task: snapshot_changes
-


### PR DESCRIPTION
# Development changes
-  `config_qa` flow was missing `steps' attribute in flow definition
-  Removed `deploy_qa_config` task in `config_qa` flow since the task doesn't exist

# Critical Changes

# Changes

# Issues Closed
