### PR TITLE
'Add More Participants' quick action

### DIFF
--- a/force-app/main/default/aura/addMoreParticipants/addMoreParticipants.cmp
+++ b/force-app/main/default/aura/addMoreParticipants/addMoreParticipants.cmp
@@ -1,3 +1,12 @@
+<!--
+  - /*
+  -  * Copyright (c) 2020, salesforce.com, inc.
+  -  * All rights reserved.
+  -  * SPDX-License-Identifier: BSD-3-Clause
+  -  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+  -  */
+  -->
+
 <aura:component implements="force:lightningQuickActionWithoutHeader, force:hasRecordId">
     <c:participantAdder onclose="{!c.handleClose}" recordId="{!v.recordId}" />
     <aura:html tag="style">

--- a/force-app/main/default/aura/addMoreParticipants/addMoreParticipants.cmp
+++ b/force-app/main/default/aura/addMoreParticipants/addMoreParticipants.cmp
@@ -1,0 +1,9 @@
+<aura:component implements="force:lightningQuickActionWithoutHeader, force:hasRecordId">
+    <c:participantAdder onclose="{!c.handleClose}" recordId="{!v.recordId}" />
+    <aura:html tag="style">
+        .cuf-content { padding: 0 0rem !important; } .slds-p-around--medium { padding:
+        0rem !important; } .slds-modal__content{ overflow-y:hidden !important;
+        height:unset !important; max-height:unset !important; } .slds-modal__container{
+        width: 80% !important; max-width: 80% !important; }
+    </aura:html>
+</aura:component>

--- a/force-app/main/default/aura/addMoreParticipants/addMoreParticipants.cmp-meta.xml
+++ b/force-app/main/default/aura/addMoreParticipants/addMoreParticipants.cmp-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>50.0</apiVersion>
+    <description>A Lightning Component Bundle</description>
+</AuraDefinitionBundle>

--- a/force-app/main/default/aura/addMoreParticipants/addMoreParticipantsController.js
+++ b/force-app/main/default/aura/addMoreParticipants/addMoreParticipantsController.js
@@ -1,0 +1,6 @@
+({
+    handleClose: function(component, event, helper) {
+        $A.get("e.force:closeQuickAction").fire();
+        $A.get("e.force:refreshView").fire();
+    }
+});

--- a/force-app/main/default/aura/addMoreParticipants/addMoreParticipantsController.js
+++ b/force-app/main/default/aura/addMoreParticipants/addMoreParticipantsController.js
@@ -1,3 +1,12 @@
+/*
+ *
+ *  * Copyright (c) 2020, salesforce.com, inc.
+ *  * All rights reserved.
+ *  * SPDX-License-Identifier: BSD-3-Clause
+ *  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ *
+ */
+
 ({
     handleClose: function(component, event, helper) {
         $A.get("e.force:closeQuickAction").fire();

--- a/force-app/main/default/aura/deleteFutureSessions/deleteFutureSessions.cmp
+++ b/force-app/main/default/aura/deleteFutureSessions/deleteFutureSessions.cmp
@@ -1,3 +1,12 @@
+<!--
+  - /*
+  -  * Copyright (c) 2020, salesforce.com, inc.
+  -  * All rights reserved.
+  -  * SPDX-License-Identifier: BSD-3-Clause
+  -  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+  -  */
+  -->
+
 <aura:component implements="force:lightningQuickActionWithoutHeader, force:hasRecordId">
     <c:futureSessionDeleter onclose="{!c.handleClose}" recordId="{!v.recordId}" />
     <aura:html tag="style">

--- a/force-app/main/default/aura/deleteFutureSessions/deleteFutureSessionsController.js
+++ b/force-app/main/default/aura/deleteFutureSessions/deleteFutureSessionsController.js
@@ -1,3 +1,12 @@
+/*
+ *
+ *  * Copyright (c) 2020, salesforce.com, inc.
+ *  * All rights reserved.
+ *  * SPDX-License-Identifier: BSD-3-Clause
+ *  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ *
+ */
+
 ({
     handleClose: function(component, event, helper) {
         $A.get("e.force:closeQuickAction").fire();

--- a/force-app/main/default/classes/ProgramTestDataFactory.cls
+++ b/force-app/main/default/classes/ProgramTestDataFactory.cls
@@ -108,6 +108,19 @@ public with sharing class ProgramTestDataFactory {
             serviceDeliveries.add(serviceDelivery1);
 
             insert serviceDeliveries;
+
+            ServiceSchedule__c schedule = new ServiceSchedule__c(
+                Service__c = service1.Id,
+                Name = 'Test Service Schedule'
+            );
+            insert schedule;
+
+            ServiceParticipant__c serviceParticipant = new ServiceParticipant__c(
+                Name = 'Test',
+                Contact__c = con1.Id,
+                ServiceSchedule__c = schedule.Id
+            );
+            insert serviceParticipant;
         }
     }
 }

--- a/force-app/main/default/classes/ServiceScheduleCreatorController.cls
+++ b/force-app/main/default/classes/ServiceScheduleCreatorController.cls
@@ -29,10 +29,31 @@ public with sharing class ServiceScheduleCreatorController {
         }
     }
 
+    @AuraEnabled
+    public static void saveNewParticipants(
+        List<ProgramEngagement__c> engagements,
+        Id scheduleId
+    ) {
+        try {
+            service.saveNewParticipants(engagements, scheduleId);
+        } catch (Exception ex) {
+            throw Util.getAuraHandledException(ex);
+        }
+    }
+
     @AuraEnabled(cacheable=true)
     public static SelectParticipantModel getSelectParticipantModel(Id serviceId) {
         try {
             return service.getSelectParticipantModel(serviceId);
+        } catch (Exception ex) {
+            throw Util.getAuraHandledException(ex);
+        }
+    }
+
+    @AuraEnabled(cacheable=true)
+    public static List<Id> getExistingParticipantContactIds(Id scheduleId) {
+        try {
+            return service.getExistingParticipantContactIds(scheduleId);
         } catch (Exception ex) {
             throw Util.getAuraHandledException(ex);
         }

--- a/force-app/main/default/classes/ServiceScheduleCreatorController.cls
+++ b/force-app/main/default/classes/ServiceScheduleCreatorController.cls
@@ -30,12 +30,12 @@ public with sharing class ServiceScheduleCreatorController {
     }
 
     @AuraEnabled
-    public static void saveNewParticipants(
+    public static void addParticipants(
         List<ProgramEngagement__c> engagements,
         Id scheduleId
     ) {
         try {
-            service.saveNewParticipants(engagements, scheduleId);
+            service.addParticipants(engagements, scheduleId);
         } catch (Exception ex) {
             throw Util.getAuraHandledException(ex);
         }

--- a/force-app/main/default/classes/ServiceScheduleCreatorController_TEST.cls
+++ b/force-app/main/default/classes/ServiceScheduleCreatorController_TEST.cls
@@ -53,6 +53,48 @@ public with sharing class ServiceScheduleCreatorController_TEST {
     }
 
     @IsTest
+    private static void shouldPassInfoToServiceOnSaveNewParticipants() {
+        String methodName = 'saveNewParticipants';
+        List<ProgramEngagement__c> engagements = new List<ProgramEngagement__c>();
+        Id scheduleId = TestUtil.mockId(ServiceSchedule__c.SObjectType);
+
+        ServiceScheduleCreatorController.service = (ServiceScheduleService) serviceStub.createMock();
+
+        Test.startTest();
+        ServiceScheduleCreatorController.saveNewParticipants(engagements, scheduleId);
+        Test.stopTest();
+
+        serviceStub.assertCalledWith(
+            methodName,
+            new List<Type>{ List<ProgramEngagement__c>.class, Id.class },
+            new List<Object>{ engagements, scheduleId }
+        );
+    }
+
+    @IsTest
+    private static void shouldGetExistingParticipantContactIds() {
+        String methodName = 'getExistingParticipantContactIds';
+        Id scheduleId = TestUtil.mockId(ServiceSchedule__c.SObjectType);
+        List<Id> expected = new List<Id>();
+
+        serviceStub.withReturnValue(methodName, Id.class, expected);
+        ServiceScheduleCreatorController.service = (ServiceScheduleService) serviceStub.createMock();
+
+        Test.startTest();
+        List<Id> actual = ServiceScheduleCreatorController.getExistingParticipantContactIds(
+            scheduleId
+        );
+        Test.stopTest();
+
+        System.assertEquals(
+            expected,
+            actual,
+            'Contact Ids not returned from the Service as expected.'
+        );
+        serviceStub.assertCalledWith(methodName, Id.class, scheduleId);
+    }
+
+    @IsTest
     private static void shouldGetNewSessionFromService() {
         DateTime startDateTime = System.now();
         DateTime endDateTime = startDateTime.addHours(1);
@@ -202,6 +244,77 @@ public with sharing class ServiceScheduleCreatorController_TEST {
             actualException.getMessage(),
             'Expected the stub test exception message to have been thrown.'
         );
+    }
+
+    @IsTest
+    private static void rethrowsErrorFromSaveNewParticipantsOnService() {
+        String methodName = 'saveNewParticipants';
+        List<ProgramEngagement__c> engagements = new List<ProgramEngagement__c>();
+        Id scheduleId = TestUtil.mockId(ServiceSchedule__c.SObjectType);
+        Exception actualException;
+
+        serviceStub.withThrowException(
+            methodName,
+            new List<Type>{ List<ProgramEngagement__c>.class, Id.class }
+        );
+
+        ServiceScheduleCreatorController.service = (ServiceScheduleService) serviceStub.createMock();
+
+        Test.startTest();
+        try {
+            ServiceScheduleCreatorController.saveNewParticipants(engagements, scheduleId);
+        } catch (Exception ex) {
+            actualException = ex;
+        }
+        Test.stopTest();
+
+        System.assert(
+            actualException instanceof AuraHandledException,
+            actualException.getTypeName() + ': Expected an aura handled exception.'
+        );
+        System.assertEquals(
+            serviceStub.testExceptionMessage,
+            actualException.getMessage(),
+            'Expected the stub test exception message to have been thrown.'
+        );
+        serviceStub.assertCalledWith(
+            methodName,
+            new List<Type>{ List<ProgramEngagement__c>.class, Id.class },
+            new List<Object>{ engagements, scheduleId }
+        );
+    }
+
+    @IsTest
+    private static void rethrowsErrorFromGetExistingParticipantContactIdsOnService() {
+        String methodName = 'getExistingParticipantContactIds';
+        Id scheduleId = TestUtil.mockId(ServiceSchedule__c.SObjectType);
+
+        List<Id> actual;
+        Exception actualException;
+        serviceStub.withThrowException(methodName, Id.class);
+
+        ServiceScheduleCreatorController.service = (ServiceScheduleService) serviceStub.createMock();
+        Test.startTest();
+        try {
+            actual = ServiceScheduleCreatorController.getExistingParticipantContactIds(
+                scheduleId
+            );
+        } catch (Exception ex) {
+            actualException = ex;
+        }
+        Test.stopTest();
+
+        System.assert(
+            actualException instanceof AuraHandledException,
+            actualException.getTypeName() + ': Expected an aura handled exception.'
+        );
+        System.assertEquals(
+            serviceStub.testExceptionMessage,
+            actualException.getMessage(),
+            'Expected the stub test exception message to have been thrown.'
+        );
+        serviceStub.assertCalledWith(methodName, Id.class, scheduleId);
+        System.assertEquals(null, actual);
     }
 
     @IsTest

--- a/force-app/main/default/classes/ServiceScheduleCreatorController_TEST.cls
+++ b/force-app/main/default/classes/ServiceScheduleCreatorController_TEST.cls
@@ -53,15 +53,15 @@ public with sharing class ServiceScheduleCreatorController_TEST {
     }
 
     @IsTest
-    private static void shouldPassInfoToServiceOnSaveNewParticipants() {
-        String methodName = 'saveNewParticipants';
+    private static void shouldPassInfoToServiceOnAddParticipants() {
+        String methodName = 'addParticipants';
         List<ProgramEngagement__c> engagements = new List<ProgramEngagement__c>();
         Id scheduleId = TestUtil.mockId(ServiceSchedule__c.SObjectType);
 
         ServiceScheduleCreatorController.service = (ServiceScheduleService) serviceStub.createMock();
 
         Test.startTest();
-        ServiceScheduleCreatorController.saveNewParticipants(engagements, scheduleId);
+        ServiceScheduleCreatorController.addParticipants(engagements, scheduleId);
         Test.stopTest();
 
         serviceStub.assertCalledWith(
@@ -247,8 +247,8 @@ public with sharing class ServiceScheduleCreatorController_TEST {
     }
 
     @IsTest
-    private static void rethrowsErrorFromSaveNewParticipantsOnService() {
-        String methodName = 'saveNewParticipants';
+    private static void rethrowsErrorFromAddParticipantsOnService() {
+        String methodName = 'addParticipants';
         List<ProgramEngagement__c> engagements = new List<ProgramEngagement__c>();
         Id scheduleId = TestUtil.mockId(ServiceSchedule__c.SObjectType);
         Exception actualException;
@@ -262,7 +262,7 @@ public with sharing class ServiceScheduleCreatorController_TEST {
 
         Test.startTest();
         try {
-            ServiceScheduleCreatorController.saveNewParticipants(engagements, scheduleId);
+            ServiceScheduleCreatorController.addParticipants(engagements, scheduleId);
         } catch (Exception ex) {
             actualException = ex;
         }

--- a/force-app/main/default/classes/ServiceScheduleDomain.cls
+++ b/force-app/main/default/classes/ServiceScheduleDomain.cls
@@ -54,7 +54,7 @@ public with sharing class ServiceScheduleDomain {
     ) {
         List<ServiceParticipant__c> participants = new List<ServiceParticipant__c>();
         for (ProgramEngagement__c engagement : engagements) {
-            participants.add(getServiceParticipant(engagement, schedule));
+            participants.add(createServiceParticipant(engagement, schedule));
         }
         insertRelatedRecords((List<SObject>) participants);
     }
@@ -62,12 +62,12 @@ public with sharing class ServiceScheduleDomain {
     private void generateParticipants(ServiceScheduleModel model) {
         for (ProgramEngagement__c engagement : model.selectedParticipants) {
             model.serviceParticipants.add(
-                getServiceParticipant(engagement, model.serviceSchedule)
+                createServiceParticipant(engagement, model.serviceSchedule)
             );
         }
     }
 
-    private ServiceParticipant__c getServiceParticipant(
+    private ServiceParticipant__c createServiceParticipant(
         ProgramEngagement__c engagement,
         ServiceSchedule__c schedule
     ) {

--- a/force-app/main/default/classes/ServiceScheduleDomain.cls
+++ b/force-app/main/default/classes/ServiceScheduleDomain.cls
@@ -48,21 +48,36 @@ public with sharing class ServiceScheduleDomain {
         }
     }
 
+    public void insertParticipants(
+        List<ProgramEngagement__c> engagements,
+        ServiceSchedule__c schedule
+    ) {
+        List<ServiceParticipant__c> participants = new List<ServiceParticipant__c>();
+        for (ProgramEngagement__c engagement : engagements) {
+            participants.add(getServiceParticipant(engagement, schedule));
+        }
+        insertRelatedRecords((List<SObject>) participants);
+    }
+
     private void generateParticipants(ServiceScheduleModel model) {
         for (ProgramEngagement__c engagement : model.selectedParticipants) {
-            ServiceParticipant__c participant = new ServiceParticipant__c(
-                Name = (engagement.Contact__r.Name +
-                    ' - ' +
-                    model.serviceSchedule.Name)
-                    .abbreviate(80),
-                ServiceSchedule__c = model.serviceSchedule.Id,
-                Service__c = model.serviceSchedule.Service__c,
-                ProgramEngagement__c = engagement.Id,
-                Contact__c = engagement.Contact__c
+            model.serviceParticipants.add(
+                getServiceParticipant(engagement, model.serviceSchedule)
             );
-
-            model.serviceParticipants.add(participant);
         }
+    }
+
+    private ServiceParticipant__c getServiceParticipant(
+        ProgramEngagement__c engagement,
+        ServiceSchedule__c schedule
+    ) {
+        return new ServiceParticipant__c(
+            Name = (engagement.Contact__r.Name + ' - ' + schedule.Name).abbreviate(80),
+            ServiceSchedule__c = schedule.Id,
+            Service__c = schedule.Service__c,
+            ProgramEngagement__c = engagement.Id,
+            Contact__c = engagement.Contact__c
+        );
     }
 
     private void validateCreateAccess(List<SObject> sObjects) {

--- a/force-app/main/default/classes/ServiceScheduleDomain_TEST.cls
+++ b/force-app/main/default/classes/ServiceScheduleDomain_TEST.cls
@@ -163,6 +163,46 @@ private with sharing class ServiceScheduleDomain_TEST {
     }
 
     @IsTest
+    private static void shouldInsertParticipants() {
+        ServiceSchedule__c schedule = [
+            SELECT Id, Service__c, Name
+            FROM ServiceSchedule__c
+            LIMIT 1
+        ];
+        List<ProgramEngagement__c> engagements = [
+            SELECT Id, Contact__c, Contact__r.Name
+            FROM ProgramEngagement__c
+            ORDER BY Contact__c
+        ];
+        domain.insertParticipants(engagements, schedule);
+        List<ServiceParticipant__c> actual = [
+            SELECT
+                Id,
+                Name,
+                ProgramEngagement__c,
+                ServiceSchedule__c,
+                Service__c,
+                Contact__c
+            FROM ServiceParticipant__c
+            WHERE ProgramEngagement__c IN :engagements
+            ORDER BY Contact__c
+        ];
+        System.assertEquals(engagements.size(), actual.size());
+        for (Integer i = 0; i < engagements.size(); i++) {
+            ProgramEngagement__c engagement = engagements[i];
+            ServiceParticipant__c participant = actual[i];
+            System.assertEquals(
+                (engagement.Contact__r.Name + ' - ' + schedule.Name).abbreviate(80),
+                participant.Name
+            );
+            System.assertEquals(schedule.Id, participant.ServiceSchedule__c);
+            System.assertEquals(schedule.Service__c, participant.Service__c);
+            System.assertEquals(engagement.Id, participant.ProgramEngagement__c);
+            System.assertEquals(engagement.Contact__c, participant.Contact__c);
+        }
+    }
+
+    @IsTest
     private static void throwsExceptionWhenNameTooLong() {
         ServiceScheduleModel model = new ServiceScheduleModel();
         ServiceSchedule__c schedule = new ServiceSchedule__c();

--- a/force-app/main/default/classes/ServiceScheduleService.cls
+++ b/force-app/main/default/classes/ServiceScheduleService.cls
@@ -39,6 +39,22 @@ public with sharing class ServiceScheduleService {
         }
     }
 
+    public List<Id> getExistingParticipantContactIds(Id scheduleId) {
+        return serviceSelector.getExistingParticipantContactIdsByScheduleId(scheduleId);
+    }
+
+    public void saveNewParticipants(
+        List<ProgramEngagement__c> engagements,
+        Id scheduleId
+    ) {
+        ServiceSchedule__c schedule = [
+            SELECT Id, Name, Service__c
+            FROM ServiceSchedule__c
+            WHERE Id = :scheduleId
+        ];
+        domain.insertParticipants(engagements, schedule);
+    }
+
     public SelectParticipantModel getSelectParticipantModel(Id serviceId) {
         SelectParticipantModel model = new SelectParticipantModel();
         populateRecords(serviceId, model);

--- a/force-app/main/default/classes/ServiceScheduleService.cls
+++ b/force-app/main/default/classes/ServiceScheduleService.cls
@@ -44,11 +44,7 @@ public with sharing class ServiceScheduleService {
     }
 
     public void addParticipants(List<ProgramEngagement__c> engagements, Id scheduleId) {
-        ServiceSchedule__c schedule = [
-            SELECT Id, Name, Service__c
-            FROM ServiceSchedule__c
-            WHERE Id = :scheduleId
-        ];
+        ServiceSchedule__c schedule = serviceSelector.getScheduleById(scheduleId);
         domain.insertParticipants(engagements, schedule);
     }
 

--- a/force-app/main/default/classes/ServiceScheduleService.cls
+++ b/force-app/main/default/classes/ServiceScheduleService.cls
@@ -43,10 +43,7 @@ public with sharing class ServiceScheduleService {
         return serviceSelector.getExistingParticipantContactIdsByScheduleId(scheduleId);
     }
 
-    public void saveNewParticipants(
-        List<ProgramEngagement__c> engagements,
-        Id scheduleId
-    ) {
+    public void addParticipants(List<ProgramEngagement__c> engagements, Id scheduleId) {
         ServiceSchedule__c schedule = [
             SELECT Id, Name, Service__c
             FROM ServiceSchedule__c

--- a/force-app/main/default/classes/ServiceScheduleService_TEST.cls
+++ b/force-app/main/default/classes/ServiceScheduleService_TEST.cls
@@ -363,7 +363,8 @@ public with sharing class ServiceScheduleService_TEST {
             Id = TestUtil.mockId(Contact.SObjectType)
         );
         DateTime firstSessionStart = System.now();
-        DateTime firstSessionEnd = System.now().addHours(2);
+        Integer hours = 2;
+        DateTime firstSessionEnd = System.now().addHours(hours);
         ServiceSchedule__c schedule = new ServiceSchedule__c(
             Name = 'test',
             FirstSessionStart__c = firstSessionStart,
@@ -417,10 +418,7 @@ public with sharing class ServiceScheduleService_TEST {
                 new ServiceSession__c(
                     Name = sessionDateTime.date().format() + ': ' + schedule.Name,
                     SessionStart__c = sessionDateTime,
-                    SessionEnd__c = DateTime.newInstance(
-                        sessionDateTime.date(),
-                        firstSessionEnd.time()
-                    )
+                    SessionEnd__c = sessionDateTime.addHours(hours)
                 )
             );
         }
@@ -486,7 +484,8 @@ public with sharing class ServiceScheduleService_TEST {
         String getServiceProviderMethod = 'getContactsByIds';
         String rRuleString = 'abc';
         DateTime firstSessionStart = System.now();
-        DateTime firstSessionEnd = System.now().addHours(2);
+        Integer hours = 2;
+        DateTime firstSessionEnd = System.now().addHours(hours);
         ServiceSchedule__c schedule = new ServiceSchedule__c(
             Name = 'test',
             FirstSessionStart__c = firstSessionStart,
@@ -534,10 +533,7 @@ public with sharing class ServiceScheduleService_TEST {
                 new ServiceSession__c(
                     Name = sessionDateTime.date().format() + ': ' + schedule.Name,
                     SessionStart__c = sessionDateTime,
-                    SessionEnd__c = DateTime.newInstance(
-                        sessionDateTime.date(),
-                        firstSessionEnd.time()
-                    )
+                    SessionEnd__c = sessionDateTime.addHours(hours)
                 )
             );
         }

--- a/force-app/main/default/classes/ServiceScheduleService_TEST.cls
+++ b/force-app/main/default/classes/ServiceScheduleService_TEST.cls
@@ -735,6 +735,47 @@ public with sharing class ServiceScheduleService_TEST {
     }
 
     @IsTest
+    private static void shouldCallSelectorAndDomainOnAddParticipants() {
+        String selectorMethod = 'getScheduleById';
+        String domainMethod = 'insertParticipants';
+        Id scheduleId = TestUtil.mockId(ServiceSchedule__c.SObjectType);
+        List<ProgramEngagement__c> engagements = new List<ProgramEngagement__c>();
+        ServiceSchedule__c expectedSchedule = new ServiceSchedule__c();
+        serviceSelectorStub.withReturnValue(selectorMethod, Id.class, expectedSchedule);
+
+        service.serviceSelector = (ServiceSelector) serviceSelectorStub.createMock();
+        service.domain = (ServiceScheduleDomain) domainStub.createMock();
+
+        Test.startTest();
+        service.addParticipants(engagements, scheduleId);
+        Test.stopTest();
+
+        serviceSelectorStub.assertCalledWith(selectorMethod, Id.class, scheduleId);
+        domainStub.assertCalledWith(
+            domainMethod,
+            new List<Type>{ List<ProgramEngagement__c>.class, ServiceSchedule__c.class },
+            new List<Object>{ engagements, expectedSchedule }
+        );
+    }
+
+    @IsTest
+    private static void shouldCallSelectorOnGetExistingParticipants() {
+        String selectorMethod = 'getExistingParticipantContactIdsByScheduleId';
+        Id scheduleId = TestUtil.mockId(ServiceSchedule__c.SObjectType);
+        List<Id> expected = new List<Id>();
+        serviceSelectorStub.withReturnValue(selectorMethod, Id.class, expected);
+
+        service.serviceSelector = (ServiceSelector) serviceSelectorStub.createMock();
+
+        Test.startTest();
+        List<Id> actual = service.getExistingParticipantContactIds(scheduleId);
+        Test.stopTest();
+
+        serviceSelectorStub.assertCalledWith(selectorMethod, Id.class, scheduleId);
+        System.assertEquals(expected, actual);
+    }
+
+    @IsTest
     private static void testGetSelectParticipantModel() {
         final String programEngagementsMethodName = 'getProgramEngagementsByProgramId';
         final String cohortsMethodName = 'getProgramCohortsByProgramId';

--- a/force-app/main/default/classes/ServiceSelector.cls
+++ b/force-app/main/default/classes/ServiceSelector.cls
@@ -62,4 +62,28 @@ public with sharing class ServiceSelector {
                 AND DAY_ONLY(convertTimezone(SessionStart__c)) > :startDate
         ];
     }
+
+    public List<Id> getExistingParticipantContactIdsByScheduleId(Id scheduleId) {
+        if (
+            !Schema.SObjectType.Contact.isAccessible() ||
+            !Schema.SObjectType.ServiceParticipant__c.isAccessible()
+        ) {
+            return new List<Id>();
+        }
+        return new List<Id>(
+            new Map<Id, Contact>(
+                    [
+                        SELECT Id
+                        FROM Contact
+                        WHERE
+                            Id IN (
+                                SELECT Contact__c
+                                FROM ServiceParticipant__c
+                                WHERE ServiceSchedule__c = :scheduleId
+                            )
+                    ]
+                )
+                .keySet()
+        );
+    }
 }

--- a/force-app/main/default/classes/ServiceSelector.cls
+++ b/force-app/main/default/classes/ServiceSelector.cls
@@ -63,6 +63,17 @@ public with sharing class ServiceSelector {
         ];
     }
 
+    public ServiceSchedule__c getScheduleById(Id scheduleId) {
+        if (!Schema.SObjectType.ServiceSchedule__c.isAccessible()) {
+            return new ServiceSchedule__c();
+        }
+        return [
+            SELECT Id, Name, Service__c
+            FROM ServiceSchedule__c
+            WHERE Id = :scheduleId
+        ];
+    }
+
     public List<Id> getExistingParticipantContactIdsByScheduleId(Id scheduleId) {
         if (
             !Schema.SObjectType.Contact.isAccessible() ||

--- a/force-app/main/default/classes/ServiceSelector_TEST.cls
+++ b/force-app/main/default/classes/ServiceSelector_TEST.cls
@@ -10,6 +10,115 @@
 @isTest
 public with sharing class ServiceSelector_TEST {
     @IsTest
+    private static void testGetScheduleById() {
+        ProgramTestDataFactory.insertTestData(true);
+
+        ServiceSchedule__c expected = [
+            SELECT Id, Name, Service__c
+            FROM ServiceSchedule__c
+        ];
+        Test.startTest();
+        ServiceSelector selector = new ServiceSelector();
+        ServiceSchedule__c actual = selector.getScheduleById(expected.Id);
+        Test.stopTest();
+
+        System.assertEquals(expected, actual);
+    }
+
+    @IsTest
+    private static void testGetScheduleByIdNoAccess() {
+        Profile p = [SELECT Id FROM Profile WHERE Name = 'Standard User'];
+        Integer random = Integer.valueOf(math.rint(math.random() * 1000000));
+        User u = new User(
+            Alias = 'stand',
+            Email = 'standarduser1@' + random + '.example.com',
+            EmailEncodingKey = 'UTF-8',
+            LastName = 'StandardUser',
+            LanguageLocaleKey = 'en_US',
+            LocaleSidKey = 'en_US',
+            ProfileId = p.Id,
+            TimeZoneSidKey = 'America/Los_Angeles',
+            UserName = 'standarduser1@' + random + '.example.com'
+        );
+
+        ProgramTestDataFactory.insertTestData(true);
+
+        Program__c program1 = [
+            SELECT Id, Name
+            FROM Program__c
+            WHERE Name = 'Program 1'
+            LIMIT 1
+        ][0];
+        ServiceSchedule__c expected = [
+            SELECT Id, Name, Service__c
+            FROM ServiceSchedule__c
+        ];
+
+        Test.startTest();
+        System.runAs(u) {
+            ServiceSelector selector = new ServiceSelector();
+            ServiceSchedule__c actual = selector.getScheduleById(expected.Id);
+            System.assertEquals(new ServiceSchedule__c(), actual);
+        }
+        Test.stopTest();
+    }
+
+    @IsTest
+    private static void testGetExistingParticipantContactIdsByScheduleId() {
+        ProgramTestDataFactory.insertTestData(true);
+
+        ServiceSchedule__c schedule = [SELECT Id FROM ServiceSchedule__c];
+
+        List<Contact> contacts = [SELECT Id FROM Contact ORDER BY Id];
+
+        List<Id> expected = new List<Id>{ contacts[0].Id };
+
+        Test.startTest();
+        ServiceSelector selector = new ServiceSelector();
+        List<Id> actual = selector.getExistingParticipantContactIdsByScheduleId(
+            schedule.Id
+        );
+        Test.stopTest();
+
+        System.assertEquals(expected, actual);
+    }
+
+    @IsTest
+    private static void testGetExistingParticipantContactIdsByScheduleIdNoAccess() {
+        Profile p = [SELECT Id FROM Profile WHERE Name = 'Standard User'];
+        Integer random = Integer.valueOf(math.rint(math.random() * 1000000));
+        User u = new User(
+            Alias = 'stand',
+            Email = 'standarduser1@' + random + '.example.com',
+            EmailEncodingKey = 'UTF-8',
+            LastName = 'StandardUser',
+            LanguageLocaleKey = 'en_US',
+            LocaleSidKey = 'en_US',
+            ProfileId = p.Id,
+            TimeZoneSidKey = 'America/Los_Angeles',
+            UserName = 'standarduser1@' + random + '.example.com'
+        );
+
+        ProgramTestDataFactory.insertTestData(true);
+
+        ServiceSchedule__c schedule = [SELECT Id FROM ServiceSchedule__c];
+
+        List<Contact> contacts = [SELECT Id FROM Contact ORDER BY Id];
+
+        List<Id> expected = new List<Id>();
+
+        Test.startTest();
+        System.runAs(u) {
+            ServiceSelector selector = new ServiceSelector();
+            List<Id> actual = selector.getExistingParticipantContactIdsByScheduleId(
+                schedule.Id
+            );
+            System.assertEquals(expected, actual);
+        }
+        Test.stopTest();
+    }
+
+    @IsTest
     private static void testGetServicesByProgramIds() {
         ProgramTestDataFactory.insertTestData(true);
 

--- a/force-app/main/default/flexipages/Service_Schedule_Record_Page.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/Service_Schedule_Record_Page.flexipage-meta.xml
@@ -17,7 +17,7 @@
                 </componentInstanceProperties>
                 <componentInstanceProperties>
                     <name>numVisibleActions</name>
-                    <value>2</value>
+                    <value>3</value>
                 </componentInstanceProperties>
                 <componentName>force:highlightsPanel</componentName>
             </componentInstance>

--- a/force-app/main/default/labels/CustomLabels.labels-meta.xml
+++ b/force-app/main/default/labels/CustomLabels.labels-meta.xml
@@ -18,8 +18,8 @@
         <fullName>Add_Service_Participants_Success</fullName>
         <language>en_US</language>
         <protected>true</protected>
-        <shortDescription>Successfully added {0} Service Participants.</shortDescription>
-        <value>Successfully added {0} Service Participants.</value>
+        <shortDescription>Added {0} Service Participants.</shortDescription>
+        <value>Added {0} Service Participants.</value>
     </labels>
     <labels>
         <fullName>Add_Service_Delivery</fullName>

--- a/force-app/main/default/labels/CustomLabels.labels-meta.xml
+++ b/force-app/main/default/labels/CustomLabels.labels-meta.xml
@@ -15,6 +15,13 @@
         <value>Add {0}</value>
     </labels>
     <labels>
+        <fullName>Add_Service_Participants_Success</fullName>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>Successfully added {0} Service Participants.</shortDescription>
+        <value>Successfully added {0} Service Participants.</value>
+    </labels>
+    <labels>
         <fullName>Add_Service_Delivery</fullName>
         <categories>Service Delivery</categories>
         <language>en_US</language>

--- a/force-app/main/default/layouts/ServiceSchedule__c-Service Schedule Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/ServiceSchedule__c-Service Schedule Layout.layout-meta.xml
@@ -106,29 +106,34 @@
     <platformActionList>
         <actionListContext>Record</actionListContext>
         <platformActionListItems>
-            <actionName>ServiceSchedule__c.Delete_Future_Sessions</actionName>
+            <actionName>Edit</actionName>
+            <actionType>StandardButton</actionType>
+            <sortOrder>0</sortOrder>
+        </platformActionListItems>
+        <platformActionListItems>
+            <actionName>ServiceSchedule__c.Add_More_Participants</actionName>
             <actionType>QuickAction</actionType>
             <sortOrder>1</sortOrder>
         </platformActionListItems>
         <platformActionListItems>
-            <actionName>Clone</actionName>
-            <actionType>StandardButton</actionType>
+            <actionName>ServiceSchedule__c.Delete_Future_Sessions</actionName>
+            <actionType>QuickAction</actionType>
             <sortOrder>2</sortOrder>
         </platformActionListItems>
         <platformActionListItems>
-            <actionName>PrintableView</actionName>
+            <actionName>Clone</actionName>
             <actionType>StandardButton</actionType>
             <sortOrder>3</sortOrder>
         </platformActionListItems>
         <platformActionListItems>
-            <actionName>Delete</actionName>
+            <actionName>PrintableView</actionName>
             <actionType>StandardButton</actionType>
             <sortOrder>4</sortOrder>
         </platformActionListItems>
         <platformActionListItems>
-            <actionName>Edit</actionName>
+            <actionName>Delete</actionName>
             <actionType>StandardButton</actionType>
-            <sortOrder>0</sortOrder>
+            <sortOrder>5</sortOrder>
         </platformActionListItems>
     </platformActionList>
     <relatedLists>

--- a/force-app/main/default/lwc/futureSessionDeleter/futureSessionDeleter.html
+++ b/force-app/main/default/lwc/futureSessionDeleter/futureSessionDeleter.html
@@ -1,3 +1,12 @@
+<!--
+  - /*
+  -  * Copyright (c) 2020, salesforce.com, inc.
+  -  * All rights reserved.
+  -  * SPDX-License-Identifier: BSD-3-Clause
+  -  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+  -  */
+  -->
+
 <template>
     <header class="slds-modal__header">
         <h2 id="modal-heading-01" class="slds-modal__title slds-hyphenate">

--- a/force-app/main/default/lwc/participantAdder/participantAdder.html
+++ b/force-app/main/default/lwc/participantAdder/participantAdder.html
@@ -10,7 +10,7 @@
             <c-participant-selector
                 service-id={serviceId}
                 schedule-id={recordId}
-                previously-selected-participant-contact-ids={selectedParticipantContactIds}
+                existing-contact-ids={existingParticipants.data}
                 service-schedule-model={serviceScheduleModel}
             ></c-participant-selector>
             <template if:true={errorMessage}>

--- a/force-app/main/default/lwc/participantAdder/participantAdder.html
+++ b/force-app/main/default/lwc/participantAdder/participantAdder.html
@@ -1,3 +1,12 @@
+<!--
+  - /*
+  -  * Copyright (c) 2020, salesforce.com, inc.
+  -  * All rights reserved.
+  -  * SPDX-License-Identifier: BSD-3-Clause
+  -  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+  -  */
+  -->
+
 <template>
     <header class="slds-modal__header">
         <h2 id="modal-heading-01" class="slds-modal__title slds-hyphenate">

--- a/force-app/main/default/lwc/participantAdder/participantAdder.html
+++ b/force-app/main/default/lwc/participantAdder/participantAdder.html
@@ -1,0 +1,42 @@
+<template>
+    <header class="slds-modal__header">
+        <h2 id="modal-heading-01" class="slds-modal__title slds-hyphenate">
+            {labels.addServiceParticipants}
+        </h2>
+    </header>
+
+    <template if:true={isLoaded}>
+        <div class="slds-modal__content slds-p-around_medium" id="modal-content-id-1">
+            <c-participant-selector
+                service-id={serviceId}
+                schedule-id={recordId}
+                previously-selected-participant-contact-ids={selectedParticipantContactIds}
+                service-schedule-model={serviceScheduleModel}
+            ></c-participant-selector>
+            <template if:true={errorMessage}>
+                <c-scoped-notification
+                    theme="error"
+                    title={errorMessage}
+                    class="slds-var-p-around_small"
+                ></c-scoped-notification
+            ></template>
+        </div>
+    </template>
+
+    <footer class="slds-modal__footer">
+        <lightning-button
+            onclick={handleCancel}
+            label={labels.cancel}
+            title={labels.cancel}
+        ></lightning-button>
+        <lightning-button
+            label={labels.save}
+            title={labels.save}
+            variant="brand"
+            onclick={handleSave}
+            class="slds-m-left_x-small"
+            disabled={isSaveDisabled}
+        >
+        </lightning-button>
+    </footer>
+</template>

--- a/force-app/main/default/lwc/participantAdder/participantAdder.js
+++ b/force-app/main/default/lwc/participantAdder/participantAdder.js
@@ -1,0 +1,142 @@
+/*
+ *
+ *  * Copyright (c) 2020, salesforce.com, inc.
+ *  * All rights reserved.
+ *  * SPDX-License-Identifier: BSD-3-Clause
+ *  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ *
+ */
+
+import { LightningElement, api, wire } from "lwc";
+import { format } from "c/util";
+import { getRecord } from "lightning/uiRecordApi";
+import { refreshApex } from "@salesforce/apex";
+import { ShowToastEvent } from "lightning/platformShowToastEvent";
+import getExistingParticipantContactIds from "@salesforce/apex/ServiceScheduleCreatorController.getExistingParticipantContactIds";
+import getServiceScheduleModel from "@salesforce/apex/ServiceScheduleCreatorController.getServiceScheduleModel";
+import saveNewParticipants from "@salesforce/apex/ServiceScheduleCreatorController.saveNewParticipants";
+
+import SUCCESS_LABEL from "@salesforce/label/c.Success";
+import SAVE_LABEL from "@salesforce/label/c.Save";
+import BACK_WARNING_LABEL from "@salesforce/label/c.Clicking_Back_Button_In_Modal_Warning";
+import CANCEL_LABEL from "@salesforce/label/c.Cancel";
+import LOADING_LABEL from "@salesforce/label/c.Loading";
+import SERVICE_FIELD from "@salesforce/schema/ServiceSchedule__c.Service__c";
+import SAVE_SUCCESS from "@salesforce/label/c.Add_Service_Participants_Success";
+
+export default class ParticipantAdder extends LightningElement {
+    @api recordId;
+    errorMessage;
+    isLoaded = false;
+    serviceScheduleModel;
+    selectedParticipantContactIds;
+    existingParticipants;
+    labels = {
+        save: SAVE_LABEL,
+        success: SUCCESS_LABEL,
+        backWarning: BACK_WARNING_LABEL,
+        cancel: CANCEL_LABEL,
+        loading: LOADING_LABEL,
+        successMessage: SAVE_SUCCESS,
+    };
+
+    @wire(getRecord, {
+        recordId: "$recordId",
+        fields: [SERVICE_FIELD],
+    })
+    wiredSchedule(result) {
+        if (!(result.data || result.error)) {
+            return;
+        }
+        if (result.data) {
+            this.serviceId = result.data.fields[SERVICE_FIELD.fieldApiName].value;
+        }
+    }
+
+    @wire(getServiceScheduleModel, { recordTypeId: null })
+    wireServiceScheduleModel(result) {
+        if (!result) {
+            return;
+        }
+
+        if (result.data) {
+            this.serviceScheduleModel = JSON.parse(JSON.stringify(result.data));
+            this.extractLabels(this.serviceScheduleModel.labels.serviceParticipant);
+            this.isLoaded = true;
+        } else if (result.error) {
+            console.log(JSON.stringify(result.error));
+        }
+    }
+
+    extractLabels(labels) {
+        if (!labels) {
+            return;
+        }
+
+        Object.keys(labels).forEach(label => {
+            let value = labels[label];
+            this.labels[label] = value;
+        });
+    }
+
+    @wire(getExistingParticipantContactIds, { scheduleId: "$recordId" })
+    wiredExistingParticipants(result) {
+        if (!result) {
+            return;
+        }
+        this.existingParticipants = result; //cache for refreshing
+
+        if (result.data) {
+            this.selectedParticipantContactIds = result.data;
+        }
+    }
+
+    handleSave() {
+        let participantSelector = this.template.querySelector("c-participant-selector");
+
+        if (
+            !(
+                participantSelector &&
+                participantSelector.newParticipantsProgramEngagements
+            )
+        ) {
+            return;
+        }
+
+        saveNewParticipants({
+            engagements: participantSelector.newParticipantsProgramEngagements,
+            scheduleId: this.recordId,
+        })
+            .then(() => {
+                this.showSuccessToast(
+                    participantSelector.newParticipantsProgramEngagements.length
+                );
+                refreshApex(this.existingParticipants);
+                this.closeModal();
+            })
+            .catch(error => {
+                this.error = error;
+            });
+    }
+
+    handleCancel() {
+        this.closeModal();
+    }
+
+    closeModal() {
+        this.dispatchEvent(new CustomEvent("close"));
+    }
+
+    showSuccessToast(numSaved) {
+        const event = new ShowToastEvent({
+            title: this.labels.success,
+            variant: "success",
+            message: format(this.labels.successMessage, [numSaved]),
+        });
+        this.dispatchEvent(event);
+    }
+
+    get isDisabled() {
+        return !this.isLoaded;
+    }
+}

--- a/force-app/main/default/lwc/participantAdder/participantAdder.js
+++ b/force-app/main/default/lwc/participantAdder/participantAdder.js
@@ -14,7 +14,7 @@ import { refreshApex } from "@salesforce/apex";
 import { ShowToastEvent } from "lightning/platformShowToastEvent";
 import getExistingParticipantContactIds from "@salesforce/apex/ServiceScheduleCreatorController.getExistingParticipantContactIds";
 import getServiceScheduleModel from "@salesforce/apex/ServiceScheduleCreatorController.getServiceScheduleModel";
-import saveNewParticipants from "@salesforce/apex/ServiceScheduleCreatorController.saveNewParticipants";
+import addParticipants from "@salesforce/apex/ServiceScheduleCreatorController.addParticipants";
 
 import SUCCESS_LABEL from "@salesforce/label/c.Success";
 import SAVE_LABEL from "@salesforce/label/c.Save";
@@ -29,7 +29,6 @@ export default class ParticipantAdder extends LightningElement {
     errorMessage;
     isLoaded = false;
     serviceScheduleModel;
-    selectedParticipantContactIds;
     existingParticipants;
     labels = {
         save: SAVE_LABEL,
@@ -85,10 +84,6 @@ export default class ParticipantAdder extends LightningElement {
             return;
         }
         this.existingParticipants = result; //cache for refreshing
-
-        if (result.data) {
-            this.selectedParticipantContactIds = result.data;
-        }
     }
 
     handleSave() {
@@ -103,7 +98,7 @@ export default class ParticipantAdder extends LightningElement {
             return;
         }
 
-        saveNewParticipants({
+        addParticipants({
             engagements: participantSelector.newParticipantsProgramEngagements,
             scheduleId: this.recordId,
         })

--- a/force-app/main/default/lwc/participantAdder/participantAdder.js-meta.xml
+++ b/force-app/main/default/lwc/participantAdder/participantAdder.js-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>50.0</apiVersion>
+    <isExposed>false</isExposed>
+</LightningComponentBundle>

--- a/force-app/main/default/lwc/participantSelector/participantSelector.css
+++ b/force-app/main/default/lwc/participantSelector/participantSelector.css
@@ -7,14 +7,6 @@
  *
  */
 
-/*
- *
- *  * Copyright (c) 2020, salesforce.com, inc.
- *  * All rights reserved.
- *  * SPDX-License-Identifier: BSD-3-Clause
- *  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
- *
- */
 .container {
     border-color: var(--lwc-colorBorder, rgb(221, 219, 218));
     border-radius: var(--lwc-borderRadiusMedium, 0.25rem);

--- a/force-app/main/default/lwc/participantSelector/participantSelector.css
+++ b/force-app/main/default/lwc/participantSelector/participantSelector.css
@@ -6,6 +6,15 @@
  *  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  *
  */
+
+/*
+ *
+ *  * Copyright (c) 2020, salesforce.com, inc.
+ *  * All rights reserved.
+ *  * SPDX-License-Identifier: BSD-3-Clause
+ *  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ *
+ */
 .container {
     border-color: var(--lwc-colorBorder, rgb(221, 219, 218));
     border-radius: var(--lwc-borderRadiusMedium, 0.25rem);

--- a/force-app/main/default/lwc/participantSelector/participantSelector.js
+++ b/force-app/main/default/lwc/participantSelector/participantSelector.js
@@ -19,7 +19,7 @@ export default class ParticipantSelector extends LightningElement {
     @api serviceId;
     @api serviceScheduleModel;
     @api selectedParticipants = [];
-    @api previouslySelectedParticipantContactIds = [];
+    @api existingContactIds = [];
     @api columns;
 
     selectedRowCount = 0;
@@ -41,7 +41,7 @@ export default class ParticipantSelector extends LightningElement {
         let result = [];
         this.selectedParticipants.forEach(row => {
             let contactId = row[PE_CONTACT_FIELD.fieldApiName];
-            if (!this.previouslySelectedParticipantContactIds.includes(contactId)) {
+            if (!this.existingContactIds.includes(contactId)) {
                 result.push(row);
             }
         });
@@ -159,11 +159,7 @@ export default class ParticipantSelector extends LightningElement {
         }
         this.selectedRows = [...this.serviceScheduleModel.selectedParticipants];
         this.availableEngagements.forEach(eng => {
-            if (
-                this.previouslySelectedParticipantContactIds.includes(
-                    eng[PE_CONTACT_FIELD.fieldApiName]
-                )
-            ) {
+            if (this.existingContactIds.includes(eng[PE_CONTACT_FIELD.fieldApiName])) {
                 eng.disableDeselect = true;
                 this.selectedRows.push(eng);
             }

--- a/force-app/main/default/permissionsets/PMDM_Deliver.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/PMDM_Deliver.permissionset-meta.xml
@@ -56,6 +56,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>ProgramEngagement__c.Contact__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>ProgramEngagement__c.AutoName_Override__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/force-app/main/default/permissionsets/PMDM_Manage.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/PMDM_Manage.permissionset-meta.xml
@@ -56,6 +56,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>ProgramEngagement__c.Contact__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>ProgramEngagement__c.AutoName_Override__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/force-app/main/default/permissionsets/PMDM_View.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/PMDM_View.permissionset-meta.xml
@@ -36,6 +36,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>ProgramEngagement__c.Contact__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>ProgramEngagement__c.EndDate__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/force-app/main/default/quickActions/ServiceSchedule__c.Add_More_Participants.quickAction-meta.xml
+++ b/force-app/main/default/quickActions/ServiceSchedule__c.Add_More_Participants.quickAction-meta.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<QuickAction xmlns="http://soap.sforce.com/2006/04/metadata">
+    <height>250</height>
+    <label>Add More Participants</label>
+    <lightningComponent>addMoreParticipants</lightningComponent>
+    <optionsCreateFeedItem>false</optionsCreateFeedItem>
+    <type>LightningComponent</type>
+    <width>-100</width>
+</QuickAction>


### PR DESCRIPTION
# Critical Changes

# Changes
- Add a quick action to Service Schedule to fire the Add Participants component.

# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
- [x] Place holder data is incorporated (Refer to [Case Management Sample Data document](https://quip.com/cbFcAPJF8t0z))
- [ ] Base axe-core JEST test included for any new LWC (No critical violations)
- [x] CRUD/FLS is enforced in Apex
- [x] Permission sets & field sets are updated to account for CRUD/FLS/TABS for new object metadata
- [x] All modified classes are unit tested (Apex) at 100% coverage
- [x] UX approval or UX not necessary
- [x] PR contains draft release notes
- [x] Attach work item to the pull request with [Lurch](https://salesforce.quip.com/50ZRA5LEWVzH) `**Lurch:attach W-000000` or `**Lurch:add`
- [ ] All **acceptance criteria** have been met
    - [x] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [ ] QE story level testing completed


