### PR TITLE
BSDT bug fix 

### DIFF
--- a/force-app/main/default/lwc/serviceDeliveryRow/serviceDeliveryRow.js
+++ b/force-app/main/default/lwc/serviceDeliveryRow/serviceDeliveryRow.js
@@ -213,7 +213,6 @@ export default class ServiceDeliveryRow extends LightningElement {
         //Getting this error Uncaught TypeError: 'set' on proxy: when trying to enable an element
         //on Input field change and we suspect that since the record edit form is updating the values on the same array and
         //that is the reason why we are cloning the object here
-
         this.localFieldSet = JSON.parse(JSON.stringify(this.localFieldSet));
         this.localFieldSet.forEach(element => {
             if (fieldApiName !== element.apiName) {
@@ -531,7 +530,7 @@ export default class ServiceDeliveryRow extends LightningElement {
                 }
             });
 
-            if (this.hasContactField && contactId) {
+            if (this.hasContactField && this.hasProgramEngagementField && contactId) {
                 this.handleGetServicesEngagements(contactId);
                 this.selectedContact = contactId;
             }
@@ -543,6 +542,10 @@ export default class ServiceDeliveryRow extends LightningElement {
             ) {
                 this.isServiceFiltered = true;
                 this.handleGetServicesForProgramEngagement(this.programEngagementId);
+            }
+
+            if (this.hasContactField && !this.hasProgramEngagementField && contactId) {
+                this.handleEnableFieldOnInputChange(this.fields.contact.fieldApiName);
             }
         }
     }


### PR DESCRIPTION
When a contact and service field are on the field set and the user is using the Manage Services button on caseman, the service field is now enabled and is a lookup.

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
~~- [ ] Place holder data is incorporated (Refer to [Case Management Sample Data document](https://quip.com/cbFcAPJF8t0z))~~
~~- [ ] Base axe-core JEST test included for any new LWC (No critical violations)~~
~~- [ ] CRUD/FLS is enforced in Apex~~
~~- [ ] Permission sets are updated to account for CRUD/FLS for new object metadata~~
~~- [ ] All modified classes are unit tested (Apex) at 100% coverage~~
~~- [ ] UX approval or UX not necessary~~
~~- [ ] PR contains draft release notes~~
- [x] Attach work item to the pull request with [Lurch](https://salesforce.quip.com/50ZRA5LEWVzH) `**Lurch:attach W-000000` or `**Lurch:add`
- [ ] All **acceptance criteria** have been met
    - [x] Developer
    - [x] Code Reviewer
    - [ ] QA
- [ ] QE story level testing completed


