### PR TITLE
Add Feature Parameters to Count Permission Set Assignments

### DIFF
--- a/force-app/main/default/classes/FeatureParameters.cls
+++ b/force-app/main/default/classes/FeatureParameters.cls
@@ -12,18 +12,28 @@ update the methods within the inner class accordingly
 
 public inherited sharing class FeatureParameters {
     @TestVisible
-     private enum DeveloperName {
+    private enum DeveloperName {
         ACTIVE_PROGRAMS,
         ACTIVE_PROGRAMS_WITH_ENGAGEMENTS_LAST30,
-        ACTIVE_PROGRAMS_WITH_SERVICE_DELIVERIES_LAST30
+        ACTIVE_PROGRAMS_WITH_SERVICE_DELIVERIES_LAST30,
+        PERM_SET_DELIVER_USERS,
+        PERM_SET_MANAGE_USERS
     }
 
     private static final String ACTIVE_PROGRAM_CONDITION =
         String.valueOf(Program__c.Status__c) +
         ' = ' +
         '\'Active\'';
-
     private static final String CREATED_LAST_30_CONDITION = 'CreatedDate = LAST_N_DAYS:30';
+    private static final String PERMISSION_SET_NAME_CONDITION =
+        String.valueOf(PermissionSet.SObjectType) +
+        '.' +
+        String.valueOf(PermissionSet.Name) +
+        ' = ';
+    @TestVisible
+    private static final String DELIVER_PERMISSION = 'PMDM_Deliver';
+    @TestVisible
+    private static final String MANAGE_PERMISSION = 'PMDM_Manage';
 
     @TestVisible
     private List<FeatureManagement.FeatureParameter> featureParameters = new List<FeatureManagement.FeatureParameter>();
@@ -49,6 +59,12 @@ public inherited sharing class FeatureParameters {
             }
             when ACTIVE_PROGRAMS_WITH_SERVICE_DELIVERIES_LAST30 {
                 return new ActiveProgramsWithServiceDeliveriesLast30();
+            }
+            when PERM_SET_DELIVER_USERS {
+                return new PermSetDeliverUsers();
+            }
+            when PERM_SET_MANAGE_USERS {
+                return new PermSetManageUsers();
             }
             when else {
                 return null;
@@ -222,6 +238,132 @@ public inherited sharing class FeatureParameters {
                 programIds.add(serviceDelivery.programengagement__r.Program__c);
             }
             return programIds.size();
+        }
+    }
+
+    @TestVisible
+    private inherited sharing class PermSetDeliverUsers implements FeatureManagement.FeatureParameter {
+        @TestVisible
+        private QueryBuilder queryBuilder {
+            get {
+                if (queryBuilder == null) {
+                    queryBuilder = new QueryBuilder()
+                        .withSObjectType(User.SObjectType)
+                        .addCondition(String.valueOf(User.IsActive) + ' = ' + 'true')
+                        .addCondition(
+                            ' Id IN (' +
+                            buildAssignemntQuery(DELIVER_PERMISSION) +
+                            ')'
+                        )
+                        .addCondition(
+                            ' Id NOT IN (' +
+                            buildAssignemntQuery(MANAGE_PERMISSION) +
+                            ')'
+                        );
+                }
+
+                return queryBuilder;
+            }
+            set;
+        }
+        @TestVisible
+        private Finder finder {
+            get {
+                if (finder == null) {
+                    finder = new Finder(queryBuilder);
+                }
+
+                return finder;
+            }
+            set;
+        }
+
+        public void send() {
+            final Object value = getValue();
+
+            if (value instanceof Integer) {
+                FeatureManagement.getInstance()
+                    .setPackageIntegerValue(getName(), (Integer) value);
+            }
+        }
+
+        private String getName() {
+            return DeveloperName.PERM_SET_DELIVER_USERS.name().remove('_');
+        }
+
+        private Object getValue() {
+            return finder.findCount();
+        }
+
+        private String buildAssignemntQuery(String permissionSetName) {
+            return new QueryBuilder()
+                .withSObjectType(PermissionSetAssignment.SObjectType)
+                .withSelectFields(
+                    new List<String>{ String.valueOf(PermissionSetAssignment.AssigneeId) }
+                )
+                .addCondition(
+                    PERMISSION_SET_NAME_CONDITION +
+                    '\'' +
+                    permissionSetName +
+                    '\''
+                )
+                .buildSoqlQuery();
+        }
+    }
+
+    @TestVisible
+    private inherited sharing class PermSetManageUsers implements FeatureManagement.FeatureParameter {
+        @TestVisible
+        private QueryBuilder queryBuilder {
+            get {
+                if (queryBuilder == null) {
+                    queryBuilder = new QueryBuilder()
+                        .withSObjectType(PermissionSetAssignment.SObjectType)
+                        .addCondition(
+                            PERMISSION_SET_NAME_CONDITION +
+                            '\'' +
+                            MANAGE_PERMISSION +
+                            '\''
+                        )
+                        .addCondition(
+                            'Assignee.' +
+                            String.valueOf(User.IsActive) +
+                            ' = ' +
+                            true
+                        );
+                }
+
+                return queryBuilder;
+            }
+            set;
+        }
+        @TestVisible
+        private Finder finder {
+            get {
+                if (finder == null) {
+                    finder = new Finder(queryBuilder);
+                }
+
+                return finder;
+            }
+            set;
+        }
+
+        public void send() {
+            final Object value = getValue();
+
+            if (value instanceof Integer) {
+                FeatureManagement.getInstance()
+                    .setPackageIntegerValue(getName(), (Integer) value);
+            }
+        }
+
+        private String getName() {
+            return DeveloperName.PERM_SET_MANAGE_USERS.name().remove('_');
+        }
+
+        private Object getValue() {
+            return finder.findCount();
         }
     }
 }

--- a/force-app/main/default/classes/FeatureParameters.cls
+++ b/force-app/main/default/classes/FeatureParameters.cls
@@ -326,7 +326,9 @@ public inherited sharing class FeatureParameters {
                             '\''
                         )
                         .addCondition(
-                            'Assignee.' +
+                            PermissionSetAssignment.AssigneeId.getDescribe()
+                                .getRelationshipName() +
+                            '.' +
                             String.valueOf(User.IsActive) +
                             ' = ' +
                             true

--- a/force-app/main/default/classes/FeatureParameters.cls
+++ b/force-app/main/default/classes/FeatureParameters.cls
@@ -252,12 +252,12 @@ public inherited sharing class FeatureParameters {
                         .addCondition(String.valueOf(User.IsActive) + ' = ' + 'true')
                         .addCondition(
                             ' Id IN (' +
-                            buildAssignemntQuery(DELIVER_PERMISSION) +
+                            buildAssignmentQuery(DELIVER_PERMISSION) +
                             ')'
                         )
                         .addCondition(
                             ' Id NOT IN (' +
-                            buildAssignemntQuery(MANAGE_PERMISSION) +
+                            buildAssignmentQuery(MANAGE_PERMISSION) +
                             ')'
                         );
                 }
@@ -295,7 +295,7 @@ public inherited sharing class FeatureParameters {
             return finder.findCount();
         }
 
-        private String buildAssignemntQuery(String permissionSetName) {
+        private String buildAssignmentQuery(String permissionSetName) {
             return new QueryBuilder()
                 .withSObjectType(PermissionSetAssignment.SObjectType)
                 .withSelectFields(

--- a/force-app/main/default/classes/FeatureParameters_TEST.cls
+++ b/force-app/main/default/classes/FeatureParameters_TEST.cls
@@ -186,7 +186,7 @@ public with sharing class FeatureParameters_TEST {
 
     @IsTest
     private static void shouldPassActualActiveProgramsWithServiceDeliveriesLast30() {
-        set<Id> programIds = new Set<Id>();
+        Set<Id> programIds = new Set<Id>();
 
         List<ServiceDelivery__c> serviceDeliveries = [
             SELECT ProgramEngagement__r.Program__c
@@ -218,6 +218,108 @@ public with sharing class FeatureParameters_TEST {
             'setPackageIntegerValue',
             new List<Type>{ String.class, Integer.class },
             new List<Object>{ expectedName, expectedValue }
+        );
+    }
+
+    @IsTest
+    private static void shouldPassActualPermSetDeliver() {
+        deleteExistingPermissionAssignments();
+        assignPermissionSet(FeatureParameters.DELIVER_PERMISSION);
+
+        List<User> users = [
+            SELECT Id
+            FROM User
+            WHERE
+                Id IN (
+                    SELECT AssigneeId
+                    FROM PermissionSetAssignment
+                    WHERE PermissionSet.Name = :FeatureParameters.DELIVER_PERMISSION
+                )
+                AND Id NOT IN (
+                    SELECT AssigneeId
+                    FROM PermissionSetAssignment
+                    WHERE PermissionSet.Name = :FeatureParameters.MANAGE_PERMISSION
+                )
+        ];
+        System.assert(
+            !users.isEmpty(),
+            'Sanity check: There should be at least 1 user found.'
+        );
+
+        final String expectedName = FeatureParameters.DeveloperName.PERM_SET_DELIVER_USERS.name()
+            .remove('_');
+        final Integer expectedValue = users.size();
+        FeatureManagement.instance = (FeatureManagement) featureManagementStub.createMock();
+
+        Test.startTest();
+        new FeatureParameters.PermSetDeliverUsers().send();
+        Test.stopTest();
+
+        featureManagementStub.assertCalledWith(
+            'setPackageIntegerValue',
+            new List<Type>{ String.class, Integer.class },
+            new List<Object>{ expectedName, expectedValue }
+        );
+    }
+
+    @IsTest
+    private static void shouldPassActualPermSetManage() {
+        deleteExistingPermissionAssignments();
+        assignPermissionSet(FeatureParameters.MANAGE_PERMISSION);
+        List<User> users = [
+            SELECT Id
+            FROM User
+            WHERE
+                Id IN (
+                    SELECT AssigneeId
+                    FROM PermissionSetAssignment
+                    WHERE PermissionSet.Name = :FeatureParameters.MANAGE_PERMISSION
+                )
+        ];
+        System.assert(
+            !users.isEmpty(),
+            'Sanity check: There should be at least 1 user found.'
+        );
+
+        final String expectedName = FeatureParameters.DeveloperName.PERM_SET_MANAGE_USERS.name()
+            .remove('_');
+        final Integer expectedValue = users.size();
+        FeatureManagement.instance = (FeatureManagement) featureManagementStub.createMock();
+
+        Test.startTest();
+        new FeatureParameters.PermSetManageUsers().send();
+        Test.stopTest();
+
+        featureManagementStub.assertCalledWith(
+            'setPackageIntegerValue',
+            new List<Type>{ String.class, Integer.class },
+            new List<Object>{ expectedName, expectedValue }
+        );
+    }
+
+    ////////// Helper Methods //////////
+    private static void deleteExistingPermissionAssignments() {
+        delete [
+            SELECT Id
+            FROM PermissionSetAssignment
+            WHERE
+                AssigneeId = :System.UserInfo.getUserId()
+                AND (PermissionSet.Name = :FeatureParameters.MANAGE_PERMISSION
+                OR PermissionSet.Name = :FeatureParameters.DELIVER_PERMISSION)
+        ];
+    }
+
+    private static void assignPermissionSet(String permissionSetName) {
+        PermissionSet permission = [
+            SELECT Id
+            FROM PermissionSet
+            WHERE Name = :permissionSetName
+            LIMIT 1
+        ];
+
+        insert new PermissionSetAssignment(
+            AssigneeId = System.UserInfo.getUserId(),
+            PermissionSetId = permission.Id
         );
     }
 }

--- a/force-app/main/default/featureParameters/PermSetDeliverUsers.featureParameterInteger-meta.xml
+++ b/force-app/main/default/featureParameters/PermSetDeliverUsers.featureParameterInteger-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FeatureParameterInteger xmlns="http://soap.sforce.com/2006/04/metadata">
+    <dataflowDirection>SubscriberToLmo</dataflowDirection>
+    <masterLabel>Count of Users with Deliver Perm Set</masterLabel>
+    <value>-1</value>
+</FeatureParameterInteger>

--- a/force-app/main/default/featureParameters/PermSetManageUsers.featureParameterInteger-meta.xml
+++ b/force-app/main/default/featureParameters/PermSetManageUsers.featureParameterInteger-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FeatureParameterInteger xmlns="http://soap.sforce.com/2006/04/metadata">
+    <dataflowDirection>SubscriberToLmo</dataflowDirection>
+    <masterLabel>Count of Users with Manage Perm Set</masterLabel>
+    <value>-1</value>
+</FeatureParameterInteger>


### PR DESCRIPTION
- Added a new Feature Parameter that returns a count of how many Users are assigned the PMM: Deliver permission.
- Added a new Feature Parameter that returns a count of how many Users are assigned the PMM: Manage permission.
# Critical Changes

# Changes
-We updated PMM Feature Telemetry to include a count of Users assigned the PMM: Deliver permission, and a count of Users assigned the PMM: Manage permission. No personally identifiable information is collected through PMM Feature Telemetry. Read more about [PMM Feature Telemetry](https://powerofus.force.com/s/article/PMM-Feature-Telemetry).


# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
~~Place holder data is incorporated (Refer to [Case Management Sample Data document](https://quip.com/cbFcAPJF8t0z))~~
~~Base axe-core JEST test included for any new LWC (No critical violations)~~
~~CRUD/FLS is enforced in Apex~~
~~Permission sets are updated to account for CRUD/FLS for new object metadata~~
- [x] All modified classes are unit tested (Apex) at 100% coverage
~~UX approval or UX not necessary~~
- [ ] PR contains draft release notes
- [ ] Attach work item to the pull request
- [ ] All **acceptance criteria** have been met
    - [ ] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [ ] QE story level testing completed


