### PR TITLE
Respect record types when added by customer

### DIFF
--- a/force-app/main/default/aura/createServiceSchedule/createServiceSchedule.cmp
+++ b/force-app/main/default/aura/createServiceSchedule/createServiceSchedule.cmp
@@ -15,7 +15,7 @@
     <aura:attribute name="recordTypeId" type="String" access="private" />
 
     <aura:handler name="init" value="{!this}" action="{!c.doInit}" />
-    <aura:handler name="change" value="{!v.pageReference}" action="{!c.reInit}" />
+    <aura:handler name="change" value="{!v.pageReference}" action="{!c.refresh}" />
 
     <aura:html tag="style">
         lightning-timepicker, lightning-datepicker { width: 100% }
@@ -25,5 +25,6 @@
     <c:serviceScheduleCreator
         serviceId="{!v.serviceId}"
         recordTypeId="{!v.recordTypeId}"
+        onclose="{!c.refresh}"
     />
 </aura:component>

--- a/force-app/main/default/aura/createServiceSchedule/createServiceSchedule.cmp
+++ b/force-app/main/default/aura/createServiceSchedule/createServiceSchedule.cmp
@@ -8,10 +8,11 @@
   -->
 
 <aura:component
-    implements="flexipage:availableForRecordHome, force:hasRecordId, lightning:actionOverride, lightning:isUrlAddressable"
+    implements="flexipage:availableForRecordHome, force:hasRecordId, lightning:actionOverride, lightning:hasPageReference"
     access="global"
 >
     <aura:attribute name="serviceId" type="String" access="private" />
+    <aura:attribute name="recordTypeId" type="String" access="private" />
 
     <aura:handler name="init" value="{!this}" action="{!c.doInit}" />
     <aura:handler name="change" value="{!v.pageReference}" action="{!c.reInit}" />
@@ -21,5 +22,8 @@
         .slds-accordion__list-item { border-top: none; }
         .slds-table_header-fixed_container { overflow-x: hidden; }
     </aura:html>
-    <c:serviceScheduleCreator serviceId="{!v.serviceId}" />
+    <c:serviceScheduleCreator
+        serviceId="{!v.serviceId}"
+        recordTypeId="{!v.recordTypeId}"
+    />
 </aura:component>

--- a/force-app/main/default/aura/createServiceSchedule/createServiceScheduleController.js
+++ b/force-app/main/default/aura/createServiceSchedule/createServiceScheduleController.js
@@ -12,7 +12,7 @@
         helper.extractUrlParams(component, event, helper);
     },
 
-    reInit: function(component, event, helper) {
+    refresh: function(component, event, helper) {
         helper.refresh();
     }
 });

--- a/force-app/main/default/aura/createServiceSchedule/createServiceScheduleHelper.js
+++ b/force-app/main/default/aura/createServiceSchedule/createServiceScheduleHelper.js
@@ -50,6 +50,8 @@
     },
 
     refresh: function(component, event, helper) {
+        // We refresh whenever the modal is closed or the page reference has changed
+        // to force init to run on subsequent launches
         $A.get("e.force:refreshView").fire();
     }
 });

--- a/force-app/main/default/aura/createServiceSchedule/createServiceScheduleHelper.js
+++ b/force-app/main/default/aura/createServiceSchedule/createServiceScheduleHelper.js
@@ -12,6 +12,13 @@
         let pageRef = component.get("v.pageReference");
         let state = pageRef.state;
         let context = state.inContextOfRef;
+        let recordTypeId = state.recordTypeId;
+
+        if (recordTypeId) {
+            component.set("v.recordTypeId", recordTypeId);
+        } else {
+            component.set("v.recordTypeId", null);
+        }
 
         if (!context) {
             return;

--- a/force-app/main/default/classes/ServiceScheduleCreatorController.cls
+++ b/force-app/main/default/classes/ServiceScheduleCreatorController.cls
@@ -12,9 +12,9 @@ public with sharing class ServiceScheduleCreatorController {
     private static ServiceScheduleService service = new ServiceScheduleService();
 
     @AuraEnabled(cacheable=true)
-    public static ServiceScheduleModel getServiceScheduleModel() {
+    public static ServiceScheduleModel getServiceScheduleModel(Id recordTypeId) {
         try {
-            return service.getServiceScheduleModel();
+            return service.getServiceScheduleModel(recordTypeId);
         } catch (Exception ex) {
             throw Util.getAuraHandledException(ex);
         }

--- a/force-app/main/default/classes/ServiceScheduleCreatorController_TEST.cls
+++ b/force-app/main/default/classes/ServiceScheduleCreatorController_TEST.cls
@@ -16,11 +16,13 @@ public with sharing class ServiceScheduleCreatorController_TEST {
         String methodName = 'getServiceScheduleModel';
         ServiceScheduleModel modelToReturn = new ServiceScheduleModel();
 
-        serviceStub.withReturnValue(methodName, modelToReturn);
+        serviceStub.withReturnValue(methodName, Id.class, modelToReturn);
         ServiceScheduleCreatorController.service = (ServiceScheduleService) serviceStub.createMock();
 
         Test.startTest();
-        ServiceScheduleModel actualModel = ServiceScheduleCreatorController.getServiceScheduleModel();
+        ServiceScheduleModel actualModel = ServiceScheduleCreatorController.getServiceScheduleModel(
+            null
+        );
         Test.stopTest();
 
         System.assertEquals(
@@ -29,7 +31,7 @@ public with sharing class ServiceScheduleCreatorController_TEST {
             'Expected the controller to return the model from the Service.'
         );
 
-        serviceStub.assertCalled(methodName);
+        serviceStub.assertCalled(methodName, Id.class);
     }
 
     @IsTest
@@ -153,12 +155,12 @@ public with sharing class ServiceScheduleCreatorController_TEST {
         String methodName = 'getServiceScheduleModel';
         Exception actualException;
 
-        serviceStub.withThrowException(methodName);
+        serviceStub.withThrowException(methodName, Id.class);
         ServiceScheduleCreatorController.service = (ServiceScheduleService) serviceStub.createMock();
 
         Test.startTest();
         try {
-            ServiceScheduleCreatorController.getServiceScheduleModel();
+            ServiceScheduleCreatorController.getServiceScheduleModel(null);
         } catch (Exception ex) {
             actualException = ex;
         }

--- a/force-app/main/default/classes/ServiceScheduleModel.cls
+++ b/force-app/main/default/classes/ServiceScheduleModel.cls
@@ -97,9 +97,12 @@ public with sharing class ServiceScheduleModel {
     public List<Map<String, Object>> engagementFields = new List<Map<String, Object>>();
 
     public ServiceScheduleModel() {
-        serviceSchedule = new ServiceSchedule__c();
+        this(null);
+    }
+
+    public ServiceScheduleModel(Id recordTypeId) {
         serviceSchedule = (ServiceSchedule__c) ServiceSchedule__c.SObjectType.newSObject(
-            null,
+            recordTypeId,
             true
         );
         serviceSessions = new List<ServiceSession__c>();

--- a/force-app/main/default/classes/ServiceScheduleService.cls
+++ b/force-app/main/default/classes/ServiceScheduleService.cls
@@ -18,8 +18,8 @@ public with sharing class ServiceScheduleService {
     private RecurrenceService recurrenceService = new RecurrenceService();
     private static final String ONE_TIME = 'One Time';
 
-    public ServiceScheduleModel getServiceScheduleModel() {
-        return new ServiceScheduleModel();
+    public ServiceScheduleModel getServiceScheduleModel(Id recordTypeId) {
+        return new ServiceScheduleModel(recordTypeId);
     }
 
     public ServiceScheduleModel persist(ServiceScheduleModel model) {

--- a/force-app/main/default/classes/ServiceScheduleService_TEST.cls
+++ b/force-app/main/default/classes/ServiceScheduleService_TEST.cls
@@ -35,7 +35,7 @@ public with sharing class ServiceScheduleService_TEST {
         expectedModel.serviceSchedule = schedule;
 
         Test.startTest();
-        ServiceScheduleModel actualModel = service.getServiceScheduleModel();
+        ServiceScheduleModel actualModel = service.getServiceScheduleModel(null);
         Test.stopTest();
 
         System.assertEquals(
@@ -777,7 +777,7 @@ public with sharing class ServiceScheduleService_TEST {
         );
 
         // Step 1
-        ServiceScheduleModel model = service.getServiceScheduleModel();
+        ServiceScheduleModel model = service.getServiceScheduleModel(null);
         DateTime firstSessionStart = System.now();
         DateTime firstSessionEnd = System.now().addHours(2);
         ServiceSchedule__c schedule = new ServiceSchedule__c(

--- a/force-app/main/default/lwc/serviceScheduleCreator/serviceScheduleCreator.js
+++ b/force-app/main/default/lwc/serviceScheduleCreator/serviceScheduleCreator.js
@@ -28,6 +28,7 @@ import SERVICE_FIELD from "@salesforce/schema/ServiceSchedule__c.Service__c";
 
 export default class ServiceScheduleCreator extends NavigationMixin(LightningElement) {
     @track hideSpinner = false;
+    @api recordTypeId;
     isLoaded = false;
     serviceScheduleModel;
     originalModel;
@@ -47,7 +48,7 @@ export default class ServiceScheduleCreator extends NavigationMixin(LightningEle
     _steps = new ProgressSteps();
     _serviceSchedules = [];
 
-    @wire(getServiceScheduleModel)
+    @wire(getServiceScheduleModel, { recordTypeId: "$recordTypeId" })
     wireServiceScheduleModel(result) {
         if (!result) {
             return;
@@ -209,6 +210,10 @@ export default class ServiceScheduleCreator extends NavigationMixin(LightningEle
 
         this.hideSpinner = false;
         this.serviceScheduleModel.serviceSchedule = newServiceSchedule.serviceSchedule;
+        if (this.recordTypeId) {
+            // Ok to hardcode standard field, cannot import schema since we do not package record types
+            this.serviceScheduleModel.serviceSchedule.RecordTypeId = this.recordTypeId;
+        }
         this._serviceId = this.serviceScheduleModel.serviceSchedule[
             SERVICE_FIELD.fieldApiName
         ];

--- a/force-app/main/default/lwc/serviceScheduleCreator/serviceScheduleCreator.js
+++ b/force-app/main/default/lwc/serviceScheduleCreator/serviceScheduleCreator.js
@@ -292,6 +292,7 @@ export default class ServiceScheduleCreator extends NavigationMixin(LightningEle
     handleClose() {
         this.hideModal();
         this.navigate();
+        this.dispatchEvent(new CustomEvent("close"));
     }
 
     init() {
@@ -350,11 +351,6 @@ export default class ServiceScheduleCreator extends NavigationMixin(LightningEle
                 filterName: "Recent",
             },
         });
-        // Refresh is triggered by a page reference change in the aura component
-        // if starting from the recent list; closing and clicking new does not
-        // trigger a change in the page reference. Notify component of close
-        // only needed when navigating back to the list view
-        this.dispatchEvent(new CustomEvent("close"));
     }
 
     handleLoaded(event) {

--- a/force-app/main/default/lwc/serviceScheduleCreator/serviceScheduleCreator.js
+++ b/force-app/main/default/lwc/serviceScheduleCreator/serviceScheduleCreator.js
@@ -350,6 +350,11 @@ export default class ServiceScheduleCreator extends NavigationMixin(LightningEle
                 filterName: "Recent",
             },
         });
+        // Refresh is triggered by a page reference change in the aura component
+        // if starting from the recent list; closing and clicking new does not
+        // trigger a change in the page reference. Notify component of close
+        // only needed when navigating back to the list view
+        this.dispatchEvent(new CustomEvent("close"));
     }
 
     handleLoaded(event) {


### PR DESCRIPTION
# Critical Changes

# Changes
- Allow and respect record type selections for Service Schedule
- Fix issue where New button when clicked on from the List View did not show modal after modal was previously closed.

# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
~~Place holder data is incorporated (Refer to [Case Management Sample Data document](https://quip.com/cbFcAPJF8t0z))~~
~~Base axe-core JEST test included for any new LWC (No critical violations)~~
~~CRUD/FLS is enforced in Apex~~
~~Update & Test permission sets to account for new features and CRUD/FLS~~
- [x] All modified classes are unit tested (Apex) at 100% coverage
~~UX approval or UX not necessary~~
- [x] PR contains draft release notes
- [x] Attach work item to the pull request with [Lurch](https://salesforce.quip.com/50ZRA5LEWVzH) `**Lurch:attach W-000000` or `**Lurch:add`
- [ ] All **acceptance criteria** have been met
    - [x] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [ ] QE story level testing completed


