### PR TITLE
Update StartDate population on Program Engagement

### DIFF
--- a/unpackaged/config/dev/flows/Auto_Populate_Date_And_Name_On_Program_Engagement.flow-meta.xml
+++ b/unpackaged/config/dev/flows/Auto_Populate_Date_And_Name_On_Program_Engagement.flow-meta.xml
@@ -410,12 +410,12 @@ NOT(ISBLANK({!myVariable_current.%%%NAMESPACE%%%StartDate__c})),  TEXT({!myVaria
         <processMetadataValues>
             <name>originalFormula</name>
             <value>
-                <stringValue>IF([%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%Program__c.%%%NAMESPACE%%%StartDate__c &lt;TODAY() , TODAY(), NULL)</stringValue>
+                <stringValue>IF([%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%Program__c.%%%NAMESPACE%%%StartDate__c &lt;= TODAY() , TODAY(), NULL)</stringValue>
             </value>
         </processMetadataValues>
         <name>formula_8_myRule_7_A1_6369948895</name>
         <dataType>Date</dataType>
-        <expression>IF({!myVariable_current.%%%NAMESPACE%%%Program__r.%%%NAMESPACE%%%StartDate__c} &lt;TODAY() , TODAY(), NULL)</expression>
+        <expression>IF({!myVariable_current.%%%NAMESPACE%%%Program__r.%%%NAMESPACE%%%StartDate__c} &lt;= TODAY() , TODAY(), NULL)</expression>
     </formulas>
     <formulas>
         <processMetadataValues>


### PR DESCRIPTION

# Critical Changes

# Changes
 When a new program Engagement record is created with 'Active' status and is associated to a program whose start date is earlier than or equal to today , the Start date on the program engagement record is set to Today.
# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
~~- [ ] Place holder data is incorporated (Refer to [Case Management Sample Data document](https://quip.com/cbFcAPJF8t0z))~~
~~- [ ] Base axe-core JEST test included for any new LWC (No critical violations)~~
~~- [ ] CRUD/FLS is enforced in Apex~~
~~- [ ] Permission sets are updated to account for CRUD/FLS for new object metadata~~
~~- [ ] All modified classes are unit tested (Apex) at 100% coverage~~
~~- [ ] UX approval or UX not necessary~~
~~- [ ] PR contains draft release notes~~
- [X] Attach work item to the pull request with [Lurch](https://salesforce.quip.com/50ZRA5LEWVzH) `**Lurch:attach W-000000` or `**Lurch:add`
- [ ] All **acceptance criteria** have been met
    - [X] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [ ] QE story level testing completed


