### PR TITLE
Fix Program Engagement Process Builder

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -72,7 +72,7 @@ tasks:
         description: "Preserve the source so it can be modified during deployment"
         class_path: tasks.GenericSrcRevert.GenericSrcRevert
         options:
-            path: force-app/main/default/quickActions
+            path: force-app/main/default
             revert_path: force-app-bak
 
     robot:
@@ -267,6 +267,12 @@ flows:
             2.999:
                 task: clear_namespaced_org_quick_action
                 when: not org_config.namespaced
+            2.9999:
+                task: inject_namespaced_org_flow
+                when: org_config.namespaced
+            2.99999:
+                task: clear_namespaced_org_flow
+                when: not org_config.namespaced
             4.099:
                 task: source_revert
                 options:
@@ -274,10 +280,7 @@ flows:
 
     #deploy_packaging:
     #    steps:
-    #        3.01:
-    #            task: inject_namespaced_org_flow
-    #            options:
-    #                path: "src/flows"
+    #        Moved the steps as 3.02 below
 
     deploy_packaging:
         steps:
@@ -285,6 +288,10 @@ flows:
                 task: inject_namespaced_org_quick_action
                 options:
                     path: "src/quickActions"
+            3.02:
+                task: inject_namespaced_org_flow
+                options:
+                    path: "src/flows"
 
     customer_org:
         steps:

--- a/force-app/main/default/flows/Auto_Populate_Date_And_Name_On_Program_Engagement.flow-meta.xml
+++ b/force-app/main/default/flows/Auto_Populate_Date_And_Name_On_Program_Engagement.flow-meta.xml
@@ -325,7 +325,7 @@
                 <stringValue>TODAY() </stringValue>
             </value>
         </processMetadataValues>
-        <name>formula_11_myRule_10_A1_6433572107</name>
+        <name>formula_11_myRule_10_A1_9228346885</name>
         <dataType>Date</dataType>
         <expression>TODAY()</expression>
     </formulas>
@@ -335,64 +335,64 @@
             <value>
                 <stringValue>IF(NOT(ISBLANK([ProgramEngagement__c].Contact__c)),IF(
 LEN(
-[ProgramEngagement__c].Contact__c.FirstName  + &apos; &apos; + [ProgramEngagement__c].Contact__c.LastName + &apos; &apos; +
+[ProgramEngagement__c].Contact__c.FirstName  + &#39; &#39; + [ProgramEngagement__c].Contact__c.LastName + &#39; &#39; +
 IF(
 NOT(ISBLANK([ProgramEngagement__c].StartDate__c)),  TEXT([ProgramEngagement__c].StartDate__c) , LEFT(TEXT([ProgramEngagement__c].CreatedDate),10 ))+
-&apos;: &apos; + [ProgramEngagement__c].Program__c.Name) &gt; 77,
-LEFT(([ProgramEngagement__c].Contact__c.FirstName  + &apos; &apos; + [ProgramEngagement__c].Contact__c.LastName + &apos; &apos; +
+&#39;: &#39; + [ProgramEngagement__c].Program__c.Name) &gt; 77,
+LEFT(([ProgramEngagement__c].Contact__c.FirstName  + &#39; &#39; + [ProgramEngagement__c].Contact__c.LastName + &#39; &#39; +
 IF (NOT(ISBLANK([ProgramEngagement__c].StartDate__c)),  TEXT([ProgramEngagement__c].StartDate__c) , LEFT(TEXT([ProgramEngagement__c].CreatedDate),10)) +
-&apos;: &apos; + [ProgramEngagement__c].Program__c.Name),77)
-+ &apos;...&apos;, [ProgramEngagement__c].Contact__c.FirstName  + &apos; &apos; + [ProgramEngagement__c].Contact__c.LastName + &apos; &apos; +
+&#39;: &#39; + [ProgramEngagement__c].Program__c.Name),77)
++ &#39;...&#39;, [ProgramEngagement__c].Contact__c.FirstName  + &#39; &#39; + [ProgramEngagement__c].Contact__c.LastName + &#39; &#39; +
 IF(
 NOT(ISBLANK([ProgramEngagement__c].StartDate__c)),  TEXT([ProgramEngagement__c].StartDate__c) , LEFT(TEXT([ProgramEngagement__c].CreatedDate),10 ))+
-&apos;: &apos; + [ProgramEngagement__c].Program__c.Name
+&#39;: &#39; + [ProgramEngagement__c].Program__c.Name
 ), 
 IF(
 LEN(
-$Label.Anonymous+ &apos; &apos; +
+$Label.Anonymous+ &#39; &#39; +
 IF(
 NOT(ISBLANK([ProgramEngagement__c].StartDate__c)),  TEXT([ProgramEngagement__c].StartDate__c) , LEFT(TEXT([ProgramEngagement__c].CreatedDate),10 ))+
-&apos;: &apos; + [ProgramEngagement__c].Program__c.Name) &gt; 77,
-LEFT(($Label.Anonymous + &apos; &apos; +
+&#39;: &#39; + [ProgramEngagement__c].Program__c.Name) &gt; 77,
+LEFT(($Label.Anonymous + &#39; &#39; +
 IF (NOT(ISBLANK([ProgramEngagement__c].StartDate__c)),  TEXT([ProgramEngagement__c].StartDate__c) , LEFT(TEXT([ProgramEngagement__c].CreatedDate),10)) +
-&apos;: &apos; + [ProgramEngagement__c].Program__c.Name),77)
-+ &apos;...&apos;, $Label.Anonymous + &apos; &apos; +
+&#39;: &#39; + [ProgramEngagement__c].Program__c.Name),77)
++ &#39;...&#39;, $Label.Anonymous + &#39; &#39; +
 IF(
 NOT(ISBLANK([ProgramEngagement__c].StartDate__c)),  TEXT([ProgramEngagement__c].StartDate__c) , LEFT(TEXT([ProgramEngagement__c].CreatedDate),10 ))+
-&apos;: &apos; + [ProgramEngagement__c].Program__c.Name
+&#39;: &#39; + [ProgramEngagement__c].Program__c.Name
 ))
 </stringValue>
             </value>
         </processMetadataValues>
-        <name>formula_2_myRule_1_A1_2224060128</name>
+        <name>formula_2_myRule_1_A1_3915232854</name>
         <dataType>String</dataType>
         <expression>IF(NOT(ISBLANK({!myVariable_current.Contact__c})),IF(
 LEN(
-{!myVariable_current.Contact__r.FirstName}  + &apos; &apos; + {!myVariable_current.Contact__r.LastName} + &apos; &apos; +
+{!myVariable_current.Contact__r.FirstName}  + &#39; &#39; + {!myVariable_current.Contact__r.LastName} + &#39; &#39; +
 IF(
 NOT(ISBLANK({!myVariable_current.StartDate__c})),  TEXT({!myVariable_current.StartDate__c}) , LEFT(TEXT({!myVariable_current.CreatedDate}),10 ))+
-&apos;: &apos; + {!myVariable_current.Program__r.Name}) &gt; 77,
-LEFT(({!myVariable_current.Contact__r.FirstName}  + &apos; &apos; + {!myVariable_current.Contact__r.LastName} + &apos; &apos; +
+&#39;: &#39; + {!myVariable_current.Program__r.Name}) &gt; 77,
+LEFT(({!myVariable_current.Contact__r.FirstName}  + &#39; &#39; + {!myVariable_current.Contact__r.LastName} + &#39; &#39; +
 IF (NOT(ISBLANK({!myVariable_current.StartDate__c})),  TEXT({!myVariable_current.StartDate__c}) , LEFT(TEXT({!myVariable_current.CreatedDate}),10)) +
-&apos;: &apos; + {!myVariable_current.Program__r.Name}),77)
-+ &apos;...&apos;, {!myVariable_current.Contact__r.FirstName}  + &apos; &apos; + {!myVariable_current.Contact__r.LastName} + &apos; &apos; +
+&#39;: &#39; + {!myVariable_current.Program__r.Name}),77)
++ &#39;...&#39;, {!myVariable_current.Contact__r.FirstName}  + &#39; &#39; + {!myVariable_current.Contact__r.LastName} + &#39; &#39; +
 IF(
 NOT(ISBLANK({!myVariable_current.StartDate__c})),  TEXT({!myVariable_current.StartDate__c}) , LEFT(TEXT({!myVariable_current.CreatedDate}),10 ))+
-&apos;: &apos; + {!myVariable_current.Program__r.Name}
+&#39;: &#39; + {!myVariable_current.Program__r.Name}
 ), 
 IF(
 LEN(
-{!$Label.Anonymous}+ &apos; &apos; +
+{!$Label.Anonymous}+ &#39; &#39; +
 IF(
 NOT(ISBLANK({!myVariable_current.StartDate__c})),  TEXT({!myVariable_current.StartDate__c}) , LEFT(TEXT({!myVariable_current.CreatedDate}),10 ))+
-&apos;: &apos; + {!myVariable_current.Program__r.Name}) &gt; 77,
-LEFT(({!$Label.Anonymous} + &apos; &apos; +
+&#39;: &#39; + {!myVariable_current.Program__r.Name}) &gt; 77,
+LEFT(({!$Label.Anonymous} + &#39; &#39; +
 IF (NOT(ISBLANK({!myVariable_current.StartDate__c})),  TEXT({!myVariable_current.StartDate__c}) , LEFT(TEXT({!myVariable_current.CreatedDate}),10)) +
-&apos;: &apos; + {!myVariable_current.Program__r.Name}),77)
-+ &apos;...&apos;, {!$Label.Anonymous} + &apos; &apos; +
+&#39;: &#39; + {!myVariable_current.Program__r.Name}),77)
++ &#39;...&#39;, {!$Label.Anonymous} + &#39; &#39; +
 IF(
 NOT(ISBLANK({!myVariable_current.StartDate__c})),  TEXT({!myVariable_current.StartDate__c}) , LEFT(TEXT({!myVariable_current.CreatedDate}),10 ))+
-&apos;: &apos; + {!myVariable_current.Program__r.Name}
+&#39;: &#39; + {!myVariable_current.Program__r.Name}
 ))</expression>
     </formulas>
     <formulas>
@@ -402,7 +402,7 @@ NOT(ISBLANK({!myVariable_current.StartDate__c})),  TEXT({!myVariable_current.Sta
                 <stringValue>IF(NOT(ISNULL([ProgramEngagement__c].StartDate__c)), IF ([ProgramEngagement__c].StartDate__c &gt; TODAY(), TODAY(), NULL), TODAY())</stringValue>
             </value>
         </processMetadataValues>
-        <name>formula_5_myRule_4_A1_0925925767</name>
+        <name>formula_5_myRule_4_A1_9452998888</name>
         <dataType>Date</dataType>
         <expression>IF(NOT(ISNULL({!myVariable_current.StartDate__c})), IF ({!myVariable_current.StartDate__c} &gt; TODAY(), TODAY(), NULL), TODAY())</expression>
     </formulas>
@@ -413,7 +413,7 @@ NOT(ISBLANK({!myVariable_current.StartDate__c})),  TEXT({!myVariable_current.Sta
                 <stringValue>IF([ProgramEngagement__c].Program__c.StartDate__c &lt;= TODAY() , TODAY(), NULL)</stringValue>
             </value>
         </processMetadataValues>
-        <name>formula_8_myRule_7_A1_2608436668</name>
+        <name>formula_8_myRule_7_A1_6369948895</name>
         <dataType>Date</dataType>
         <expression>IF({!myVariable_current.Program__r.StartDate__c} &lt;= TODAY() , TODAY(), NULL)</expression>
     </formulas>
@@ -531,7 +531,7 @@ NOT(ISBLANK({!myVariable_current.StartDate__c})),  TEXT({!myVariable_current.Sta
             </processMetadataValues>
             <field>EndDate__c</field>
             <value>
-                <elementReference>formula_11_myRule_10_A1_6433572107</elementReference>
+                <elementReference>formula_11_myRule_10_A1_9228346885</elementReference>
             </value>
         </inputAssignments>
         <object>ProgramEngagement__c</object>
@@ -614,7 +614,7 @@ NOT(ISBLANK({!myVariable_current.StartDate__c})),  TEXT({!myVariable_current.Sta
             </processMetadataValues>
             <field>Name</field>
             <value>
-                <elementReference>formula_2_myRule_1_A1_2224060128</elementReference>
+                <elementReference>formula_2_myRule_1_A1_3915232854</elementReference>
             </value>
         </inputAssignments>
         <object>ProgramEngagement__c</object>
@@ -694,7 +694,7 @@ NOT(ISBLANK({!myVariable_current.StartDate__c})),  TEXT({!myVariable_current.Sta
             </processMetadataValues>
             <field>ApplicationDate__c</field>
             <value>
-                <elementReference>formula_5_myRule_4_A1_0925925767</elementReference>
+                <elementReference>formula_5_myRule_4_A1_9452998888</elementReference>
             </value>
         </inputAssignments>
         <object>ProgramEngagement__c</object>
@@ -774,7 +774,7 @@ NOT(ISBLANK({!myVariable_current.StartDate__c})),  TEXT({!myVariable_current.Sta
             </processMetadataValues>
             <field>StartDate__c</field>
             <value>
-                <elementReference>formula_8_myRule_7_A1_2608436668</elementReference>
+                <elementReference>formula_8_myRule_7_A1_6369948895</elementReference>
             </value>
         </inputAssignments>
         <object>ProgramEngagement__c</object>

--- a/force-app/main/default/flows/Auto_Populate_Date_And_Name_On_Program_Engagement.flow-meta.xml
+++ b/force-app/main/default/flows/Auto_Populate_Date_And_Name_On_Program_Engagement.flow-meta.xml
@@ -74,7 +74,7 @@
                         <stringValue>Picklist</stringValue>
                     </value>
                 </processMetadataValues>
-                <leftValueReference>myVariable_current.Stage__c</leftValueReference>
+                <leftValueReference>myVariable_current.%%%NAMESPACE%%%Stage__c</leftValueReference>
                 <operator>EqualTo</operator>
                 <rightValue>
                     <stringValue>Applied</stringValue>
@@ -105,7 +105,7 @@
                         <stringValue>Boolean</stringValue>
                     </value>
                 </processMetadataValues>
-                <leftValueReference>myVariable_current.ApplicationDate__c</leftValueReference>
+                <leftValueReference>myVariable_current.%%%NAMESPACE%%%ApplicationDate__c</leftValueReference>
                 <operator>IsNull</operator>
                 <rightValue>
                     <booleanValue>true</booleanValue>
@@ -160,7 +160,7 @@
                         <stringValue>Picklist</stringValue>
                     </value>
                 </processMetadataValues>
-                <leftValueReference>myVariable_current.Stage__c</leftValueReference>
+                <leftValueReference>myVariable_current.%%%NAMESPACE%%%Stage__c</leftValueReference>
                 <operator>EqualTo</operator>
                 <rightValue>
                     <stringValue>Active</stringValue>
@@ -191,7 +191,7 @@
                         <stringValue>Boolean</stringValue>
                     </value>
                 </processMetadataValues>
-                <leftValueReference>myVariable_current.StartDate__c</leftValueReference>
+                <leftValueReference>myVariable_current.%%%NAMESPACE%%%StartDate__c</leftValueReference>
                 <operator>IsNull</operator>
                 <rightValue>
                     <booleanValue>true</booleanValue>
@@ -243,7 +243,7 @@
                         <stringValue>Picklist</stringValue>
                     </value>
                 </processMetadataValues>
-                <leftValueReference>myVariable_current.Stage__c</leftValueReference>
+                <leftValueReference>myVariable_current.%%%NAMESPACE%%%Stage__c</leftValueReference>
                 <operator>EqualTo</operator>
                 <rightValue>
                     <stringValue>Completed</stringValue>
@@ -274,7 +274,7 @@
                         <stringValue>Picklist</stringValue>
                     </value>
                 </processMetadataValues>
-                <leftValueReference>myVariable_current.Stage__c</leftValueReference>
+                <leftValueReference>myVariable_current.%%%NAMESPACE%%%Stage__c</leftValueReference>
                 <operator>EqualTo</operator>
                 <rightValue>
                     <stringValue>Withdrawn</stringValue>
@@ -305,7 +305,7 @@
                         <stringValue>Boolean</stringValue>
                     </value>
                 </processMetadataValues>
-                <leftValueReference>myVariable_current.EndDate__c</leftValueReference>
+                <leftValueReference>myVariable_current.%%%NAMESPACE%%%EndDate__c</leftValueReference>
                 <operator>IsNull</operator>
                 <rightValue>
                     <booleanValue>true</booleanValue>
@@ -333,100 +333,100 @@
         <processMetadataValues>
             <name>originalFormula</name>
             <value>
-                <stringValue>IF(NOT(ISBLANK([ProgramEngagement__c].Contact__c)),IF(
+                <stringValue>IF(NOT(ISBLANK([%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%Contact__c)),IF(
 LEN(
-[ProgramEngagement__c].Contact__c.FirstName  + &#39; &#39; + [ProgramEngagement__c].Contact__c.LastName + &#39; &#39; +
+[%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%Contact__c.FirstName  + &#39; &#39; + [%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%Contact__c.LastName + &#39; &#39; +
 IF(
-NOT(ISBLANK([ProgramEngagement__c].StartDate__c)),  TEXT([ProgramEngagement__c].StartDate__c) , LEFT(TEXT([ProgramEngagement__c].CreatedDate),10 ))+
-&#39;: &#39; + [ProgramEngagement__c].Program__c.Name) &gt; 77,
-LEFT(([ProgramEngagement__c].Contact__c.FirstName  + &#39; &#39; + [ProgramEngagement__c].Contact__c.LastName + &#39; &#39; +
-IF (NOT(ISBLANK([ProgramEngagement__c].StartDate__c)),  TEXT([ProgramEngagement__c].StartDate__c) , LEFT(TEXT([ProgramEngagement__c].CreatedDate),10)) +
-&#39;: &#39; + [ProgramEngagement__c].Program__c.Name),77)
-+ &#39;...&#39;, [ProgramEngagement__c].Contact__c.FirstName  + &#39; &#39; + [ProgramEngagement__c].Contact__c.LastName + &#39; &#39; +
+NOT(ISBLANK([%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%StartDate__c)),  TEXT([%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%StartDate__c) , LEFT(TEXT([%%%NAMESPACE%%%ProgramEngagement__c].CreatedDate),10 ))+
+&#39;: &#39; + [%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%Program__c.Name) &gt; 77,
+LEFT(([%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%Contact__c.FirstName  + &#39; &#39; + [%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%Contact__c.LastName + &#39; &#39; +
+IF (NOT(ISBLANK([%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%StartDate__c)),  TEXT([%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%StartDate__c) , LEFT(TEXT([%%%NAMESPACE%%%ProgramEngagement__c].CreatedDate),10)) +
+&#39;: &#39; + [%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%Program__c.Name),77)
++ &#39;...&#39;, [%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%Contact__c.FirstName  + &#39; &#39; + [%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%Contact__c.LastName + &#39; &#39; +
 IF(
-NOT(ISBLANK([ProgramEngagement__c].StartDate__c)),  TEXT([ProgramEngagement__c].StartDate__c) , LEFT(TEXT([ProgramEngagement__c].CreatedDate),10 ))+
-&#39;: &#39; + [ProgramEngagement__c].Program__c.Name
+NOT(ISBLANK([%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%StartDate__c)),  TEXT([%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%StartDate__c) , LEFT(TEXT([%%%NAMESPACE%%%ProgramEngagement__c].CreatedDate),10 ))+
+&#39;: &#39; + [%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%Program__c.Name
 ), 
 IF(
 LEN(
-$Label.Anonymous+ &#39; &#39; +
+$Label.%%%NAMESPACE%%%Anonymous+ &#39; &#39; +
 IF(
-NOT(ISBLANK([ProgramEngagement__c].StartDate__c)),  TEXT([ProgramEngagement__c].StartDate__c) , LEFT(TEXT([ProgramEngagement__c].CreatedDate),10 ))+
-&#39;: &#39; + [ProgramEngagement__c].Program__c.Name) &gt; 77,
-LEFT(($Label.Anonymous + &#39; &#39; +
-IF (NOT(ISBLANK([ProgramEngagement__c].StartDate__c)),  TEXT([ProgramEngagement__c].StartDate__c) , LEFT(TEXT([ProgramEngagement__c].CreatedDate),10)) +
-&#39;: &#39; + [ProgramEngagement__c].Program__c.Name),77)
-+ &#39;...&#39;, $Label.Anonymous + &#39; &#39; +
+NOT(ISBLANK([%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%StartDate__c)),  TEXT([%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%StartDate__c) , LEFT(TEXT([%%%NAMESPACE%%%ProgramEngagement__c].CreatedDate),10 ))+
+&#39;: &#39; + [%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%Program__c.Name) &gt; 77,
+LEFT(($Label.%%%NAMESPACE%%%Anonymous + &#39; &#39; +
+IF (NOT(ISBLANK([%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%StartDate__c)),  TEXT([%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%StartDate__c) , LEFT(TEXT([%%%NAMESPACE%%%ProgramEngagement__c].CreatedDate),10)) +
+&#39;: &#39; + [%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%Program__c.Name),77)
++ &#39;...&#39;, $Label.%%%NAMESPACE%%%Anonymous + &#39; &#39; +
 IF(
-NOT(ISBLANK([ProgramEngagement__c].StartDate__c)),  TEXT([ProgramEngagement__c].StartDate__c) , LEFT(TEXT([ProgramEngagement__c].CreatedDate),10 ))+
-&#39;: &#39; + [ProgramEngagement__c].Program__c.Name
+NOT(ISBLANK([%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%StartDate__c)),  TEXT([%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%StartDate__c) , LEFT(TEXT([%%%NAMESPACE%%%ProgramEngagement__c].CreatedDate),10 ))+
+&#39;: &#39; + [%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%Program__c.Name
 ))
 </stringValue>
             </value>
         </processMetadataValues>
         <name>formula_2_myRule_1_A1_3915232854</name>
         <dataType>String</dataType>
-        <expression>IF(NOT(ISBLANK({!myVariable_current.Contact__c})),IF(
+        <expression>IF(NOT(ISBLANK({!myVariable_current.%%%NAMESPACE%%%Contact__c})),IF(
 LEN(
-{!myVariable_current.Contact__r.FirstName}  + &#39; &#39; + {!myVariable_current.Contact__r.LastName} + &#39; &#39; +
+{!myVariable_current.%%%NAMESPACE%%%Contact__r.FirstName}  + &#39; &#39; + {!myVariable_current.%%%NAMESPACE%%%Contact__r.LastName} + &#39; &#39; +
 IF(
-NOT(ISBLANK({!myVariable_current.StartDate__c})),  TEXT({!myVariable_current.StartDate__c}) , LEFT(TEXT({!myVariable_current.CreatedDate}),10 ))+
-&#39;: &#39; + {!myVariable_current.Program__r.Name}) &gt; 77,
-LEFT(({!myVariable_current.Contact__r.FirstName}  + &#39; &#39; + {!myVariable_current.Contact__r.LastName} + &#39; &#39; +
-IF (NOT(ISBLANK({!myVariable_current.StartDate__c})),  TEXT({!myVariable_current.StartDate__c}) , LEFT(TEXT({!myVariable_current.CreatedDate}),10)) +
-&#39;: &#39; + {!myVariable_current.Program__r.Name}),77)
-+ &#39;...&#39;, {!myVariable_current.Contact__r.FirstName}  + &#39; &#39; + {!myVariable_current.Contact__r.LastName} + &#39; &#39; +
+NOT(ISBLANK({!myVariable_current.%%%NAMESPACE%%%StartDate__c})),  TEXT({!myVariable_current.%%%NAMESPACE%%%StartDate__c}) , LEFT(TEXT({!myVariable_current.CreatedDate}),10 ))+
+&#39;: &#39; + {!myVariable_current.%%%NAMESPACE%%%Program__r.Name}) &gt; 77,
+LEFT(({!myVariable_current.%%%NAMESPACE%%%Contact__r.FirstName}  + &#39; &#39; + {!myVariable_current.%%%NAMESPACE%%%Contact__r.LastName} + &#39; &#39; +
+IF (NOT(ISBLANK({!myVariable_current.%%%NAMESPACE%%%StartDate__c})),  TEXT({!myVariable_current.%%%NAMESPACE%%%StartDate__c}) , LEFT(TEXT({!myVariable_current.CreatedDate}),10)) +
+&#39;: &#39; + {!myVariable_current.%%%NAMESPACE%%%Program__r.Name}),77)
++ &#39;...&#39;, {!myVariable_current.%%%NAMESPACE%%%Contact__r.FirstName}  + &#39; &#39; + {!myVariable_current.%%%NAMESPACE%%%Contact__r.LastName} + &#39; &#39; +
 IF(
-NOT(ISBLANK({!myVariable_current.StartDate__c})),  TEXT({!myVariable_current.StartDate__c}) , LEFT(TEXT({!myVariable_current.CreatedDate}),10 ))+
-&#39;: &#39; + {!myVariable_current.Program__r.Name}
+NOT(ISBLANK({!myVariable_current.%%%NAMESPACE%%%StartDate__c})),  TEXT({!myVariable_current.%%%NAMESPACE%%%StartDate__c}) , LEFT(TEXT({!myVariable_current.CreatedDate}),10 ))+
+&#39;: &#39; + {!myVariable_current.%%%NAMESPACE%%%Program__r.Name}
 ), 
 IF(
 LEN(
-{!$Label.Anonymous}+ &#39; &#39; +
+{!$Label.%%%NAMESPACE%%%Anonymous}+ &#39; &#39; +
 IF(
-NOT(ISBLANK({!myVariable_current.StartDate__c})),  TEXT({!myVariable_current.StartDate__c}) , LEFT(TEXT({!myVariable_current.CreatedDate}),10 ))+
-&#39;: &#39; + {!myVariable_current.Program__r.Name}) &gt; 77,
-LEFT(({!$Label.Anonymous} + &#39; &#39; +
-IF (NOT(ISBLANK({!myVariable_current.StartDate__c})),  TEXT({!myVariable_current.StartDate__c}) , LEFT(TEXT({!myVariable_current.CreatedDate}),10)) +
-&#39;: &#39; + {!myVariable_current.Program__r.Name}),77)
-+ &#39;...&#39;, {!$Label.Anonymous} + &#39; &#39; +
+NOT(ISBLANK({!myVariable_current.%%%NAMESPACE%%%StartDate__c})),  TEXT({!myVariable_current.%%%NAMESPACE%%%StartDate__c}) , LEFT(TEXT({!myVariable_current.CreatedDate}),10 ))+
+&#39;: &#39; + {!myVariable_current.%%%NAMESPACE%%%Program__r.Name}) &gt; 77,
+LEFT(({!$Label.%%%NAMESPACE%%%Anonymous} + &#39; &#39; +
+IF (NOT(ISBLANK({!myVariable_current.%%%NAMESPACE%%%StartDate__c})),  TEXT({!myVariable_current.%%%NAMESPACE%%%StartDate__c}) , LEFT(TEXT({!myVariable_current.CreatedDate}),10)) +
+&#39;: &#39; + {!myVariable_current.%%%NAMESPACE%%%Program__r.Name}),77)
++ &#39;...&#39;, {!$Label.%%%NAMESPACE%%%Anonymous} + &#39; &#39; +
 IF(
-NOT(ISBLANK({!myVariable_current.StartDate__c})),  TEXT({!myVariable_current.StartDate__c}) , LEFT(TEXT({!myVariable_current.CreatedDate}),10 ))+
-&#39;: &#39; + {!myVariable_current.Program__r.Name}
+NOT(ISBLANK({!myVariable_current.%%%NAMESPACE%%%StartDate__c})),  TEXT({!myVariable_current.%%%NAMESPACE%%%StartDate__c}) , LEFT(TEXT({!myVariable_current.CreatedDate}),10 ))+
+&#39;: &#39; + {!myVariable_current.%%%NAMESPACE%%%Program__r.Name}
 ))</expression>
     </formulas>
     <formulas>
         <processMetadataValues>
             <name>originalFormula</name>
             <value>
-                <stringValue>IF(NOT(ISNULL([ProgramEngagement__c].StartDate__c)), IF ([ProgramEngagement__c].StartDate__c &gt; TODAY(), TODAY(), NULL), TODAY())</stringValue>
+                <stringValue>IF(NOT(ISNULL([%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%StartDate__c)), IF ([%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%StartDate__c &gt; TODAY(), TODAY(), NULL), TODAY())</stringValue>
             </value>
         </processMetadataValues>
         <name>formula_5_myRule_4_A1_9452998888</name>
         <dataType>Date</dataType>
-        <expression>IF(NOT(ISNULL({!myVariable_current.StartDate__c})), IF ({!myVariable_current.StartDate__c} &gt; TODAY(), TODAY(), NULL), TODAY())</expression>
+        <expression>IF(NOT(ISNULL({!myVariable_current.%%%NAMESPACE%%%StartDate__c})), IF ({!myVariable_current.%%%NAMESPACE%%%StartDate__c} &gt; TODAY(), TODAY(), NULL), TODAY())</expression>
     </formulas>
     <formulas>
         <processMetadataValues>
             <name>originalFormula</name>
             <value>
-                <stringValue>IF([ProgramEngagement__c].Program__c.StartDate__c &lt;= TODAY() , TODAY(), NULL)</stringValue>
+                <stringValue>IF([%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%Program__c.%%%NAMESPACE%%%StartDate__c &lt;= TODAY() , TODAY(), NULL)</stringValue>
             </value>
         </processMetadataValues>
         <name>formula_8_myRule_7_A1_6369948895</name>
         <dataType>Date</dataType>
-        <expression>IF({!myVariable_current.Program__r.StartDate__c} &lt;= TODAY() , TODAY(), NULL)</expression>
+        <expression>IF({!myVariable_current.%%%NAMESPACE%%%Program__r.%%%NAMESPACE%%%StartDate__c} &lt;= TODAY() , TODAY(), NULL)</expression>
     </formulas>
     <formulas>
         <processMetadataValues>
             <name>originalFormula</name>
             <value>
-                <stringValue> NOT([ProgramEngagement__c].AutoName_Override__c) </stringValue>
+                <stringValue> NOT([%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%AutoName_Override__c) </stringValue>
             </value>
         </processMetadataValues>
         <name>formula_myRule_1</name>
         <dataType>Boolean</dataType>
-        <expression> NOT({!myVariable_current.AutoName_Override__c})</expression>
+        <expression> NOT({!myVariable_current.%%%NAMESPACE%%%AutoName_Override__c})</expression>
     </formulas>
     <interviewLabel>Auto_Populate_Date_And_Name_On_Program_Engagement-2_InterviewLabel</interviewLabel>
     <isTemplate>true</isTemplate>
@@ -434,7 +434,7 @@ NOT(ISBLANK({!myVariable_current.StartDate__c})),  TEXT({!myVariable_current.Sta
     <processMetadataValues>
         <name>ObjectType</name>
         <value>
-            <stringValue>ProgramEngagement__c</stringValue>
+            <stringValue>%%%NAMESPACE%%%ProgramEngagement__c</stringValue>
         </value>
     </processMetadataValues>
     <processMetadataValues>
@@ -475,7 +475,7 @@ NOT(ISBLANK({!myVariable_current.StartDate__c})),  TEXT({!myVariable_current.Sta
         <processMetadataValues>
             <name>reference</name>
             <value>
-                <stringValue>[ProgramEngagement__c]</stringValue>
+                <stringValue>[%%%NAMESPACE%%%ProgramEngagement__c]</stringValue>
             </value>
         </processMetadataValues>
         <processMetadataValues>
@@ -529,12 +529,12 @@ NOT(ISBLANK({!myVariable_current.StartDate__c})),  TEXT({!myVariable_current.Sta
                     <stringValue>Formula</stringValue>
                 </value>
             </processMetadataValues>
-            <field>EndDate__c</field>
+            <field>%%%NAMESPACE%%%EndDate__c</field>
             <value>
                 <elementReference>formula_11_myRule_10_A1_9228346885</elementReference>
             </value>
         </inputAssignments>
-        <object>ProgramEngagement__c</object>
+        <object>%%%NAMESPACE%%%ProgramEngagement__c</object>
     </recordUpdates>
     <recordUpdates>
         <processMetadataValues>
@@ -555,7 +555,7 @@ NOT(ISBLANK({!myVariable_current.StartDate__c})),  TEXT({!myVariable_current.Sta
         <processMetadataValues>
             <name>reference</name>
             <value>
-                <stringValue>[ProgramEngagement__c]</stringValue>
+                <stringValue>[%%%NAMESPACE%%%ProgramEngagement__c]</stringValue>
             </value>
         </processMetadataValues>
         <processMetadataValues>
@@ -617,7 +617,7 @@ NOT(ISBLANK({!myVariable_current.StartDate__c})),  TEXT({!myVariable_current.Sta
                 <elementReference>formula_2_myRule_1_A1_3915232854</elementReference>
             </value>
         </inputAssignments>
-        <object>ProgramEngagement__c</object>
+        <object>%%%NAMESPACE%%%ProgramEngagement__c</object>
     </recordUpdates>
     <recordUpdates>
         <processMetadataValues>
@@ -638,7 +638,7 @@ NOT(ISBLANK({!myVariable_current.StartDate__c})),  TEXT({!myVariable_current.Sta
         <processMetadataValues>
             <name>reference</name>
             <value>
-                <stringValue>[ProgramEngagement__c]</stringValue>
+                <stringValue>[%%%NAMESPACE%%%ProgramEngagement__c]</stringValue>
             </value>
         </processMetadataValues>
         <processMetadataValues>
@@ -692,12 +692,12 @@ NOT(ISBLANK({!myVariable_current.StartDate__c})),  TEXT({!myVariable_current.Sta
                     <stringValue>Formula</stringValue>
                 </value>
             </processMetadataValues>
-            <field>ApplicationDate__c</field>
+            <field>%%%NAMESPACE%%%ApplicationDate__c</field>
             <value>
                 <elementReference>formula_5_myRule_4_A1_9452998888</elementReference>
             </value>
         </inputAssignments>
-        <object>ProgramEngagement__c</object>
+        <object>%%%NAMESPACE%%%ProgramEngagement__c</object>
     </recordUpdates>
     <recordUpdates>
         <processMetadataValues>
@@ -718,7 +718,7 @@ NOT(ISBLANK({!myVariable_current.StartDate__c})),  TEXT({!myVariable_current.Sta
         <processMetadataValues>
             <name>reference</name>
             <value>
-                <stringValue>[ProgramEngagement__c]</stringValue>
+                <stringValue>[%%%NAMESPACE%%%ProgramEngagement__c]</stringValue>
             </value>
         </processMetadataValues>
         <processMetadataValues>
@@ -772,12 +772,12 @@ NOT(ISBLANK({!myVariable_current.StartDate__c})),  TEXT({!myVariable_current.Sta
                     <stringValue>Formula</stringValue>
                 </value>
             </processMetadataValues>
-            <field>StartDate__c</field>
+            <field>%%%NAMESPACE%%%StartDate__c</field>
             <value>
                 <elementReference>formula_8_myRule_7_A1_6369948895</elementReference>
             </value>
         </inputAssignments>
-        <object>ProgramEngagement__c</object>
+        <object>%%%NAMESPACE%%%ProgramEngagement__c</object>
     </recordUpdates>
     <startElementReference>myDecision</startElementReference>
     <status>Active</status>
@@ -787,7 +787,7 @@ NOT(ISBLANK({!myVariable_current.StartDate__c})),  TEXT({!myVariable_current.Sta
         <isCollection>false</isCollection>
         <isInput>true</isInput>
         <isOutput>true</isOutput>
-        <objectType>ProgramEngagement__c</objectType>
+        <objectType>%%%NAMESPACE%%%ProgramEngagement__c</objectType>
     </variables>
     <variables>
         <name>myVariable_old</name>
@@ -795,6 +795,6 @@ NOT(ISBLANK({!myVariable_current.StartDate__c})),  TEXT({!myVariable_current.Sta
         <isCollection>false</isCollection>
         <isInput>true</isInput>
         <isOutput>false</isOutput>
-        <objectType>ProgramEngagement__c</objectType>
+        <objectType>%%%NAMESPACE%%%ProgramEngagement__c</objectType>
     </variables>
 </Flow>

--- a/force-app/main/default/flows/Auto_Populate_Date_And_Name_On_Program_Engagement.flow-meta.xml
+++ b/force-app/main/default/flows/Auto_Populate_Date_And_Name_On_Program_Engagement.flow-meta.xml
@@ -74,7 +74,7 @@
                         <stringValue>Picklist</stringValue>
                     </value>
                 </processMetadataValues>
-                <leftValueReference>myVariable_current.%%%NAMESPACE%%%Stage__c</leftValueReference>
+                <leftValueReference>myVariable_current.Stage__c</leftValueReference>
                 <operator>EqualTo</operator>
                 <rightValue>
                     <stringValue>Applied</stringValue>
@@ -105,7 +105,7 @@
                         <stringValue>Boolean</stringValue>
                     </value>
                 </processMetadataValues>
-                <leftValueReference>myVariable_current.%%%NAMESPACE%%%ApplicationDate__c</leftValueReference>
+                <leftValueReference>myVariable_current.ApplicationDate__c</leftValueReference>
                 <operator>IsNull</operator>
                 <rightValue>
                     <booleanValue>true</booleanValue>
@@ -160,7 +160,7 @@
                         <stringValue>Picklist</stringValue>
                     </value>
                 </processMetadataValues>
-                <leftValueReference>myVariable_current.%%%NAMESPACE%%%Stage__c</leftValueReference>
+                <leftValueReference>myVariable_current.Stage__c</leftValueReference>
                 <operator>EqualTo</operator>
                 <rightValue>
                     <stringValue>Active</stringValue>
@@ -191,7 +191,7 @@
                         <stringValue>Boolean</stringValue>
                     </value>
                 </processMetadataValues>
-                <leftValueReference>myVariable_current.%%%NAMESPACE%%%StartDate__c</leftValueReference>
+                <leftValueReference>myVariable_current.StartDate__c</leftValueReference>
                 <operator>IsNull</operator>
                 <rightValue>
                     <booleanValue>true</booleanValue>
@@ -243,7 +243,7 @@
                         <stringValue>Picklist</stringValue>
                     </value>
                 </processMetadataValues>
-                <leftValueReference>myVariable_current.%%%NAMESPACE%%%Stage__c</leftValueReference>
+                <leftValueReference>myVariable_current.Stage__c</leftValueReference>
                 <operator>EqualTo</operator>
                 <rightValue>
                     <stringValue>Completed</stringValue>
@@ -274,7 +274,7 @@
                         <stringValue>Picklist</stringValue>
                     </value>
                 </processMetadataValues>
-                <leftValueReference>myVariable_current.%%%NAMESPACE%%%Stage__c</leftValueReference>
+                <leftValueReference>myVariable_current.Stage__c</leftValueReference>
                 <operator>EqualTo</operator>
                 <rightValue>
                     <stringValue>Withdrawn</stringValue>
@@ -305,7 +305,7 @@
                         <stringValue>Boolean</stringValue>
                     </value>
                 </processMetadataValues>
-                <leftValueReference>myVariable_current.%%%NAMESPACE%%%EndDate__c</leftValueReference>
+                <leftValueReference>myVariable_current.EndDate__c</leftValueReference>
                 <operator>IsNull</operator>
                 <rightValue>
                     <booleanValue>true</booleanValue>
@@ -325,7 +325,7 @@
                 <stringValue>TODAY() </stringValue>
             </value>
         </processMetadataValues>
-        <name>formula_11_myRule_10_A1_9228346885</name>
+        <name>formula_11_myRule_10_A1_6433572107</name>
         <dataType>Date</dataType>
         <expression>TODAY()</expression>
     </formulas>
@@ -333,100 +333,100 @@
         <processMetadataValues>
             <name>originalFormula</name>
             <value>
-                <stringValue>IF(NOT(ISBLANK([%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%Contact__c)),IF(
+                <stringValue>IF(NOT(ISBLANK([ProgramEngagement__c].Contact__c)),IF(
 LEN(
-[%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%Contact__c.FirstName  + &#39; &#39; + [%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%Contact__c.LastName + &#39; &#39; +
+[ProgramEngagement__c].Contact__c.FirstName  + &apos; &apos; + [ProgramEngagement__c].Contact__c.LastName + &apos; &apos; +
 IF(
-NOT(ISBLANK([%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%StartDate__c)),  TEXT([%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%StartDate__c) , LEFT(TEXT([%%%NAMESPACE%%%ProgramEngagement__c].CreatedDate),10 ))+
-&#39;: &#39; + [%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%Program__c.Name) &gt; 77,
-LEFT(([%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%Contact__c.FirstName  + &#39; &#39; + [%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%Contact__c.LastName + &#39; &#39; +
-IF (NOT(ISBLANK([%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%StartDate__c)),  TEXT([%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%StartDate__c) , LEFT(TEXT([%%%NAMESPACE%%%ProgramEngagement__c].CreatedDate),10)) +
-&#39;: &#39; + [%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%Program__c.Name),77)
-+ &#39;...&#39;, [%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%Contact__c.FirstName  + &#39; &#39; + [%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%Contact__c.LastName + &#39; &#39; +
+NOT(ISBLANK([ProgramEngagement__c].StartDate__c)),  TEXT([ProgramEngagement__c].StartDate__c) , LEFT(TEXT([ProgramEngagement__c].CreatedDate),10 ))+
+&apos;: &apos; + [ProgramEngagement__c].Program__c.Name) &gt; 77,
+LEFT(([ProgramEngagement__c].Contact__c.FirstName  + &apos; &apos; + [ProgramEngagement__c].Contact__c.LastName + &apos; &apos; +
+IF (NOT(ISBLANK([ProgramEngagement__c].StartDate__c)),  TEXT([ProgramEngagement__c].StartDate__c) , LEFT(TEXT([ProgramEngagement__c].CreatedDate),10)) +
+&apos;: &apos; + [ProgramEngagement__c].Program__c.Name),77)
++ &apos;...&apos;, [ProgramEngagement__c].Contact__c.FirstName  + &apos; &apos; + [ProgramEngagement__c].Contact__c.LastName + &apos; &apos; +
 IF(
-NOT(ISBLANK([%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%StartDate__c)),  TEXT([%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%StartDate__c) , LEFT(TEXT([%%%NAMESPACE%%%ProgramEngagement__c].CreatedDate),10 ))+
-&#39;: &#39; + [%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%Program__c.Name
+NOT(ISBLANK([ProgramEngagement__c].StartDate__c)),  TEXT([ProgramEngagement__c].StartDate__c) , LEFT(TEXT([ProgramEngagement__c].CreatedDate),10 ))+
+&apos;: &apos; + [ProgramEngagement__c].Program__c.Name
 ), 
 IF(
 LEN(
-$Label.%%%NAMESPACE%%%Anonymous+ &#39; &#39; +
+$Label.Anonymous+ &apos; &apos; +
 IF(
-NOT(ISBLANK([%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%StartDate__c)),  TEXT([%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%StartDate__c) , LEFT(TEXT([%%%NAMESPACE%%%ProgramEngagement__c].CreatedDate),10 ))+
-&#39;: &#39; + [%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%Program__c.Name) &gt; 77,
-LEFT(($Label.%%%NAMESPACE%%%Anonymous + &#39; &#39; +
-IF (NOT(ISBLANK([%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%StartDate__c)),  TEXT([%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%StartDate__c) , LEFT(TEXT([%%%NAMESPACE%%%ProgramEngagement__c].CreatedDate),10)) +
-&#39;: &#39; + [%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%Program__c.Name),77)
-+ &#39;...&#39;, $Label.%%%NAMESPACE%%%Anonymous + &#39; &#39; +
+NOT(ISBLANK([ProgramEngagement__c].StartDate__c)),  TEXT([ProgramEngagement__c].StartDate__c) , LEFT(TEXT([ProgramEngagement__c].CreatedDate),10 ))+
+&apos;: &apos; + [ProgramEngagement__c].Program__c.Name) &gt; 77,
+LEFT(($Label.Anonymous + &apos; &apos; +
+IF (NOT(ISBLANK([ProgramEngagement__c].StartDate__c)),  TEXT([ProgramEngagement__c].StartDate__c) , LEFT(TEXT([ProgramEngagement__c].CreatedDate),10)) +
+&apos;: &apos; + [ProgramEngagement__c].Program__c.Name),77)
++ &apos;...&apos;, $Label.Anonymous + &apos; &apos; +
 IF(
-NOT(ISBLANK([%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%StartDate__c)),  TEXT([%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%StartDate__c) , LEFT(TEXT([%%%NAMESPACE%%%ProgramEngagement__c].CreatedDate),10 ))+
-&#39;: &#39; + [%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%Program__c.Name
+NOT(ISBLANK([ProgramEngagement__c].StartDate__c)),  TEXT([ProgramEngagement__c].StartDate__c) , LEFT(TEXT([ProgramEngagement__c].CreatedDate),10 ))+
+&apos;: &apos; + [ProgramEngagement__c].Program__c.Name
 ))
 </stringValue>
             </value>
         </processMetadataValues>
-        <name>formula_2_myRule_1_A1_3915232854</name>
+        <name>formula_2_myRule_1_A1_2224060128</name>
         <dataType>String</dataType>
-        <expression>IF(NOT(ISBLANK({!myVariable_current.%%%NAMESPACE%%%Contact__c})),IF(
+        <expression>IF(NOT(ISBLANK({!myVariable_current.Contact__c})),IF(
 LEN(
-{!myVariable_current.%%%NAMESPACE%%%Contact__r.FirstName}  + &#39; &#39; + {!myVariable_current.%%%NAMESPACE%%%Contact__r.LastName} + &#39; &#39; +
+{!myVariable_current.Contact__r.FirstName}  + &apos; &apos; + {!myVariable_current.Contact__r.LastName} + &apos; &apos; +
 IF(
-NOT(ISBLANK({!myVariable_current.%%%NAMESPACE%%%StartDate__c})),  TEXT({!myVariable_current.%%%NAMESPACE%%%StartDate__c}) , LEFT(TEXT({!myVariable_current.CreatedDate}),10 ))+
-&#39;: &#39; + {!myVariable_current.%%%NAMESPACE%%%Program__r.Name}) &gt; 77,
-LEFT(({!myVariable_current.%%%NAMESPACE%%%Contact__r.FirstName}  + &#39; &#39; + {!myVariable_current.%%%NAMESPACE%%%Contact__r.LastName} + &#39; &#39; +
-IF (NOT(ISBLANK({!myVariable_current.%%%NAMESPACE%%%StartDate__c})),  TEXT({!myVariable_current.%%%NAMESPACE%%%StartDate__c}) , LEFT(TEXT({!myVariable_current.CreatedDate}),10)) +
-&#39;: &#39; + {!myVariable_current.%%%NAMESPACE%%%Program__r.Name}),77)
-+ &#39;...&#39;, {!myVariable_current.%%%NAMESPACE%%%Contact__r.FirstName}  + &#39; &#39; + {!myVariable_current.%%%NAMESPACE%%%Contact__r.LastName} + &#39; &#39; +
+NOT(ISBLANK({!myVariable_current.StartDate__c})),  TEXT({!myVariable_current.StartDate__c}) , LEFT(TEXT({!myVariable_current.CreatedDate}),10 ))+
+&apos;: &apos; + {!myVariable_current.Program__r.Name}) &gt; 77,
+LEFT(({!myVariable_current.Contact__r.FirstName}  + &apos; &apos; + {!myVariable_current.Contact__r.LastName} + &apos; &apos; +
+IF (NOT(ISBLANK({!myVariable_current.StartDate__c})),  TEXT({!myVariable_current.StartDate__c}) , LEFT(TEXT({!myVariable_current.CreatedDate}),10)) +
+&apos;: &apos; + {!myVariable_current.Program__r.Name}),77)
++ &apos;...&apos;, {!myVariable_current.Contact__r.FirstName}  + &apos; &apos; + {!myVariable_current.Contact__r.LastName} + &apos; &apos; +
 IF(
-NOT(ISBLANK({!myVariable_current.%%%NAMESPACE%%%StartDate__c})),  TEXT({!myVariable_current.%%%NAMESPACE%%%StartDate__c}) , LEFT(TEXT({!myVariable_current.CreatedDate}),10 ))+
-&#39;: &#39; + {!myVariable_current.%%%NAMESPACE%%%Program__r.Name}
+NOT(ISBLANK({!myVariable_current.StartDate__c})),  TEXT({!myVariable_current.StartDate__c}) , LEFT(TEXT({!myVariable_current.CreatedDate}),10 ))+
+&apos;: &apos; + {!myVariable_current.Program__r.Name}
 ), 
 IF(
 LEN(
-{!$Label.%%%NAMESPACE%%%Anonymous}+ &#39; &#39; +
+{!$Label.Anonymous}+ &apos; &apos; +
 IF(
-NOT(ISBLANK({!myVariable_current.%%%NAMESPACE%%%StartDate__c})),  TEXT({!myVariable_current.%%%NAMESPACE%%%StartDate__c}) , LEFT(TEXT({!myVariable_current.CreatedDate}),10 ))+
-&#39;: &#39; + {!myVariable_current.%%%NAMESPACE%%%Program__r.Name}) &gt; 77,
-LEFT(({!$Label.%%%NAMESPACE%%%Anonymous} + &#39; &#39; +
-IF (NOT(ISBLANK({!myVariable_current.%%%NAMESPACE%%%StartDate__c})),  TEXT({!myVariable_current.%%%NAMESPACE%%%StartDate__c}) , LEFT(TEXT({!myVariable_current.CreatedDate}),10)) +
-&#39;: &#39; + {!myVariable_current.%%%NAMESPACE%%%Program__r.Name}),77)
-+ &#39;...&#39;, {!$Label.%%%NAMESPACE%%%Anonymous} + &#39; &#39; +
+NOT(ISBLANK({!myVariable_current.StartDate__c})),  TEXT({!myVariable_current.StartDate__c}) , LEFT(TEXT({!myVariable_current.CreatedDate}),10 ))+
+&apos;: &apos; + {!myVariable_current.Program__r.Name}) &gt; 77,
+LEFT(({!$Label.Anonymous} + &apos; &apos; +
+IF (NOT(ISBLANK({!myVariable_current.StartDate__c})),  TEXT({!myVariable_current.StartDate__c}) , LEFT(TEXT({!myVariable_current.CreatedDate}),10)) +
+&apos;: &apos; + {!myVariable_current.Program__r.Name}),77)
++ &apos;...&apos;, {!$Label.Anonymous} + &apos; &apos; +
 IF(
-NOT(ISBLANK({!myVariable_current.%%%NAMESPACE%%%StartDate__c})),  TEXT({!myVariable_current.%%%NAMESPACE%%%StartDate__c}) , LEFT(TEXT({!myVariable_current.CreatedDate}),10 ))+
-&#39;: &#39; + {!myVariable_current.%%%NAMESPACE%%%Program__r.Name}
+NOT(ISBLANK({!myVariable_current.StartDate__c})),  TEXT({!myVariable_current.StartDate__c}) , LEFT(TEXT({!myVariable_current.CreatedDate}),10 ))+
+&apos;: &apos; + {!myVariable_current.Program__r.Name}
 ))</expression>
     </formulas>
     <formulas>
         <processMetadataValues>
             <name>originalFormula</name>
             <value>
-                <stringValue>IF(NOT(ISNULL([%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%StartDate__c)), IF ([%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%StartDate__c &gt; TODAY(), TODAY(), NULL), TODAY())</stringValue>
+                <stringValue>IF(NOT(ISNULL([ProgramEngagement__c].StartDate__c)), IF ([ProgramEngagement__c].StartDate__c &gt; TODAY(), TODAY(), NULL), TODAY())</stringValue>
             </value>
         </processMetadataValues>
-        <name>formula_5_myRule_4_A1_9452998888</name>
+        <name>formula_5_myRule_4_A1_0925925767</name>
         <dataType>Date</dataType>
-        <expression>IF(NOT(ISNULL({!myVariable_current.%%%NAMESPACE%%%StartDate__c})), IF ({!myVariable_current.%%%NAMESPACE%%%StartDate__c} &gt; TODAY(), TODAY(), NULL), TODAY())</expression>
+        <expression>IF(NOT(ISNULL({!myVariable_current.StartDate__c})), IF ({!myVariable_current.StartDate__c} &gt; TODAY(), TODAY(), NULL), TODAY())</expression>
     </formulas>
     <formulas>
         <processMetadataValues>
             <name>originalFormula</name>
             <value>
-                <stringValue>IF([%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%Program__c.%%%NAMESPACE%%%StartDate__c &lt;= TODAY() , TODAY(), NULL)</stringValue>
+                <stringValue>IF([ProgramEngagement__c].Program__c.StartDate__c &lt;= TODAY() , TODAY(), NULL)</stringValue>
             </value>
         </processMetadataValues>
-        <name>formula_8_myRule_7_A1_6369948895</name>
+        <name>formula_8_myRule_7_A1_2608436668</name>
         <dataType>Date</dataType>
-        <expression>IF({!myVariable_current.%%%NAMESPACE%%%Program__r.%%%NAMESPACE%%%StartDate__c} &lt;= TODAY() , TODAY(), NULL)</expression>
+        <expression>IF({!myVariable_current.Program__r.StartDate__c} &lt;= TODAY() , TODAY(), NULL)</expression>
     </formulas>
     <formulas>
         <processMetadataValues>
             <name>originalFormula</name>
             <value>
-                <stringValue> NOT([%%%NAMESPACE%%%ProgramEngagement__c].%%%NAMESPACE%%%AutoName_Override__c) </stringValue>
+                <stringValue> NOT([ProgramEngagement__c].AutoName_Override__c) </stringValue>
             </value>
         </processMetadataValues>
         <name>formula_myRule_1</name>
         <dataType>Boolean</dataType>
-        <expression> NOT({!myVariable_current.%%%NAMESPACE%%%AutoName_Override__c})</expression>
+        <expression> NOT({!myVariable_current.AutoName_Override__c})</expression>
     </formulas>
     <interviewLabel>Auto_Populate_Date_And_Name_On_Program_Engagement-2_InterviewLabel</interviewLabel>
     <isTemplate>true</isTemplate>
@@ -434,7 +434,7 @@ NOT(ISBLANK({!myVariable_current.%%%NAMESPACE%%%StartDate__c})),  TEXT({!myVaria
     <processMetadataValues>
         <name>ObjectType</name>
         <value>
-            <stringValue>%%%NAMESPACE%%%ProgramEngagement__c</stringValue>
+            <stringValue>ProgramEngagement__c</stringValue>
         </value>
     </processMetadataValues>
     <processMetadataValues>
@@ -475,7 +475,7 @@ NOT(ISBLANK({!myVariable_current.%%%NAMESPACE%%%StartDate__c})),  TEXT({!myVaria
         <processMetadataValues>
             <name>reference</name>
             <value>
-                <stringValue>[%%%NAMESPACE%%%ProgramEngagement__c]</stringValue>
+                <stringValue>[ProgramEngagement__c]</stringValue>
             </value>
         </processMetadataValues>
         <processMetadataValues>
@@ -529,12 +529,12 @@ NOT(ISBLANK({!myVariable_current.%%%NAMESPACE%%%StartDate__c})),  TEXT({!myVaria
                     <stringValue>Formula</stringValue>
                 </value>
             </processMetadataValues>
-            <field>%%%NAMESPACE%%%EndDate__c</field>
+            <field>EndDate__c</field>
             <value>
-                <elementReference>formula_11_myRule_10_A1_9228346885</elementReference>
+                <elementReference>formula_11_myRule_10_A1_6433572107</elementReference>
             </value>
         </inputAssignments>
-        <object>%%%NAMESPACE%%%ProgramEngagement__c</object>
+        <object>ProgramEngagement__c</object>
     </recordUpdates>
     <recordUpdates>
         <processMetadataValues>
@@ -555,7 +555,7 @@ NOT(ISBLANK({!myVariable_current.%%%NAMESPACE%%%StartDate__c})),  TEXT({!myVaria
         <processMetadataValues>
             <name>reference</name>
             <value>
-                <stringValue>[%%%NAMESPACE%%%ProgramEngagement__c]</stringValue>
+                <stringValue>[ProgramEngagement__c]</stringValue>
             </value>
         </processMetadataValues>
         <processMetadataValues>
@@ -614,10 +614,10 @@ NOT(ISBLANK({!myVariable_current.%%%NAMESPACE%%%StartDate__c})),  TEXT({!myVaria
             </processMetadataValues>
             <field>Name</field>
             <value>
-                <elementReference>formula_2_myRule_1_A1_3915232854</elementReference>
+                <elementReference>formula_2_myRule_1_A1_2224060128</elementReference>
             </value>
         </inputAssignments>
-        <object>%%%NAMESPACE%%%ProgramEngagement__c</object>
+        <object>ProgramEngagement__c</object>
     </recordUpdates>
     <recordUpdates>
         <processMetadataValues>
@@ -638,7 +638,7 @@ NOT(ISBLANK({!myVariable_current.%%%NAMESPACE%%%StartDate__c})),  TEXT({!myVaria
         <processMetadataValues>
             <name>reference</name>
             <value>
-                <stringValue>[%%%NAMESPACE%%%ProgramEngagement__c]</stringValue>
+                <stringValue>[ProgramEngagement__c]</stringValue>
             </value>
         </processMetadataValues>
         <processMetadataValues>
@@ -692,12 +692,12 @@ NOT(ISBLANK({!myVariable_current.%%%NAMESPACE%%%StartDate__c})),  TEXT({!myVaria
                     <stringValue>Formula</stringValue>
                 </value>
             </processMetadataValues>
-            <field>%%%NAMESPACE%%%ApplicationDate__c</field>
+            <field>ApplicationDate__c</field>
             <value>
-                <elementReference>formula_5_myRule_4_A1_9452998888</elementReference>
+                <elementReference>formula_5_myRule_4_A1_0925925767</elementReference>
             </value>
         </inputAssignments>
-        <object>%%%NAMESPACE%%%ProgramEngagement__c</object>
+        <object>ProgramEngagement__c</object>
     </recordUpdates>
     <recordUpdates>
         <processMetadataValues>
@@ -718,7 +718,7 @@ NOT(ISBLANK({!myVariable_current.%%%NAMESPACE%%%StartDate__c})),  TEXT({!myVaria
         <processMetadataValues>
             <name>reference</name>
             <value>
-                <stringValue>[%%%NAMESPACE%%%ProgramEngagement__c]</stringValue>
+                <stringValue>[ProgramEngagement__c]</stringValue>
             </value>
         </processMetadataValues>
         <processMetadataValues>
@@ -772,12 +772,12 @@ NOT(ISBLANK({!myVariable_current.%%%NAMESPACE%%%StartDate__c})),  TEXT({!myVaria
                     <stringValue>Formula</stringValue>
                 </value>
             </processMetadataValues>
-            <field>%%%NAMESPACE%%%StartDate__c</field>
+            <field>StartDate__c</field>
             <value>
-                <elementReference>formula_8_myRule_7_A1_6369948895</elementReference>
+                <elementReference>formula_8_myRule_7_A1_2608436668</elementReference>
             </value>
         </inputAssignments>
-        <object>%%%NAMESPACE%%%ProgramEngagement__c</object>
+        <object>ProgramEngagement__c</object>
     </recordUpdates>
     <startElementReference>myDecision</startElementReference>
     <status>Active</status>
@@ -787,7 +787,7 @@ NOT(ISBLANK({!myVariable_current.%%%NAMESPACE%%%StartDate__c})),  TEXT({!myVaria
         <isCollection>false</isCollection>
         <isInput>true</isInput>
         <isOutput>true</isOutput>
-        <objectType>%%%NAMESPACE%%%ProgramEngagement__c</objectType>
+        <objectType>ProgramEngagement__c</objectType>
     </variables>
     <variables>
         <name>myVariable_old</name>
@@ -795,6 +795,6 @@ NOT(ISBLANK({!myVariable_current.%%%NAMESPACE%%%StartDate__c})),  TEXT({!myVaria
         <isCollection>false</isCollection>
         <isInput>true</isInput>
         <isOutput>false</isOutput>
-        <objectType>%%%NAMESPACE%%%ProgramEngagement__c</objectType>
+        <objectType>ProgramEngagement__c</objectType>
     </variables>
 </Flow>


### PR DESCRIPTION

# Critical Changes

# Changes
 Now when the program has an earlier start date, and the stage is Active then the program engagement start date is autopopulated to 'Today'

# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
~~- [ ] Place holder data is incorporated (Refer to [Case Management Sample Data document](https://quip.com/cbFcAPJF8t0z))~~
~~- [ ] Base axe-core JEST test included for any new LWC (No critical violations)~~
~~- [ ] CRUD/FLS is enforced in Apex~~
~~- [ ] Update & Test permission sets to account for new features and CRUD/FLS~~
~~- [ ] All modified classes are unit tested (Apex) at 100% coverage~~
~~- [ ] UX approval or UX not necessary~~
- [x] PR contains draft release notes
- [x] Attach work item to the pull request with [Lurch](https://salesforce.quip.com/50ZRA5LEWVzH) `**Lurch:attach W-000000` or `**Lurch:add`
- [ ] All **acceptance criteria** have been met
    - [x] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [ ] QE story level testing completed


