### PR TITLE
Add missing CustomObjectTranslations from packaging org

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -141,9 +141,6 @@ tasks:
                     - NewOpportunity
                     - NewTask
                     - LogACall
-            ignore_types:
-                - RecordType
-                - CustomObjectTranslation
 
     deploy_service_delivery_modal_test:
         group: "PMM: Tests"

--- a/force-app/main/default/objectTranslations/Contact-de/Contact-de.objectTranslation-meta.xml
+++ b/force-app/main/default/objectTranslations/Contact-de/Contact-de.objectTranslation-meta.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata"/>

--- a/force-app/main/default/objectTranslations/Contact-es/Contact-es.objectTranslation-meta.xml
+++ b/force-app/main/default/objectTranslations/Contact-es/Contact-es.objectTranslation-meta.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata"/>

--- a/force-app/main/default/objectTranslations/Contact-fr/Contact-fr.objectTranslation-meta.xml
+++ b/force-app/main/default/objectTranslations/Contact-fr/Contact-fr.objectTranslation-meta.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata"/>

--- a/force-app/main/default/objectTranslations/Contact-iw/Contact-iw.objectTranslation-meta.xml
+++ b/force-app/main/default/objectTranslations/Contact-iw/Contact-iw.objectTranslation-meta.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata"/>

--- a/force-app/main/default/objectTranslations/Contact-ja/Contact-ja.objectTranslation-meta.xml
+++ b/force-app/main/default/objectTranslations/Contact-ja/Contact-ja.objectTranslation-meta.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata"/>

--- a/force-app/main/default/objectTranslations/Contact-nl_NL/Contact-nl_NL.objectTranslation-meta.xml
+++ b/force-app/main/default/objectTranslations/Contact-nl_NL/Contact-nl_NL.objectTranslation-meta.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata"/>

--- a/force-app/main/default/objectTranslations/ProgramCohort__c-en_US/ProgramCohort__c-en_US.objectTranslation-meta.xml
+++ b/force-app/main/default/objectTranslations/ProgramCohort__c-en_US/ProgramCohort__c-en_US.objectTranslation-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value>Program Cohort</value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value>Program Cohorts</value>
+    </caseValues>
+    <startsWith>Consonant</startsWith>
+</CustomObjectTranslation>

--- a/force-app/main/default/objectTranslations/ProgramEngagement__c-en_US/ProgramEngagement__c-en_US.objectTranslation-meta.xml
+++ b/force-app/main/default/objectTranslations/ProgramEngagement__c-en_US/ProgramEngagement__c-en_US.objectTranslation-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value>Program Engagement</value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value>Program Engagements</value>
+    </caseValues>
+    <startsWith>Consonant</startsWith>
+</CustomObjectTranslation>

--- a/force-app/main/default/objectTranslations/Program__c-en_US/Program__c-en_US.objectTranslation-meta.xml
+++ b/force-app/main/default/objectTranslations/Program__c-en_US/Program__c-en_US.objectTranslation-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value>Program</value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value>Programs</value>
+    </caseValues>
+    <startsWith>Consonant</startsWith>
+</CustomObjectTranslation>

--- a/force-app/main/default/objectTranslations/ServiceDelivery__c-en_US/ServiceDelivery__c-en_US.objectTranslation-meta.xml
+++ b/force-app/main/default/objectTranslations/ServiceDelivery__c-en_US/ServiceDelivery__c-en_US.objectTranslation-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value>Service Delivery</value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value>Service Deliveries</value>
+    </caseValues>
+    <startsWith>Consonant</startsWith>
+</CustomObjectTranslation>

--- a/force-app/main/default/objectTranslations/Service__c-en_US/Service__c-en_US.objectTranslation-meta.xml
+++ b/force-app/main/default/objectTranslations/Service__c-en_US/Service__c-en_US.objectTranslation-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
+    <caseValues>
+        <plural>false</plural>
+        <value>Service</value>
+    </caseValues>
+    <caseValues>
+        <plural>true</plural>
+        <value>Services</value>
+    </caseValues>
+    <startsWith>Consonant</startsWith>
+</CustomObjectTranslation>


### PR DESCRIPTION
# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
- [ ] Code does not reference translatable strings in its logic
- [ ] Place holder data is incorporated (Refer to [Case Management Sample Data document](https://quip.com/cbFcAPJF8t0z))
- [ ] Base axe-core JEST test included for any new LWC (No critical violations)
- [ ] CRUD/FLS is enforced in Apex
- [ ] Permission sets are updated to account for CRUD/FLS for new object metadata
- [ ] All modified classes are unit tested (Apex) at 100% coverage
- [ ] UX approval or UX not necessary
- [ ] PR contains draft release notes
- [ ] Attach work item to the pull request with [Lurch](https://salesforce.quip.com/50ZRA5LEWVzH) `**Lurch:attach W-000000` or `**Lurch:add`
- [ ] All **acceptance criteria** have been met
    - [ ] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [ ] QE story level testing completed


