### PR TITLE
Remove scrolling on BSDT to fix date popup

### DIFF
--- a/force-app/main/default/staticresources/pmm/bsdtOverrides.css
+++ b/force-app/main/default/staticresources/pmm/bsdtOverrides.css
@@ -1,6 +1,4 @@
 .bsdt .slds-card__body {
-    max-height: 600px;
-    overflow-y: scroll;
     min-height: 350px;
 }
 


### PR DESCRIPTION
# Critical Changes

# Changes
- We removed scrolling on the Bulk Service Delivery Tool to allow the date popup to successfully record the Service Delivery Date.

# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
- [ ] Code does not reference translatable strings in its logic
- [ ] Place holder data is incorporated (Refer to [Case Management Sample Data document](https://quip.com/cbFcAPJF8t0z))
- [ ] Base axe-core JEST test included for any new LWC (No critical violations)
- [ ] CRUD/FLS is enforced in Apex
- [ ] Permission sets are updated to account for CRUD/FLS for new object metadata
- [ ] All modified classes are unit tested (Apex) at 100% coverage
- [ ] UX approval or UX not necessary
- [ ] PR contains draft release notes
- [ ] Attach work item to the pull request with [Lurch](https://salesforce.quip.com/50ZRA5LEWVzH) `**Lurch:attach W-000000` or `**Lurch:add`
- [ ] All **acceptance criteria** have been met
    - [ ] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [ ] QE story level testing completed


