### PR TITLE
add date validation for PE

### DIFF
--- a/robot/pmm/resources/pmm_locators.py
+++ b/robot/pmm/resources/pmm_locators.py
@@ -35,7 +35,7 @@ pmm_lex_locators = {
         "datepicker_popup": "//table[@class='calGrid' and @role='grid']",
         "select_date": "//div[contains(@class,'uiDatePickerGrid')]/table[@class='calGrid']//*[text()='{}']",
         "checkbox": "//div[contains(@class,'uiInputCheckbox')]/label/span[text()='{}']/../following-sibling::input[@type='checkbox']",
-        "error_message":"//div[@class='pageLevelErrors']//ul[@class='errorsList']/li[text()='{}']",
+        'error_message':'//div[@class="pageLevelErrors"]//ul[@class="errorsList"]/li[text()="{}"]',
     },
     "related": {
         "button": "//article[contains(@class, 'forceRelatedListCardDesktop')][.//img][.//span[@title='{}']]//a[@title='{}']",

--- a/robot/pmm/tests/browser/ProgramEngagement/ProgramEngagement.robot
+++ b/robot/pmm/tests/browser/ProgramEngagement/ProgramEngagement.robot
@@ -4,6 +4,7 @@ Resource       robot/pmm/resources/pmm.robot
 Library        cumulusci.robotframework.PageObjects
 ...            robot/pmm/resources/pmm.py
 ...            robot/pmm/resources/ProgramEngagementPageObject.py
+...            robot/pmm/resources/ProgramPageObject.py
 Suite Setup     Run Keywords
 ...             Open Test Browser
 ...             Setup Test Data
@@ -18,49 +19,42 @@ Setup Test Data
     &{contact} =                   API Create Contact
     Set suite variable             &{contact}
     &{program} =                   API Create Program
-    Store Session Record           ${ns}Program__c         &{program}[Id]
     Set suite variable             &{program}
 
 
 *** Test Cases ***
-
 Create Program Engagemnet
-
      [Documentation]                         Creates a Program Engagement on Program Record by clicking "New" button in Related list.
      [tags]                                  W-037565   feature:Program Engagement
      Go To PMM App
      Go To Page                              Listing                                ${ns}ProgramEngagement__c
      Click Object Button                     New
-     Load Page Object                        NewProgramEngagement                   ${ns}ProgramEngagement__c
-     verify current page title               New Program Engagement
-     Populate modal Form                     Program Engagement Name= ${program_engagement_name}
+     Wait For Modal                          New                                    Program Engagement
+     Populate Modal Form                     Program Engagement Name= ${program_engagement_name}
      ...                                     Stage=Applied
      ...                                     Client=&{contact}[FirstName] &{contact}[LastName]
      ...                                     Program=&{program}[Name]
      ...                                     Role=Client
      ...                                     Start Date=10
      ...                                     End Date=25
-     Click modal button                      Save
+     Click Modal Button                      Save
      Wait Until Modal Is Closed
-     verify page header                      Program Engagement
-     verify details                          Program                  contains                  &{program}[Name]
-     verify details                          Client                   contains                  &{contact}[FirstName] &{contact}[LastName]
+     Verify Page Header                      Program Engagement
+     Verify Details                          Program                  contains                  &{program}[Name]
+     Verify Details                          Client                   contains                  &{contact}[FirstName] &{contact}[LastName]
      Page Should Not Contain                 ${program_engagement_name}
-     verify page contains related list       Service Deliveries
+     Verify Page Contains Related List       Service Deliveries
      ${program_engagement_id} =              Save Current Record ID For Deletion                ${ns}ProgramEngagement__c
 
 
 Create Program Engagement with Auto Name Override
-
     [Documentation]                         Creates a Program Engagement on Program Record by clicking "New" button in Related list
      ...                                    and Checking Auto-Name Override checkbox. Verify PE name is same as what user added.
-
     [tags]                                  W-037577   feature:Program Engagement
      Go To Page                             Listing                                ${ns}ProgramEngagement__c
      Click Object Button                    New
-     Load Page Object                       NewProgramEngagement                   ${ns}ProgramEngagement__c
-     verify current page title              New Program Engagement
-     Populate modal Form                    Program Engagement Name= ${program_engagement_name}
+     Wait For Modal                         New                                    Program Engagement
+     Populate Modal Form                    Program Engagement Name= ${program_engagement_name}
      ...                                    Auto-Name Override=checked
      ...                                    Stage=Applied
      ...                                    Client=&{contact}[FirstName] &{contact}[LastName]
@@ -68,9 +62,53 @@ Create Program Engagement with Auto Name Override
      ...                                    Role=Client
      ...                                    Start Date=10
      ...                                    End Date=25
-     Click modal button                     Save
+     Click Modal Button                     Save
      Wait Until Modal Is Closed
-     verify page header                     Program Engagement
-     verify details                         Program Engagement Name                contains         ${program_engagement_name}
-     verify page contains related list      Service Deliveries
+     Verify Page Header                     Program Engagement
+     Verify Details                         Program Engagement Name                contains         ${program_engagement_name}
+     Verify Page Contains Related List      Service Deliveries
      ${program_engagement_id} =             Save Current Record ID For Deletion    ${ns}ProgramEngagement__c
+
+Date validation when start date is later than end date
+     [Documentation]                        This test opens the new program engagement dialog and enters a end date earlier than start date
+     ...                                    and verifies that an error message is displayed
+     [tags]                                 W-042238   feature:Program Engagement
+     Go To Page                             Listing                                ${ns}ProgramEngagement__c
+     Click Object Button                    New
+     Wait For Modal                         New                                    Program Engagement
+     Populate Modal Form                    Program Engagement Name= ${program_engagement_name}
+     ...                                    Auto-Name Override=checked
+     ...                                    Stage=Applied
+     ...                                    Client=&{contact}[FirstName] &{contact}[LastName]
+     ...                                    Program=&{program}[Name]
+     ...                                    Role=Client
+     ...                                    Start Date=25
+     ...                                    End Date=10
+     Click Modal Button                     Save
+     Verify Modal Error                     Start Date must be before End Date
+
+Date validation when program engagement dates are not within program date range
+     [Documentation]                        This test opens the program record, edits the start and end dates and goes to the PE listing
+     ...                                    page, clicks on new and verifes that an error message is displayed when PE date 
+     ...                                    range is outside the program date range 
+     [tags]                                 W-042238   feature:Program Engagement
+     Go To Page                             Details                                 ${ns}Program__c                   object_id=${program}[Id]
+     Click Quick Action Button              Edit
+     Verify Current Page Title              Edit ${program}[Name]
+     Populate Modal Form                    Start Date=12
+     ...                                    End Date=20
+     Click Modal Button                     Save
+     Wait Until Modal Is Closed
+     Go To Page                             Listing                                ${ns}ProgramEngagement__c
+     Click Object Button                    New
+     Wait For Modal                         New                                    Program Engagement
+     Populate Modal Form                    Program Engagement Name= ${program_engagement_name}
+     ...                                    Stage=Applied
+     ...                                    Client=&{contact}[FirstName] &{contact}[LastName]
+     ...                                    Program=&{program}[Name]
+     ...                                    Role=Client
+     ...                                    Start Date=10
+     ...                                    End Date=25
+     Click Modal Button                     Save
+     Verify Modal Error                     Select an end date that's on or after the program start date and on or before the program end date.
+     Verify Modal Error                     Select a start date that's on or after the program start date and on or before the program end date.


### PR DESCRIPTION
1. Added date validation test for program engagement
2. Updated existing create new program engagement test to use wait for modal keyword
3. Fixed keyword case on programengagement.robot file
# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
- [ ] Place holder data is incorporated (Refer to [Case Management Sample Data document](https://quip.com/cbFcAPJF8t0z))
- [ ] Base axe-core JEST test included for any new LWC (No critical violations)
- [ ] CRUD/FLS is enforced in Apex
- [ ] Permission sets are updated to account for CRUD/FLS for new object metadata
- [ ] All modified classes are unit tested (Apex) at 100% coverage
- [ ] UX approval or UX not necessary
- [ ] PR contains draft release notes
- [ ] Attach work item to the pull request with [Lurch](https://salesforce.quip.com/50ZRA5LEWVzH) `**Lurch:attach W-000000` or `**Lurch:add`
- [ ] All **acceptance criteria** have been met
    - [ ] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [ ] QE story level testing completed


