### PR TITLE
default to Quantity label if no UoM defined on Service

### DIFF
--- a/force-app/main/default/lwc/serviceDeliveryRow/serviceDeliveryRow.js
+++ b/force-app/main/default/lwc/serviceDeliveryRow/serviceDeliveryRow.js
@@ -105,6 +105,7 @@ export default class ServiceDeliveryRow extends LightningElement {
         saved,
         saving,
         error,
+        quantity,
     };
     fields = {
         contact: CONTACT_FIELD,
@@ -264,9 +265,13 @@ export default class ServiceDeliveryRow extends LightningElement {
         this.handleSaveEnd();
         this.lockContactField();
         fireEvent(this.pageRef, "serviceDeliveryUpsert", event.detail);
-        if (event.detail.fields[this.fields.unitOfMeasurement.fieldApiName]) {
+        if (
+            event.detail.fields[this.fields.unitOfMeasurement.fieldApiName].value !== null
+        ) {
             this.unitOfMeasureValue =
                 event.detail.fields[this.fields.unitOfMeasurement.fieldApiName].value;
+        } else if (this.unitOfMeasureValue !== this.labels.quantity) {
+            this.unitOfMeasureValue = this.labels.quantity;
         }
         this.dispatchEvent(new CustomEvent("clearerror", { detail: this.index }));
     }

--- a/force-app/main/default/objects/ServiceDelivery__c/fieldSets/Default.fieldSet-meta.xml
+++ b/force-app/main/default/objects/ServiceDelivery__c/fieldSets/Default.fieldSet-meta.xml
@@ -26,11 +26,6 @@
         <isFieldManaged>false</isFieldManaged>
         <isRequired>false</isRequired>
     </availableFields>
-    <availableFields>
-        <field>UnitOfMeasurement__c</field>
-        <isFieldManaged>false</isFieldManaged>
-        <isRequired>false</isRequired>
-    </availableFields>
     <description>Used in the Bulk Service Delivery UI</description>
     <displayedFields>
         <field>Contact__c</field>


### PR DESCRIPTION
# Critical Changes

# Changes
- BSDT defaults to Unit of Measure label "Quantity" when none is defined on the Service record.

# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
- [ ] Place holder data is incorporated (Refer to [Case Management Sample Data document](https://quip.com/cbFcAPJF8t0z))
- [ ] Base axe-core JEST test included for any new LWC (No critical violations)
- [ ] CRUD/FLS is enforced in Apex
- [ ] Permission sets are updated to account for CRUD/FLS for new object metadata
- [ ] All modified classes are unit tested (Apex) at 100% coverage
- [ ] UX approval or UX not necessary
- [ ] PR contains draft release notes
- [ ] Attach work item to the pull request with [Lurch](https://salesforce.quip.com/50ZRA5LEWVzH) `**Lurch:attach W-000000` or `**Lurch:add`
- [ ] All **acceptance criteria** have been met
    - [ ] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [ ] QE story level testing completed


