### PR TITLE
Auto populate contact

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -29,6 +29,24 @@ sources:
         github: https://github.com/SalesforceFoundation/NPSP
 
 tasks:
+    inject_namespaced_org_quick_action:
+        description: "Selectively inject namespace references into QuickAction metadata"
+        class_path: cumulusci.tasks.util.FindReplace
+        options:
+            path: force-app/main/default/quickActions
+            find: "%%%NAMESPACED_ORG%%%"
+            replace: "pmdm__"
+            file_pattern: "*"
+
+    clear_namespaced_org_quick_action:
+        description: "Selectively inject namespace references into QuickAction metadata"
+        class_path: cumulusci.tasks.util.FindReplace
+        options:
+            path: force-app/main/default/quickActions
+            find: "%%%NAMESPACED_ORG%%%"
+            replace: ""
+            file_pattern: "*"
+
     inject_namespaced_org_flow:
         description: "Selectively inject namespace references into Flow metadata"
         class_path: cumulusci.tasks.util.FindReplace
@@ -51,7 +69,7 @@ tasks:
         description: "Preserve the source so it can be modified during deployment"
         class_path: tasks.GenericSrcRevert.GenericSrcRevert
         options:
-            path: force-app/main/default/flows
+            path: force-app/main/default/quickActions
             revert_path: force-app-bak
 
     cache_namespaces_in_org_config:
@@ -274,20 +292,20 @@ flows:
                 flow: npsp:install_prod
     deploy_unmanaged:
         steps:
-            #2.98:
-            #    task: source_revert
-            #    options:
-            #        revert: False
-            #2.99:
-            #    task: inject_namespaced_org_flow
-            #    when: org_config.namespaced
-            #2.999:
-            #    task: clear_namespaced_org_flow
-            #    when: not org_config.namespaced
-            #4.099:
-            #    task: source_revert
-            #    options:
-            #        revert: True
+            2.98:
+                task: source_revert
+                options:
+                    revert: False
+            2.99:
+                task: inject_namespaced_org_quick_action
+                when: org_config.namespaced
+            2.999:
+                task: clear_namespaced_org_quick_action
+                when: not org_config.namespaced
+            4.099:
+                task: source_revert
+                options:
+                    revert: True
 
     #deploy_packaging:
     #    steps:

--- a/force-app/main/default/quickActions/ProgramEngagement__c.CreateServiceDelivery.quickAction-meta.xml
+++ b/force-app/main/default/quickActions/ProgramEngagement__c.CreateServiceDelivery.quickAction-meta.xml
@@ -8,6 +8,10 @@
         <field>Name</field>
         <formula>&quot;New Service Delivery&quot;</formula>
     </fieldOverrides>
+    <fieldOverrides>
+        <field>Contact__c</field>
+        <formula>%%%NAMESPACED_ORG%%%ProgramEngagement__c.%%%NAMESPACED_ORG%%%Contact__c</formula>
+    </fieldOverrides>
     <optionsCreateFeedItem>true</optionsCreateFeedItem>
     <quickActionLayout>
         <layoutSectionStyle>TwoColumnsLeftToRight</layoutSectionStyle>


### PR DESCRIPTION
# Critical Changes

# Changes
- To streamline data entry, PMM now populates the Client field on the Program Engagement record when users create a Service Delivery from the Program Engagement record.

# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
~~- [ ] Place holder data is incorporated (Refer to [Case Management Sample Data document](https://quip.com/cbFcAPJF8t0z))~~
~~- [ ] Base axe-core JEST test included for any new LWC (No critical violations)~~
~~- [ ] CRUD/FLS is enforced in Apex~~
~~- [ ] Permission sets are updated to account for CRUD/FLS for new object metadata~~
~~- [ ] All modified classes are unit tested (Apex) at 100% coverage~~
~~- [ ] UX approval or UX not necessary~~
- [x] PR contains draft release notes
- [x] Attach work item to the pull request with [Lurch](https://salesforce.quip.com/50ZRA5LEWVzH) `**Lurch:attach W-000000` or `**Lurch:add`
- [ ] All **acceptance criteria** have been met
    - [x] Developer
    - [x] Code Reviewer
    - [ ] QA
- [ ] QE story level testing completed


