### PR TITLE
Add PE waitlisted stage

### DIFF
--- a/force-app/main/default/objects/ProgramEngagement__c/fields/Stage__c.field-meta.xml
+++ b/force-app/main/default/objects/ProgramEngagement__c/fields/Stage__c.field-meta.xml
@@ -23,6 +23,11 @@
                 <label>Application Denied</label>
             </value>
             <value>
+                <fullName>Waitlisted</fullName>
+                <default>false</default>
+                <label>Waitlisted</label>
+            </value>
+            <value>
                 <fullName>Enrolled</fullName>
                 <default>false</default>
                 <label>Enrolled</label>


### PR DESCRIPTION
# Critical Changes
- We added a new  Program Engagement Stage called Waitlisted so users can track contacts waitlisted for a Program. Existing customers are strongly encouraged to add this picklist value to the Program Engagement Stage field if it suits their needs.
![image](https://user-images.githubusercontent.com/12188165/85636486-935ba480-b635-11ea-98fa-b461c4ef5bbe.png)


# Changes

# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
- [ ] ~~Place holder data is incorporated (Refer to [Case Management Sample Data document](https://quip.com/cbFcAPJF8t0z))~~
- [ ] ~~Base axe-core JEST test included for any new LWC (No critical violations)~~
- [ ] ~~CRUD/FLS is enforced in Apex~~
- [ ] ~~Permission sets are updated to account for CRUD/FLS for new object metadata~~
- [ ] ~~All modified classes are unit tested (Apex) at 100% coverage~~
- [ ] UX approval or UX not necessary
- [x] PR contains draft release notes
- [x] Attach work item to the pull request with [Lurch](https://salesforce.quip.com/50ZRA5LEWVzH) `**Lurch:attach W-000000` or `**Lurch:add`
- [ ] All **acceptance criteria** have been met
    - [x] Developer
    - [ ] Code Reviewer
    - [x] QA
- [x] QE story level testing completed


