### PR TITLE
Enable new profile editor, login-as, deactivate force-relogin

### DIFF
--- a/orgs/beta.json
+++ b/orgs/beta.json
@@ -13,6 +13,15 @@
         },
         "pathAssistantSettings": {
             "pathAssistantEnabled": true
+        },
+        "userManagementSettings": {
+            "enableNewProfileUI": true
+        },
+        "securitySettings": {
+            "enableAdminLoginAsAnyUser": true,
+            "sessionSettings": {
+                "forceRelogin": false
+            }
         }
     }
 }

--- a/orgs/beta_prerelease.json
+++ b/orgs/beta_prerelease.json
@@ -14,6 +14,15 @@
         },
         "pathAssistantSettings": {
             "pathAssistantEnabled": true
+        },
+        "userManagementSettings": {
+            "enableNewProfileUI": true
+        },
+        "securitySettings": {
+            "enableAdminLoginAsAnyUser": true,
+            "sessionSettings": {
+                "forceRelogin": false
+            }
         }
     }
 }

--- a/orgs/dev.json
+++ b/orgs/dev.json
@@ -19,6 +19,15 @@
         },
         "pathAssistantSettings": {
             "pathAssistantEnabled": true
+        },
+        "userManagementSettings": {
+            "enableNewProfileUI": true
+        },
+        "securitySettings": {
+            "enableAdminLoginAsAnyUser": true,
+            "sessionSettings": {
+                "forceRelogin": false
+            }
         }
     }
 }

--- a/orgs/feature.json
+++ b/orgs/feature.json
@@ -16,6 +16,15 @@
         },
         "pathAssistantSettings": {
             "pathAssistantEnabled": true
+        },
+        "userManagementSettings": {
+            "enableNewProfileUI": true
+        },
+        "securitySettings": {
+            "enableAdminLoginAsAnyUser": true,
+            "sessionSettings": {
+                "forceRelogin": false
+            }
         }
     }
 }

--- a/orgs/npsp.json
+++ b/orgs/npsp.json
@@ -19,6 +19,15 @@
         },
         "pathAssistantSettings": {
             "pathAssistantEnabled": true
+        },
+        "userManagementSettings": {
+            "enableNewProfileUI": true
+        },
+        "securitySettings": {
+            "enableAdminLoginAsAnyUser": true,
+            "sessionSettings": {
+                "forceRelogin": false
+            }
         }
     }
 }

--- a/orgs/prerelease.json
+++ b/orgs/prerelease.json
@@ -17,6 +17,15 @@
         },
         "pathAssistantSettings": {
             "pathAssistantEnabled": true
+        },
+        "userManagementSettings": {
+            "enableNewProfileUI": true
+        },
+        "securitySettings": {
+            "enableAdminLoginAsAnyUser": true,
+            "sessionSettings": {
+                "forceRelogin": false
+            }
         }
     }
 }

--- a/orgs/release.json
+++ b/orgs/release.json
@@ -13,6 +13,15 @@
         },
         "pathAssistantSettings": {
             "pathAssistantEnabled": true
+        },
+        "userManagementSettings": {
+            "enableNewProfileUI": true
+        },
+        "securitySettings": {
+            "enableAdminLoginAsAnyUser": true,
+            "sessionSettings": {
+                "forceRelogin": false
+            }
         }
     }
 }


### PR DESCRIPTION
# Critical Changes

# Changes
- New orgs default to use Enhanced Profile Editor
- New orgs default to allow Login-As
- New orgs default to not force relogin after Login-As

# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
- [x] Code does not reference translatable strings in its logic
- [x] Place holder data is incorporated (Refer to [Case Management Sample Data document](https://quip.com/cbFcAPJF8t0z))
- [x] Base axe-core JEST test included for any new LWC (No critical violations)
- [x] CRUD/FLS is enforced in Apex
- [x] Permission sets are updated to account for CRUD/FLS for new object metadata
- [x] All modified classes are unit tested (Apex) at 100% coverage
- [x] UX approval or UX not necessary
- [x] PR contains draft release notes
- [x] Attach work item to the pull request with [Lurch](https://salesforce.quip.com/50ZRA5LEWVzH) `**Lurch:attach W-000000` or `**Lurch:add`
- [ ] All **acceptance criteria** have been met
    - [x] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [ ] QE story level testing completed


