### PR TITLE
[Robot] Create service session checkbox on wizard

### DIFF
--- a/robot/pmm/tests/browser/ServiceSchedule/service_schedule_screen4.robot
+++ b/robot/pmm/tests/browser/ServiceSchedule/service_schedule_screen4.robot
@@ -1,0 +1,43 @@
+*** Settings ***
+
+Resource       robot/pmm/resources/pmm.robot
+Library        cumulusci.robotframework.PageObjects
+...            robot/pmm/resources/ServiceSchedulePageObject.py
+...            robot/pmm/resources/ServicePageObject.py
+Suite Setup     Run Keywords
+...             Open Test Browser
+...             Setup Test Data
+Suite Teardown  Capture Screenshot and Delete Records and Close Browser
+
+*** Keywords ***
+Setup Test Data
+    ${ns} =                         Get PMM Namespace Prefix
+    Set suite variable              ${ns}
+    ${program} =                    API Create Program
+    Set suite variable              ${program}
+    ${service} =                    API Create Service                  ${Program}[Id]
+    Set suite variable              ${service}
+    ${service_schedule_name} =      Generate New String
+    Set suite variable              ${service_schedule_name}
+
+*** Test Cases ***
+Verify screen4 when no sessions and participants are added
+    [Documentation]                        On service schedule wizard, uncheck create service sessions checkbox and do not add service participants
+    ...                                    and validate the message displayed on Screen 4
+    [tags]                                 W-8515142       feature:Service Schedule
+    Go To PMM App
+    Go To Page                              Details                        Service__c           object_id=${service}[Id]
+    Click Wrapper Related List Button       Service Schedules              New
+    Current Page Should Be                  New                            ServiceSchedule__c
+    Verify Wizard Screen Title              Service Schedule Information
+    Populate Field                          Service Schedule Name               ${service_schedule_name}
+    Set Checkbox                            Create Service Sessions             unchecked
+    Click Dialog Button                     Next
+    Verify Wizard Screen Title              Review Service Sessions
+    Page Should Contain                     Create Service Sessions isn't selected, so no records will be automatically created. Click Add Service Session to manually add Service Session records.
+    Click Dialog Button                     Next
+    Verify Wizard Screen Title              Add Service Participants
+    Click Dialog Button                     Next
+    Verify Wizard Screen Title              Review Service Schedule
+    Page Should Contain                     No participants are selected, so no Service Participants will be created.
+    Page Should Contain                     No sessions were added, so no Service Sessions will be created.


### PR DESCRIPTION
1. Added test to validate message on screen 4 when no service session and service participants are added.

W-8515142

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
- [ ] Place holder data is incorporated (Refer to [Case Management Sample Data document](https://quip.com/cbFcAPJF8t0z))
- [ ] Base axe-core JEST test included for any new LWC (No critical violations)
- [ ] CRUD/FLS is enforced in Apex
- [ ] Permission sets & field sets are updated to account for CRUD/FLS/TABS for new object metadata
- [ ] All modified classes are unit tested (Apex) at 100% coverage
- [ ] UX approval or UX not necessary
- [ ] PR contains draft release notes
- [ ] Attach work item to the pull request with [Lurch](https://salesforce.quip.com/50ZRA5LEWVzH) `**Lurch:attach W-000000` or `**Lurch:add`
- [ ] All **acceptance criteria** have been met
    - [ ] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [ ] QE story level testing completed


