### PR TITLE
Add 'Every N Days/Weeks/Months' options to Service Schedule Wizard

### DIFF
--- a/force-app/main/default/classes/ServiceScheduleModel.cls
+++ b/force-app/main/default/classes/ServiceScheduleModel.cls
@@ -54,6 +54,9 @@ public with sharing class ServiceScheduleModel {
         ),
         'numberOfSessions' => fieldSetService.getFieldForLWC(
             Schema.ServiceSchedule__c.NumberOfServiceSessions__c.getDescribe()
+        ),
+        'interval' => fieldSetService.getFieldForLWC(
+            Schema.ServiceSchedule__c.Interval__c.getDescribe()
         )
     };
 

--- a/force-app/main/default/labels/CustomLabels.labels-meta.xml
+++ b/force-app/main/default/labels/CustomLabels.labels-meta.xml
@@ -478,8 +478,8 @@
         <fullName>Every_Custom</fullName>
         <language>en_US</language>
         <protected>true</protected>
-        <shortDescription>Every...</shortDescription>
-        <value>Every...</value>
+        <shortDescription>Every</shortDescription>
+        <value>Every</value>
     </labels>
     <labels>
         <fullName>Weeks</fullName>
@@ -489,6 +489,13 @@
         <value>Weeks</value>
     </labels>
     <labels>
+        <fullName>Week</fullName>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>Week</shortDescription>
+        <value>Week</value>
+    </labels>
+    <labels>
         <fullName>Days</fullName>
         <language>en_US</language>
         <protected>true</protected>
@@ -496,11 +503,25 @@
         <value>Days</value>
     </labels>
     <labels>
+        <fullName>Day</fullName>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>Day</shortDescription>
+        <value>Day</value>
+    </labels>
+    <labels>
         <fullName>Months</fullName>
         <language>en_US</language>
         <protected>true</protected>
         <shortDescription>Months</shortDescription>
         <value>Months</value>
+    </labels>
+    <labels>
+        <fullName>Month</fullName>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>Month</shortDescription>
+        <value>Month</value>
     </labels>
     <labels>
         <fullName>Years</fullName>

--- a/force-app/main/default/layouts/ServiceSchedule__c-Service Schedule Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/ServiceSchedule__c-Service Schedule Layout.layout-meta.xml
@@ -67,6 +67,10 @@
                 <behavior>Edit</behavior>
                 <field>NumberOfServiceSessions__c</field>
             </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Interval__c</field>
+            </layoutItems>
         </layoutColumns>
         <style>OneColumn</style>
     </layoutSections>

--- a/force-app/main/default/lwc/newServiceSchedule/newServiceSchedule.html
+++ b/force-app/main/default/lwc/newServiceSchedule/newServiceSchedule.html
@@ -103,7 +103,32 @@
                         ></c-picklist>
                     </lightning-layout-item>
                     <lightning-layout-item size={sizes.small}>
-                        <lightning-layout if:true={isRecurring}>
+                        <lightning-layout if:true={isRecurring} multiple-rows="true">
+                            <!--INTERVAL-->
+                            <lightning-layout-item size="12">
+                                <lightning-layout vertical-align="end">
+                                    <!--flexibility="auto, no-grow"-->
+                                    <lightning-layout-item>
+                                        {labels.every}
+                                    </lightning-layout-item>
+                                    <lightning-layout-item
+                                        size="3"
+                                        class="slds-var-p-horizontal_x-small"
+                                    >
+                                        <lightning-input-field
+                                            field-name={dateFields.interval.apiName}
+                                            value={dateFields.interval.value}
+                                            variant="label-hidden"
+                                            class="hideHelpText"
+                                            onchange={handleIntervalChange}
+                                        ></lightning-input-field>
+                                    </lightning-layout-item>
+                                    <lightning-layout-item flexibility="auto, no-grow">
+                                        {units}
+                                    </lightning-layout-item>
+                                </lightning-layout>
+                            </lightning-layout-item>
+                            <!--END CONDITION-->
                             <lightning-layout-item size={sizes.small}>
                                 <c-picklist
                                     picklist={picklistFields.seriesEnds}

--- a/force-app/main/default/lwc/newServiceSchedule/newServiceSchedule.js
+++ b/force-app/main/default/lwc/newServiceSchedule/newServiceSchedule.js
@@ -9,13 +9,24 @@
 
 import { LightningElement, api, track } from "lwc";
 import { format } from "c/util";
+import { loadStyle } from "lightning/platformResourceLoader";
 import getDayNum from "@salesforce/apex/ServiceScheduleCreatorController.getDayNum";
+import pmmFolder from "@salesforce/resourceUrl/pmm";
 
 import NO_END_LABEL from "@salesforce/label/c.Select_Service_Schedule_End_Date_Or_Service_Session_Number_Warning";
 import START_BEFORE_END_LABEL from "@salesforce/label/c.End_Date_After_Start_Date";
 import DAY_REQUIRED_LABEL from "@salesforce/label/c.Day_Required_When_Weekly_Selected";
+import EVERY_LABEL from "@salesforce/label/c.Every_Custom";
+import DAY_LABEL from "@salesforce/label/c.Day";
+import DAYS_LABEL from "@salesforce/label/c.Days";
+import WEEK_LABEL from "@salesforce/label/c.Week";
+import WEEKS_LABEL from "@salesforce/label/c.Weeks";
+import MONTH_LABEL from "@salesforce/label/c.Month";
+import MONTHS_LABEL from "@salesforce/label/c.Months";
 
 const WEEKLY = "Weekly";
+const MONTHLY = "Monthly";
+const DAILY = "Daily";
 const ONE_TIME = "One Time";
 const ON = "On";
 const AFTER = "After";
@@ -27,7 +38,15 @@ export default class NewServiceSchedule extends LightningElement {
     errorMessage;
     isValid = true;
     objectApiName;
-    labels;
+    @track labels = {
+        day: DAY_LABEL,
+        days: DAYS_LABEL,
+        week: WEEK_LABEL,
+        weeks: WEEKS_LABEL,
+        month: MONTH_LABEL,
+        months: MONTHS_LABEL,
+        every: EVERY_LABEL,
+    };
     sizes = {
         large: LARGE_SIZE,
         small: SMALL_SIZE,
@@ -53,7 +72,10 @@ export default class NewServiceSchedule extends LightningElement {
         // This is a nested object so the inner objects are still read only when using spread alone
         this._serviceScheduleModel = JSON.parse(JSON.stringify(value));
 
-        this.labels = this._serviceScheduleModel.labels.serviceSchedule;
+        this.labels = {
+            ...this.labels,
+            ...this._serviceScheduleModel.labels.serviceSchedule,
+        };
         this.objectApiName = this._serviceScheduleModel.labels.serviceSchedule.objectApiName;
         this.requiredFields = this._serviceScheduleModel.scheduleRequiredFields;
         this.dateFields = this._serviceScheduleModel.scheduleRecurrenceDateFields;
@@ -134,6 +156,10 @@ export default class NewServiceSchedule extends LightningElement {
         return serviceSchedule;
     }
 
+    connectedCallback() {
+        loadStyle(this, pmmFolder + "/hideHelpIcons.css");
+    }
+
     processFields() {
         let fieldsToSkip = [];
         let self = this;
@@ -174,6 +200,18 @@ export default class NewServiceSchedule extends LightningElement {
         return this.picklistFields.frequency.value === WEEKLY;
     }
 
+    get isMonthly() {
+        return this.picklistFields.frequency.value === MONTHLY;
+    }
+
+    get isDaily() {
+        return this.picklistFields.frequency.value === DAILY;
+    }
+
+    get isOneTime() {
+        return this.picklistFields.frequency.value === ONE_TIME;
+    }
+
     get isRecurring() {
         return (
             this.picklistFields.frequency.value &&
@@ -189,12 +227,32 @@ export default class NewServiceSchedule extends LightningElement {
         return this.picklistFields.seriesEnds.value === ON;
     }
 
+    get units() {
+        let interval = this.dateFields.interval.value;
+        if (this.isDaily) {
+            return interval > 1 ? this.labels.days : this.labels.day;
+        } else if (this.isWeekly) {
+            return interval > 1 ? this.labels.weeks : this.labels.week;
+        } else if (this.isMonthly) {
+            return interval > 1 ? this.labels.months : this.labels.month;
+        }
+
+        return "";
+    }
+
+    handleIntervalChange(event) {
+        this.dateFields.interval.value = event.detail.value ? event.detail.value : 1;
+    }
+
     handleFrequencyChange(event) {
         this.picklistFields.frequency.value = event.detail.length
             ? event.detail[0].value
             : undefined;
 
         this.defaultDayOfWeek();
+        if (this.isOneTime) {
+            this.dateFields.interval.value = 1;
+        }
     }
 
     async defaultDayOfWeek() {

--- a/force-app/main/default/objects/ServiceSchedule__c/fields/Interval__c.field-meta.xml
+++ b/force-app/main/default/objects/ServiceSchedule__c/fields/Interval__c.field-meta.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Interval__c</fullName>
+    <defaultValue>1</defaultValue>
     <externalId>false</externalId>
     <inlineHelpText>The interval between sessions. For a weekly schedule, an interval of 2 means once every 2 weeks.</inlineHelpText>
     <label>Interval</label>


### PR DESCRIPTION
# Critical Changes

# Changes
- Add 'Every N Days/Weeks/Months' options to Service Schedule Wizard
![image](https://user-images.githubusercontent.com/12188165/100397583-58540780-2fff-11eb-94ff-db924710bf89.png)


# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
- ~~Place holder data is incorporated (Refer to [Case Management Sample Data document](https://quip.com/cbFcAPJF8t0z))~~
- ~~Base axe-core JEST test included for any new LWC (No critical violations)~~
- [x] CRUD/FLS is enforced in Apex
- ~~Permission sets & field sets are updated to account for CRUD/FLS/TABS for new object metadata~~
- [x] All modified classes are unit tested (Apex) at 100% coverage
- [ ] UX approval or UX not necessary
- [x] PR contains draft release notes
- [x] Attach work item to the pull request with [Lurch](https://salesforce.quip.com/50ZRA5LEWVzH) `**Lurch:attach W-000000` or `**Lurch:add`
- [ ] All **acceptance criteria** have been met
    - [x] Developer
    - [ ] Code Reviewer
    - [x] QA
- [x] QE story level testing completed


