### PR TITLE
Fix filter on client records with missing phone number

### DIFF
--- a/force-app/main/default/reports/ProgramManagementReports/Client_Records_with_Missing_Phone_Number.report-meta.xml
+++ b/force-app/main/default/reports/ProgramManagementReports/Client_Records_with_Missing_Phone_Number.report-meta.xml
@@ -23,6 +23,12 @@
             <operator>equals</operator>
             <value/>
         </criteriaItems>
+        <criteriaItems>
+            <column>Contact.IsClient__c</column>
+            <isUnlocked>true</isUnlocked>
+            <operator>equals</operator>
+            <value>1</value>
+        </criteriaItems>
         <language>en_US</language>
     </filter>
     <format>Summary</format>
@@ -37,7 +43,7 @@
         <value>1</value>
     </params>
     <reportType>ContactList</reportType>
-    <scope>organization</scope>
+    <scope>my</scope>
     <showDetails>true</showDetails>
     <showGrandTotal>true</showGrandTotal>
     <showSubTotals>true</showSubTotals>

--- a/force-app/main/default/reports/ProgramManagementReports/Client_Records_with_Missing_Phone_Number.report-meta.xml
+++ b/force-app/main/default/reports/ProgramManagementReports/Client_Records_with_Missing_Phone_Number.report-meta.xml
@@ -43,7 +43,7 @@
         <value>1</value>
     </params>
     <reportType>ContactList</reportType>
-    <scope>my</scope>
+    <scope>organization</scope>
     <showDetails>true</showDetails>
     <showGrandTotal>true</showGrandTotal>
     <showSubTotals>true</showSubTotals>


### PR DESCRIPTION
# Critical Changes

# Changes
 - We added a new filter to filter by Client to the report, Client Records with Missing Phone Number.
 - We changed the existing filter on the report, Client Records with Missing Phone Number to show only 'My Contacts'  instead of 'All Accounts.'

# Issues Closed
 Fixes - #188
# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
- [ ] Code does not reference translatable strings in its logic
- [ ] Place holder data is incorporated (Refer to [Case Management Sample Data document](https://quip.com/cbFcAPJF8t0z))
- [ ] Base axe-core JEST test included for any new LWC (No critical violations)
- [ ] CRUD/FLS is enforced in Apex
- [ ] Permission sets are updated to account for CRUD/FLS for new object metadata
- [ ] All modified classes are unit tested (Apex) at 100% coverage
- [ ] UX approval or UX not necessary
- [ ] PR contains draft release notes
- [ ] Attach work item to the pull request with [Lurch](https://salesforce.quip.com/50ZRA5LEWVzH) `**Lurch:attach W-000000` or `**Lurch:add`
- [ ] All **acceptance criteria** have been met
    - [x] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [ ] QE story level testing completed


