### PR TITLE
Add Telemetry Count for Active Programs with Program Engagements

### DIFF
--- a/force-app/main/default/classes/FeatureParameters.cls
+++ b/force-app/main/default/classes/FeatureParameters.cls
@@ -4,6 +4,14 @@ public inherited sharing class FeatureParameters {
         ACTIVE_PROGRAMS,
         ACTIVE_PROGRAMS_WITH_ENGAGEMENTS_LAST30
     }
+
+    private static final String ACTIVE_PROGRAM_CONDITION =
+        String.valueOf(Program__c.Status__c) +
+        ' = ' +
+        '\'Active\'';
+
+    private static final String CREATED_LAST_30_CONDITION = 'CreatedDate = LAST_N_DAYS:30';
+
     @TestVisible
     private List<FeatureManagement.FeatureParameter> featureParameters = new List<FeatureManagement.FeatureParameter>();
 
@@ -40,11 +48,7 @@ public inherited sharing class FeatureParameters {
                 if (queryBuilder == null) {
                     queryBuilder = new QueryBuilder()
                         .withSObjectType(Program__c.SObjectType)
-                        .withCondition(
-                            String.valueOf(Program__c.Status__c) +
-                            ' = ' +
-                            '\'Active\''
-                        );
+                        .addCondition(ACTIVE_PROGRAM_CONDITION);
                 }
 
                 return queryBuilder;
@@ -89,7 +93,8 @@ public inherited sharing class FeatureParameters {
                 if (queryBuilder == null) {
                     queryBuilder = new QueryBuilder()
                         .withSObjectType(Program__c.SObjectType)
-                        .withConditions(buildConditions());
+                        .addCondition(ACTIVE_PROGRAM_CONDITION)
+                        .addCondition('Id IN (' + buildProgramEngagementQuery() + ')');
                 }
 
                 return queryBuilder;
@@ -126,19 +131,14 @@ public inherited sharing class FeatureParameters {
             return finder.findCount();
         }
 
-        private List<String> buildConditions() {
-            List<String> conditions = new List<String>();
-            String programEngagementQuery = new QueryBuilder()
+        private String buildProgramEngagementQuery() {
+            return new QueryBuilder()
                 .withSObjectType(ProgramEngagement__c.SObjectType)
                 .withSelectFields(
                     new List<String>{ String.valueOf(ProgramEngagement__c.Program__c) }
                 )
-                .withCondition('CreatedDate = LAST_N_DAYS:30')
+                .addCondition(CREATED_LAST_30_CONDITION)
                 .buildSoqlQuery();
-            conditions.add(String.valueOf(Program__c.Status__c) + ' = ' + '\'Active\'');
-            conditions.add('Id IN (' + programEngagementQuery + ')');
-
-            return conditions;
         }
     }
 }

--- a/force-app/main/default/classes/FeatureParameters.cls
+++ b/force-app/main/default/classes/FeatureParameters.cls
@@ -1,15 +1,35 @@
 public inherited sharing class FeatureParameters {
     @TestVisible
      private enum DeveloperName {
-        ACTIVE_PROGRAMS
+        ACTIVE_PROGRAMS,
+        ACTIVE_PROGRAMS_WITH_ENGAGEMENTS_LAST30
     }
     @TestVisible
     private List<FeatureManagement.FeatureParameter> featureParameters = new List<FeatureManagement.FeatureParameter>();
 
     public List<FeatureManagement.FeatureParameter> getAll() {
-        featureParameters.add(new ActivePrograms());
+        for (DeveloperName devName : DeveloperName.values()) {
+            featureParameters.add(makeFeatureParameter(devName));
+        }
 
         return featureParameters;
+    }
+
+    @TestVisible
+    private FeatureManagement.FeatureParameter makeFeatureParameter(
+        DeveloperName devName
+    ) {
+        switch on devName {
+            when ACTIVE_PROGRAMS {
+                return new ActivePrograms();
+            }
+            when ACTIVE_PROGRAMS_WITH_ENGAGEMENTS_LAST30 {
+                return new ActiveProgramsWithEngagementsLast30();
+            }
+            when else {
+                return null;
+            }
+        }
     }
 
     @TestVisible
@@ -58,6 +78,67 @@ public inherited sharing class FeatureParameters {
 
         private Object getValue() {
             return finder.findCount();
+        }
+    }
+
+    @TestVisible
+    private inherited sharing class ActiveProgramsWithEngagementsLast30 implements FeatureManagement.FeatureParameter {
+        @TestVisible
+        private QueryBuilder queryBuilder {
+            get {
+                if (queryBuilder == null) {
+                    queryBuilder = new QueryBuilder()
+                        .withSObjectType(Program__c.SObjectType)
+                        .withConditions(buildConditions());
+                }
+
+                return queryBuilder;
+            }
+            set;
+        }
+        @TestVisible
+        private Finder finder {
+            get {
+                if (finder == null) {
+                    finder = new Finder(queryBuilder);
+                }
+
+                return finder;
+            }
+            set;
+        }
+
+        public void send() {
+            final Object value = getValue();
+
+            if (value instanceof Integer) {
+                FeatureManagement.getInstance()
+                    .setPackageIntegerValue(getName(), (Integer) value);
+            }
+        }
+
+        private String getName() {
+            return DeveloperName.ACTIVE_PROGRAMS_WITH_ENGAGEMENTS_LAST30.name()
+                .remove('_');
+        }
+
+        private Object getValue() {
+            return finder.findCount();
+        }
+
+        private List<String> buildConditions() {
+            List<String> conditions = new List<String>();
+            String programEngagementQuery = new QueryBuilder()
+                .withSObjectType(ProgramEngagement__c.SObjectType)
+                .withSelectFields(
+                    new List<String>{ String.valueOf(ProgramEngagement__c.Program__c) }
+                )
+                .withCondition('CreatedDate = LAST_N_DAYS:30')
+                .buildSoqlQuery();
+            conditions.add(String.valueOf(Program__c.Status__c) + ' = ' + '\'Active\'');
+            conditions.add('Id IN (' + programEngagementQuery + ')');
+
+            return conditions;
         }
     }
 }

--- a/force-app/main/default/classes/FeatureParameters_TEST.cls
+++ b/force-app/main/default/classes/FeatureParameters_TEST.cls
@@ -69,4 +69,22 @@ public with sharing class FeatureParameters_TEST {
             'Expected the finder to auto create on demand.'
         );
     }
+
+    @IsTest
+    private static void shouldPassActualActivePrograms() {
+        final String expectedName = FeatureParameters.DeveloperName.ACTIVE_PROGRAMS.name()
+            .remove('_');
+        final Integer expectedValue = 0;
+        FeatureManagement.instance = (FeatureManagement) featureManagementStub.createMock();
+
+        Test.startTest();
+        new FeatureParameters.ActivePrograms().send();
+        Test.stopTest();
+
+        featureManagementStub.assertCalledWith(
+            'setPackageIntegerValue',
+            new List<Type>{ String.class, Integer.class },
+            new List<Object>{ expectedName, expectedValue }
+        );
+    }
 }

--- a/force-app/main/default/classes/FeatureParameters_TEST.cls
+++ b/force-app/main/default/classes/FeatureParameters_TEST.cls
@@ -1,5 +1,9 @@
 @IsTest
 public with sharing class FeatureParameters_TEST {
+    private static final BasicStub featureManagementStub = new BasicStub(
+        FeatureManagement.class
+    );
+
     @IsTest
     private static void shouldRetrunAllParameters() {
         List<FeatureManagement.FeatureParameter> allFeatureParameters = new FeatureParameters()
@@ -24,7 +28,6 @@ public with sharing class FeatureParameters_TEST {
         final Integer expectedValue = 10;
         Integer ordinalValue = FeatureParameters.DeveloperName.ACTIVE_PROGRAMS.ordinal();
 
-        BasicStub featureManagementStub = new BasicStub(FeatureManagement.class);
         FeatureManagement.instance = (FeatureManagement) featureManagementStub.createMock();
 
         List<FeatureManagement.FeatureParameter> allFeatureParameters = new FeatureParameters()

--- a/force-app/main/default/classes/FeatureParameters_TEST.cls
+++ b/force-app/main/default/classes/FeatureParameters_TEST.cls
@@ -4,6 +4,11 @@ public with sharing class FeatureParameters_TEST {
         FeatureManagement.class
     );
 
+    @TestSetup
+    static void generateData() {
+        ProgramTestDataFactory.insertTestData(true);
+    }
+
     @IsTest
     private static void shouldRetrunAllParameters() {
         List<FeatureManagement.FeatureParameter> allFeatureParameters = new FeatureParameters()
@@ -18,6 +23,20 @@ public with sharing class FeatureParameters_TEST {
         System.assert(
             !allFeatureParameters.isEmpty(),
             'Expected at least one feature parameter to be returned.'
+        );
+
+        System.assert(!allFeatureParameters.contains(null));
+    }
+
+    @IsTest
+    private static void shouldReturnNullForUndefinedParameters() {
+        FeatureManagement.FeatureParameter featureParameter = new FeatureParameters()
+            .makeFeatureParameter(null);
+
+        System.assertEquals(
+            null,
+            featureParameter,
+            'Expected null to be returned when dev enum is null.'
         );
     }
 
@@ -52,6 +71,36 @@ public with sharing class FeatureParameters_TEST {
     }
 
     @IsTest
+    private static void shouldCallSetPackageIntegerByActiveProgramsWithEngagementsLast30() {
+        final String expectedName = FeatureParameters.DeveloperName.ACTIVE_PROGRAMS_WITH_ENGAGEMENTS_LAST30.name()
+            .remove('_');
+        final Integer expectedValue = 10;
+        Integer ordinalValue = FeatureParameters.DeveloperName.ACTIVE_PROGRAMS_WITH_ENGAGEMENTS_LAST30.ordinal();
+
+        FeatureManagement.instance = (FeatureManagement) featureManagementStub.createMock();
+
+        List<FeatureManagement.FeatureParameter> allFeatureParameters = new FeatureParameters()
+            .getAll();
+        FeatureParameters.ActiveProgramsWithEngagementsLast30 activeProgramsWithEnagegmentsParameter = (FeatureParameters.ActiveProgramsWithEngagementsLast30) allFeatureParameters[
+            ordinalValue
+        ];
+        BasicStub finderStub = new BasicStub(Finder.class)
+            .withReturnValue('findCount', expectedValue);
+        activeProgramsWithEnagegmentsParameter.finder = (Finder) finderStub.createMock();
+
+        Test.startTest();
+        activeProgramsWithEnagegmentsParameter.send();
+        Test.stopTest();
+
+        finderStub.assertCalled('findCount');
+        featureManagementStub.assertCalledWith(
+            'setPackageIntegerValue',
+            new List<Type>{ String.class, Integer.class },
+            new List<Object>{ expectedName, expectedValue }
+        );
+    }
+
+    @IsTest
     private static void shouldCreateTheQueryBuilderOnDemand() {
         QueryBuilder queryBuilder = new FeatureParameters.ActivePrograms().queryBuilder;
 
@@ -75,13 +124,57 @@ public with sharing class FeatureParameters_TEST {
 
     @IsTest
     private static void shouldPassActualActivePrograms() {
+        List<Program__c> programs = [
+            SELECT Id
+            FROM Program__c
+            WHERE Status__c = 'Active'
+        ];
+        System.assert(
+            !programs.isEmpty(),
+            'Sanity check: Test setup should have generated at least 1 active record.'
+        );
+
         final String expectedName = FeatureParameters.DeveloperName.ACTIVE_PROGRAMS.name()
             .remove('_');
-        final Integer expectedValue = 0;
+        final Integer expectedValue = programs.size();
         FeatureManagement.instance = (FeatureManagement) featureManagementStub.createMock();
 
         Test.startTest();
         new FeatureParameters.ActivePrograms().send();
+        Test.stopTest();
+
+        featureManagementStub.assertCalledWith(
+            'setPackageIntegerValue',
+            new List<Type>{ String.class, Integer.class },
+            new List<Object>{ expectedName, expectedValue }
+        );
+    }
+
+    @IsTest
+    private static void shouldPassActualActiveProgramsWithEngagementsLast30() {
+        List<Program__c> programs = [
+            SELECT Id
+            FROM Program__c
+            WHERE
+                Status__c = 'Active'
+                AND Id IN (
+                    SELECT Program__c
+                    FROM ProgramEngagement__c
+                    WHERE CreatedDate = LAST_N_DAYS:30
+                )
+        ];
+        System.assert(
+            !programs.isEmpty(),
+            'Sanity check: Test setup should have generated at least 1 active record with a related program engagement.'
+        );
+
+        final String expectedName = FeatureParameters.DeveloperName.ACTIVE_PROGRAMS_WITH_ENGAGEMENTS_LAST30.name()
+            .remove('_');
+        final Integer expectedValue = programs.size();
+        FeatureManagement.instance = (FeatureManagement) featureManagementStub.createMock();
+
+        Test.startTest();
+        new FeatureParameters.ActiveProgramsWithEngagementsLast30().send();
         Test.stopTest();
 
         featureManagementStub.assertCalledWith(

--- a/force-app/main/default/classes/InstallScript_TEST.cls
+++ b/force-app/main/default/classes/InstallScript_TEST.cls
@@ -7,6 +7,7 @@ private with sharing class InstallScript_TEST {
     @IsTest
     private static void shouldNotCallTelemetryServiceOnInstall() {
         telemetryService = (TelemetryService) telemetryServiceStub.createMock();
+        installScript.telemetryService = telemetryService;
         Test.testInstall(installScript, null);
 
         telemetryServiceStub.assertNotCalled('sendUsageMetrics');

--- a/force-app/main/default/classes/QueryBuilder.cls
+++ b/force-app/main/default/classes/QueryBuilder.cls
@@ -19,12 +19,8 @@ public inherited sharing class QueryBuilder {
         return this;
     }
 
-    public QueryBuilder withCondition(String condition) {
-        return withConditions(new List<String>{ condition });
-    }
-
-    public QueryBuilder withConditions(List<String> conditions) {
-        this.conditions.addAll(conditions);
+    public QueryBuilder addCondition(String condition) {
+        conditions.add(condition);
         return this;
     }
 
@@ -39,12 +35,10 @@ public inherited sharing class QueryBuilder {
     }
 
     public String buildSoqlQuery() {
-        List<String> uniqueSelectFields = buildSelectFields();
-
         return String.format(
             'SELECT {0} FROM {1}{2}{3}{4}',
             new List<String>{
-                String.join(uniqueSelectFields, ', '),
+                buildSelectFields(),
                 sObjectType.getDescribe().getName(),
                 buildWhereClause(),
                 buildOrderBy(),
@@ -62,20 +56,20 @@ public inherited sharing class QueryBuilder {
         );
     }
 
-    private List<String> buildSelectFields() {
+    private String buildSelectFields() {
         validate();
 
         Set<String> fields = new Set<String>();
 
         if (selectFields == null || selectFields.isEmpty()) {
-            fields.add('Id');
+            fields.add('id');
         } else {
             for (String field : selectFields) {
-                fields.add(field);
+                fields.add(field.toLowerCase());
             }
         }
 
-        return new List<String>(fields);
+        return String.join(new List<String>(fields), ', ');
     }
 
     private void validate() {

--- a/force-app/main/default/classes/QueryBuilder_TEST.cls
+++ b/force-app/main/default/classes/QueryBuilder_TEST.cls
@@ -21,7 +21,7 @@ public with sharing class QueryBuilder_TEST {
             'SELECT count() FROM Account WHERE ' + condition;
         final String actualCountQuery = new QueryBuilder()
             .withSObjectType(Account.SObjectType)
-            .withCondition(condition)
+            .addCondition(condition)
             .buildCountQuery();
 
         System.assertEquals(
@@ -37,7 +37,7 @@ public with sharing class QueryBuilder_TEST {
             String.valueOf(Account.Id),
             String.valueOf(Account.Name)
         };
-        final String expectedSoqlQuery = 'SELECT Id, Name FROM Account';
+        final String expectedSoqlQuery = 'SELECT id, name FROM Account';
         final String actualSoqlQuery = new QueryBuilder()
             .withSObjectType(Account.SObjectType)
             .withSelectFields(fields)
@@ -53,7 +53,7 @@ public with sharing class QueryBuilder_TEST {
     @IsTest
     private static void shouldBuildSoqlQueryWithIdWhenWithoutFields() {
         final List<String> fields = new List<String>{ String.valueOf(Account.Id) };
-        final String expectedSoqlQuery = 'SELECT Id FROM Account';
+        final String expectedSoqlQuery = 'SELECT id FROM Account';
         final String actualSoqlQuery = new QueryBuilder()
             .withSObjectType(Account.SObjectType)
             .buildSoqlQuery();
@@ -73,11 +73,11 @@ public with sharing class QueryBuilder_TEST {
         };
         final String condition = 'Name = \'Test Account\'';
         final String expectedSoqlQuery =
-            'SELECT Id, Name FROM Account WHERE ' + condition;
+            'SELECT id, name FROM Account WHERE ' + condition;
         final String actualSoqlQuery = new QueryBuilder()
             .withSObjectType(Account.SObjectType)
             .withSelectFields(fields)
-            .withCondition(condition)
+            .addCondition(condition)
             .buildSoqlQuery();
 
         System.assertEquals(
@@ -89,7 +89,7 @@ public with sharing class QueryBuilder_TEST {
 
     @IsTest
     private static void shouldBuildSoqlQueryWithOrderBy() {
-        final String expectedSoqlQuery = 'SELECT Id FROM Account ORDER BY Id';
+        final String expectedSoqlQuery = 'SELECT id FROM Account ORDER BY Id';
         final String actualSoqlQuery = new QueryBuilder()
             .withSObjectType(Account.SObjectType)
             .withOrderBy('Id')
@@ -104,7 +104,7 @@ public with sharing class QueryBuilder_TEST {
 
     @IsTest
     private static void shouldBuildSoqlQueryWithLimit() {
-        final String expectedSoqlQuery = 'SELECT Id FROM Account LIMIT 1';
+        final String expectedSoqlQuery = 'SELECT id FROM Account LIMIT 1';
         final String actualSoqlQuery = new QueryBuilder()
             .withSObjectType(Account.SObjectType)
             .withLimit(1)
@@ -119,10 +119,10 @@ public with sharing class QueryBuilder_TEST {
 
     @IsTest
     private static void shouldNotAddWhereClauseForEmptyCondition() {
-        final String expectedSoqlQuery = 'SELECT Id FROM Account';
+        final String expectedSoqlQuery = 'SELECT id FROM Account';
         final String actualSoqlQuery = new QueryBuilder()
             .withSObjectType(Account.SObjectType)
-            .withCondition('')
+            .addCondition('')
             .buildSoqlQuery();
 
         System.assertEquals(

--- a/force-app/main/default/featureParameters/ActiveProgramsWithEngagementsLast30.featureParameterInteger-meta.xml
+++ b/force-app/main/default/featureParameters/ActiveProgramsWithEngagementsLast30.featureParameterInteger-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FeatureParameterInteger xmlns="http://soap.sforce.com/2006/04/metadata">
+    <dataflowDirection>SubscriberToLmo</dataflowDirection>
+    <masterLabel>The number of Active Programs with Program Engagements Created Last 30 Days</masterLabel>
+    <value>-1</value>
+</FeatureParameterInteger>


### PR DESCRIPTION
# Critical Changes

# Changes
- Added a Feature Parameter, type integer, to capture the count of Active Programs with Program Engagements created in the Last 30 Days. For more information about telemetry, look for the PMM Feature Telemetry article in the [Program Management Module Documentation](https://powerofus.force.com/PMM_Documentation)

# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
- [x] Code does not reference translatable strings in its logic
- [ ] Place holder data is incorporated (Refer to [Case Management Sample Data document](https://quip.com/cbFcAPJF8t0z))
- [ ] Base axe-core JEST test included for any new LWC (No critical violations)
- [ ] CRUD/FLS is enforced in Apex
- [ ] Permission sets are updated to account for CRUD/FLS for new object metadata
- [x] All modified classes are unit tested (Apex) at 100% coverage
- [ ] UX approval or UX not necessary
- [x] PR contains draft release notes
- [x] Attach work item to the pull request with [Lurch](https://salesforce.quip.com/50ZRA5LEWVzH) `**Lurch:attach W-000000` or `**Lurch:add`
- [ ] All **acceptance criteria** have been met
    - [x] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [ ] QE story level testing completed


