### PR TITLE
Default Service Quantity support for schedules and attendance

### DIFF
--- a/force-app/main/default/classes/AttendanceSelector.cls
+++ b/force-app/main/default/classes/AttendanceSelector.cls
@@ -76,7 +76,8 @@ public with sharing class AttendanceSelector {
                 ServiceSchedule__c,
                 PrimaryServiceProvider__c,
                 SessionStart__c,
-                ServiceSchedule__r.Service__c
+                ServiceSchedule__r.Service__c,
+                ServiceSchedule__r.DefaultServiceQuantity__c
             FROM ServiceSession__c
             WHERE Id = :sessionId
             LIMIT 1

--- a/force-app/main/default/classes/AttendanceSelector.cls
+++ b/force-app/main/default/classes/AttendanceSelector.cls
@@ -70,7 +70,7 @@ public with sharing class AttendanceSelector {
     }
 
     public ServiceSession__c getSession(Id sessionId) {
-        ServiceSession__c session = [
+        List<ServiceSession__c> sessions = [
             SELECT
                 Id,
                 ServiceSchedule__c,
@@ -83,8 +83,10 @@ public with sharing class AttendanceSelector {
             LIMIT 1
         ];
 
-        // Used by Apex code only for querying related records
-        // does not require strip inaccessible
-        return session;
+        return (ServiceSession__c) Security.stripInaccessible(
+                AccessType.READABLE,
+                sessions
+            )
+            .getRecords()[0];
     }
 }

--- a/force-app/main/default/classes/AttendanceService.cls
+++ b/force-app/main/default/classes/AttendanceService.cls
@@ -79,7 +79,8 @@ public with sharing class AttendanceService {
             Contact__r = participant.Contact__r,
             Service_Provider__c = session.PrimaryServiceProvider__c,
             DeliveryDate__c = Date.valueOf(session.SessionStart__c),
-            Service__c = session.ServiceSchedule__r.Service__c
+            Service__c = session.ServiceSchedule__r.Service__c,
+            Quantity__c = session.ServiceSchedule__r.DefaultServiceQuantity__c
         );
 
         for (SObjectField sourceField : SERVICE_FIELD_BY_PARTICIPANT_FIELD.keySet()) {

--- a/force-app/main/default/classes/AttendanceService_TEST.cls
+++ b/force-app/main/default/classes/AttendanceService_TEST.cls
@@ -109,6 +109,7 @@ public with sharing class AttendanceService_TEST {
         String getSession = 'getSession';
         Id sessionId = TestUtil.mockId(ServiceSession__c.SObjectType);
         Id scheduleId = TestUtil.mockId(ServiceSchedule__c.SObjectType);
+        Id serviceId = TestUtil.mockId(Service__c.SObjectType);
         List<ServiceParticipant__c> participantsToReturn = new List<ServiceParticipant__c>{
             createMockParticipant(),
             createMockParticipant()
@@ -129,7 +130,11 @@ public with sharing class AttendanceService_TEST {
         attendanceSelectorStub.withReturnValue(
             getSession,
             Id.class,
-            new ServiceSession__c(Id = sessionId, ServiceSchedule__c = scheduleId)
+            new ServiceSession__c(
+                Id = sessionId,
+                ServiceSchedule__c = scheduleId,
+                ServiceSchedule__r = new ServiceSchedule__c(Service__c = serviceId)
+            )
         );
 
         Test.startTest();
@@ -149,9 +154,9 @@ public with sharing class AttendanceService_TEST {
                 'Expected the contact id to have been copied from the particpant.'
             );
             System.assertEquals(
-                participantsToReturn[i].Service__c,
+                serviceId,
                 actualDeliveries[i].Service__c,
-                'Expected the service id to have been copied from the particpant.'
+                'Expected the service id to have been copied from the Session via the Schedule.'
             );
             System.assertEquals(
                 participantsToReturn[i].ProgramEngagement__c,
@@ -335,8 +340,7 @@ public with sharing class AttendanceService_TEST {
         return new ServiceParticipant__c(
             Id = TestUtil.mockId(ServiceParticipant__c.SObjectType),
             Contact__c = TestUtil.mockId(Contact.SObjectType),
-            ProgramEngagement__c = TestUtil.mockId(ProgramEngagement__c.SObjectType),
-            Service__c = TestUtil.mockId(Service__c.SObjectType)
+            ProgramEngagement__c = TestUtil.mockId(ProgramEngagement__c.SObjectType)
         );
     }
 }

--- a/force-app/main/default/layouts/ServiceSchedule__c-Service Schedule Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/ServiceSchedule__c-Service Schedule Layout.layout-meta.xml
@@ -30,6 +30,10 @@
                 <behavior>Edit</behavior>
                 <field>ParticipantCapacity__c</field>
             </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>DefaultServiceQuantity__c</field>
+            </layoutItems>
         </layoutColumns>
         <style>OneColumn</style>
     </layoutSections>

--- a/force-app/main/default/layouts/ServiceSession__c-Service Session Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/ServiceSession__c-Service Session Layout.layout-meta.xml
@@ -90,17 +90,13 @@
             <actionType>StandardButton</actionType>
             <sortOrder>3</sortOrder>
         </platformActionListItems>
-        <platformActionListItems>
-            <actionName>Edit</actionName>
-            <actionType>StandardButton</actionType>
-            <sortOrder>0</sortOrder>
-        </platformActionListItems>
     </platformActionList>
     <relatedLists>
         <excludeButtons>MassChangeOwner</excludeButtons>
         <fields>NAME</fields>
         <fields>DeliveryDate__c</fields>
         <fields>Quantity__c</fields>
+        <fields>AttendanceStatus__c</fields>
         <relatedList>ServiceDelivery__c.ServiceSession__c</relatedList>
         <sortField>DeliveryDate__c</sortField>
         <sortOrder>Asc</sortOrder>

--- a/force-app/main/default/lwc/attendance/attendance.js
+++ b/force-app/main/default/lwc/attendance/attendance.js
@@ -92,7 +92,7 @@ export default class Attendance extends LightningElement {
             let service = getChildObjectByName(schedule.value.fields, "Service__r");
             this.unitOfMeasurement = service.value.fields[
                 UNIT_MEASUREMENT_SERVICE_FIELD.fieldApiName
-            ]
+            ].value
                 ? service.value.fields[UNIT_MEASUREMENT_SERVICE_FIELD.fieldApiName].value
                 : this.labels.quantity;
             this.sessionStatus = result.data.fields[

--- a/force-app/main/default/lwc/attendanceRow/attendanceRow.js
+++ b/force-app/main/default/lwc/attendanceRow/attendanceRow.js
@@ -58,7 +58,7 @@ export default class AttendanceRow extends LightningElement {
 
     @api
     getRow() {
-        return this._isEdited ? this.localRecord : null;
+        return this._isEdited || !this.recordId ? this.localRecord : null;
     }
 
     @api

--- a/force-app/main/default/lwc/newServiceSchedule/newServiceSchedule.html
+++ b/force-app/main/default/lwc/newServiceSchedule/newServiceSchedule.html
@@ -44,17 +44,35 @@
                         <lightning-input-field
                             field-name={requiredFields.serviceId.apiName}
                             value={requiredFields.serviceId.value}
+                            onchange={handleServiceChange}
                             required
                         >
                         </lightning-input-field>
                     </lightning-layout-item>
                     <template for:each={fieldSet} for:item="field">
                         <lightning-layout-item key={field.apiName} size={field.size}>
-                            <lightning-input-field
-                                field-name={field.apiName}
-                                value={field.value}
-                                required={field.isRequired}
-                            ></lightning-input-field>
+                            <template if:true={field.isQuantityField}>
+                                <!--QUANTITY FIELD SPECIAL HANDLING FOR LABEL-->
+                                <div class="slds-form-element slds-form-element_stacked">
+                                    <lightning-input
+                                        label={defaultServiceQuantityLabelWithUnit}
+                                        onchange={handleDefaultServiceQuantityChange}
+                                        type="number"
+                                        min="0"
+                                        step=".01"
+                                        value={field.value}
+                                        required={field.isRequired}
+                                        field-level-help={field.helpText}
+                                    ></lightning-input>
+                                </div>
+                            </template>
+                            <template if:false={field.isQuantityField}>
+                                <lightning-input-field
+                                    field-name={field.apiName}
+                                    value={field.value}
+                                    required={field.isRequired}
+                                ></lightning-input-field>
+                            </template>
                         </lightning-layout-item>
                     </template>
                 </lightning-layout>

--- a/force-app/main/default/lwc/newServiceSchedule/newServiceSchedule.js
+++ b/force-app/main/default/lwc/newServiceSchedule/newServiceSchedule.js
@@ -26,6 +26,7 @@ import UNIT_MEASUREMENT_FIELD from "@salesforce/schema/Service__c.UnitOfMeasurem
 
 export default class NewServiceSchedule extends LightningElement {
     @api recordTypeId;
+    @api serviceId;
     errorMessage;
     isValid = true;
     objectApiName;
@@ -36,19 +37,15 @@ export default class NewServiceSchedule extends LightningElement {
     };
 
     _serviceScheduleModel;
-    @track
-    picklistFields;
-    @track
-    requiredFields;
-    @track
-    dateFields;
+    @track picklistFields;
+    @track requiredFields;
+    @track dateFields;
     fieldSet;
     isLoaded = false;
     duration = 1;
     defaultServiceQuantity;
     defaultServiceQuantityLabel;
     defaultServiceQuantityLabelWithUnit;
-    serviceId;
 
     @api
     get serviceScheduleModel() {

--- a/force-app/main/default/lwc/newServiceSchedule/newServiceSchedule.js
+++ b/force-app/main/default/lwc/newServiceSchedule/newServiceSchedule.js
@@ -195,7 +195,12 @@ export default class NewServiceSchedule extends LightningElement {
         fields: [UNIT_MEASUREMENT_FIELD],
     })
     wiredSession(result) {
-        if (result.data) {
+        if (
+            result.data &&
+            result.data.fields &&
+            result.data.fields[UNIT_MEASUREMENT_FIELD.fieldApiName] &&
+            result.data.fields[UNIT_MEASUREMENT_FIELD.fieldApiName].value
+        ) {
             this.defaultServiceQuantityLabelWithUnit =
                 this.defaultServiceQuantityLabel +
                 " (" +
@@ -224,8 +229,6 @@ export default class NewServiceSchedule extends LightningElement {
     }
 
     handleServiceChange(event) {
-        console.log("service changed");
-        console.log(JSON.stringify(event.detail));
         this.serviceId = event.detail.value.length ? event.detail.value[0] : undefined; // lookup values come back as arrays
         if (!this.serviceId) {
             this.defaultServiceQuantityLabelWithUnit = this.defaultServiceQuantityLabel;

--- a/force-app/main/default/lwc/newServiceSchedule/newServiceSchedule.js
+++ b/force-app/main/default/lwc/newServiceSchedule/newServiceSchedule.js
@@ -7,8 +7,9 @@
  *
  */
 
-import { LightningElement, api, track } from "lwc";
+import { LightningElement, api, track, wire } from "lwc";
 import { format } from "c/util";
+import { getRecord } from "lightning/uiRecordApi";
 
 const WEEKLY = "Weekly";
 const ONE_TIME = "One Time";
@@ -20,6 +21,8 @@ const SMALL_SIZE = 6;
 import NO_END_LABEL from "@salesforce/label/c.Select_Service_Schedule_End_Date_Or_Service_Session_Number_Warning";
 import START_BEFORE_END_LABEL from "@salesforce/label/c.End_Date_After_Start_Date";
 import DAY_REQUIRED_LABEL from "@salesforce/label/c.Day_Required_When_Weekly_Selected";
+import DEFAULT_SERVICE_QUANTITY from "@salesforce/schema/ServiceSchedule__c.DefaultServiceQuantity__c";
+import UNIT_MEASUREMENT_FIELD from "@salesforce/schema/Service__c.UnitOfMeasurement__c";
 
 export default class NewServiceSchedule extends LightningElement {
     @api recordTypeId;
@@ -42,6 +45,10 @@ export default class NewServiceSchedule extends LightningElement {
     fieldSet;
     isLoaded = false;
     duration = 1;
+    defaultServiceQuantity;
+    defaultServiceQuantityLabel;
+    defaultServiceQuantityLabelWithUnit;
+    serviceId;
 
     @api
     get serviceScheduleModel() {
@@ -130,6 +137,12 @@ export default class NewServiceSchedule extends LightningElement {
             serviceSchedule[apiName] = value;
         });
 
+        if (this.defaultServiceQuantity) {
+            serviceSchedule[
+                DEFAULT_SERVICE_QUANTITY.fieldApiName
+            ] = this.defaultServiceQuantity;
+        }
+
         return serviceSchedule;
     }
 
@@ -153,6 +166,14 @@ export default class NewServiceSchedule extends LightningElement {
                 field.value = this._serviceScheduleModel.serviceSchedule[field.apiName];
                 return field;
             });
+
+        this.fieldSet.forEach(field => {
+            if (field.apiName === DEFAULT_SERVICE_QUANTITY.fieldApiName) {
+                field.isQuantityField = true;
+                this.defaultServiceQuantityLabel = field.label;
+                this.defaultServiceQuantityLabelWithUnit = field.label;
+            }
+        });
     }
 
     handleLoad() {
@@ -167,6 +188,20 @@ export default class NewServiceSchedule extends LightningElement {
                 }
             }
         });
+    }
+
+    @wire(getRecord, {
+        recordId: "$serviceId",
+        fields: [UNIT_MEASUREMENT_FIELD],
+    })
+    wiredSession(result) {
+        if (result.data) {
+            this.defaultServiceQuantityLabelWithUnit =
+                this.defaultServiceQuantityLabel +
+                " (" +
+                result.data.fields[UNIT_MEASUREMENT_FIELD.fieldApiName].value +
+                ")";
+        }
     }
 
     get isWeekly() {
@@ -186,6 +221,19 @@ export default class NewServiceSchedule extends LightningElement {
 
     get isEndsOn() {
         return this.picklistFields.seriesEnds.value === ON;
+    }
+
+    handleServiceChange(event) {
+        console.log("service changed");
+        console.log(JSON.stringify(event.detail));
+        this.serviceId = event.detail.value.length ? event.detail.value[0] : undefined; // lookup values come back as arrays
+        if (!this.serviceId) {
+            this.defaultServiceQuantityLabelWithUnit = this.defaultServiceQuantityLabel;
+        }
+    }
+
+    handleDefaultServiceQuantityChange(event) {
+        this.defaultServiceQuantity = event.detail.value;
     }
 
     handleFrequencyChange(event) {

--- a/force-app/main/default/lwc/participantSelector/participantSelector.css
+++ b/force-app/main/default/lwc/participantSelector/participantSelector.css
@@ -6,6 +6,7 @@
  *  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  *
  */
+
 .container {
     border-color: var(--lwc-colorBorder, rgb(221, 219, 218));
     border-radius: var(--lwc-borderRadiusMedium, 0.25rem);

--- a/force-app/main/default/objects/ServiceSchedule__c/fieldSets/ServiceScheduleInformation.fieldSet-meta.xml
+++ b/force-app/main/default/objects/ServiceSchedule__c/fieldSets/ServiceScheduleInformation.fieldSet-meta.xml
@@ -17,5 +17,10 @@
         <isFieldManaged>false</isFieldManaged>
         <isRequired>false</isRequired>
     </displayedFields>
+    <displayedFields>
+        <field>DefaultServiceQuantity__c</field>
+        <isFieldManaged>false</isFieldManaged>
+        <isRequired>false</isRequired>
+    </displayedFields>
     <label>Service Schedule Information</label>
 </FieldSet>

--- a/force-app/main/default/objects/ServiceSchedule__c/fields/DefaultServiceQuantity__c.field-meta.xml
+++ b/force-app/main/default/objects/ServiceSchedule__c/fields/DefaultServiceQuantity__c.field-meta.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>DefaultServiceQuantity__c</fullName>
+    <description>The default quantity for attendance Service Deliveries for Service Sessions in this Schedule, expressed in the Unit of Measurement in the Service. For example, 30 minutes of tutoring where the Unit of Measure is hours, Quantity is .50.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>The default Service quantity reflected on a Service Delivery when tracking attendance.</inlineHelpText>
+    <label>Default Service Quantity</label>
+    <precision>16</precision>
+    <required>false</required>
+    <scale>2</scale>
+    <trackTrending>false</trackTrending>
+    <type>Number</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/ServiceSchedule__c/fields/DefaultServiceQuantity__c.field-meta.xml
+++ b/force-app/main/default/objects/ServiceSchedule__c/fields/DefaultServiceQuantity__c.field-meta.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>DefaultServiceQuantity__c</fullName>
-    <description>The default quantity for attendance Service Deliveries for Service Sessions in this Schedule, expressed in the Unit of Measurement in the Service. For example, 30 minutes of tutoring where the Unit of Measure is hours, Quantity is .50.</description>
+    <description>The default Service quantity reflected on a Service Delivery when tracking attendance.</description>
     <externalId>false</externalId>
     <inlineHelpText>The default Service quantity reflected on a Service Delivery when tracking attendance.</inlineHelpText>
     <label>Default Service Quantity</label>

--- a/force-app/main/default/permissionsets/PMDM_Deliver.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/PMDM_Deliver.permissionset-meta.xml
@@ -210,6 +210,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>ServiceSchedule__c.DefaultServiceQuantity__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>ServiceSchedule__c.FirstSessionEnd__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/force-app/main/default/permissionsets/PMDM_Manage.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/PMDM_Manage.permissionset-meta.xml
@@ -210,6 +210,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>ServiceSchedule__c.DefaultServiceQuantity__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>ServiceSchedule__c.FirstSessionEnd__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/force-app/main/default/permissionsets/PMDM_View.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/PMDM_View.permissionset-meta.xml
@@ -181,6 +181,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>ServiceSchedule__c.DefaultServiceQuantity__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>ServiceSchedule__c.FirstSessionEnd__c</field>
         <readable>true</readable>
     </fieldPermissions>


### PR DESCRIPTION
# Critical Changes

# Changes
- In Service Schedule Creator, a Default Service Quantity field will now appear. When filled in, attendance for that schedule will have that value pre-populated for Quantity.

# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
- [ ] ~~Place holder data is incorporated (Refer to [Case Management Sample Data document](https://quip.com/cbFcAPJF8t0z))~~
- [x] Base axe-core JEST test included for any new LWC (No critical violations)
- [x] CRUD/FLS is enforced in Apex
- [x] Permission sets & field sets are updated to account for CRUD/FLS/TABS for new object metadata
- [x] All modified classes are unit tested (Apex) at 100% coverage
- [x] UX approval or UX not necessary
- [x] PR contains draft release notes
- [x] Attach work item to the pull request with [Lurch](https://salesforce.quip.com/50ZRA5LEWVzH) `**Lurch:attach W-000000` or `**Lurch:add`
- [ ] All **acceptance criteria** have been met
    - [x] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [ ] QE story level testing completed


