### PR TITLE
Check CRUD and FLS before displaying Add More Participants quick action modal

### DIFF
--- a/force-app/main/default/classes/PermissionValidator.cls
+++ b/force-app/main/default/classes/PermissionValidator.cls
@@ -53,13 +53,17 @@ public with sharing class PermissionValidator {
                     return true;
                 } else if (
                     operation == 'insert' &&
-                    !fieldsMap.get(fieldName).getDescribe().isCreateable()
+                    !hasFieldCreateAccess(fieldsMap.get(fieldName).getDescribe())
                 ) {
                     return false;
                 } else if (
                     operation == 'upsert' &&
-                    (!fieldsMap.get(fieldName).getDescribe().isCreateable() ||
-                    !fieldsMap.get(fieldName).getDescribe().isUpdateable())
+                    !hasFieldUpsertAccess(fieldsMap.get(fieldName).getDescribe())
+                ) {
+                    return false;
+                } else if (
+                    operation == 'update' &&
+                    !hasFieldUpdateAccess(fieldsMap.get(fieldName).getDescribe())
                 ) {
                     return false;
                 } else if (
@@ -73,6 +77,44 @@ public with sharing class PermissionValidator {
         } catch (Exception e) {
             return false;
         }
+    }
+
+    public Boolean hasFLSAccessForFields(Schema.SObjectField field, String operation) {
+        return hasFLSAccessForFields(new List<Schema.SObjectField>{ field }, operation);
+    }
+
+    public Boolean hasFLSAccessForFields(
+        List<Schema.SObjectField> fields,
+        String operation
+    ) {
+        for (Schema.SObjectField field : fields) {
+            if (operation == 'insert' && !hasFieldCreateAccess(field.getDescribe())) {
+                return false;
+            } else if (
+                operation == 'upsert' && !hasFieldUpsertAccess(field.getDescribe())
+            ) {
+                return false;
+            } else if (
+                operation == 'update' && !hasFieldUpdateAccess(field.getDescribe())
+            ) {
+                return false;
+            } else if (operation == 'read' && !hasFieldReadAccess(field.getDescribe())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public Boolean hasFieldCreateAccess(DescribeFieldResult field) {
+        return field.isCreateable();
+    }
+
+    public Boolean hasFieldUpsertAccess(DescribeFieldResult field) {
+        return field.isCreateable() && field.isUpdateable();
+    }
+
+    public Boolean hasFieldUpdateAccess(DescribeFieldResult field) {
+        return field.isUpdateable();
     }
 
     public Boolean hasFieldReadAccess(DescribeFieldResult field) {

--- a/force-app/main/default/classes/PermissionValidator_TEST.cls
+++ b/force-app/main/default/classes/PermissionValidator_TEST.cls
@@ -72,7 +72,7 @@ private class PermissionValidator_TEST {
     }
 
     @IsTest
-    private static void testHasFLSAccessUpsertNonReparentable() {
+    private static void testHasFLSAccessUpsertNonUpdateable() {
         Boolean nonUpdateableField = PermissionValidator.getInstance()
             .hasFLSAccessForFields(
                 Schema.SObjectType.Program__c.getName(),
@@ -85,9 +85,29 @@ private class PermissionValidator_TEST {
     }
 
     @IsTest
+    private static void testHasFLSAccessUpdateNonUpdateable() {
+        Boolean nonUpdateableField = PermissionValidator.getInstance()
+            .hasFLSAccessForFields(
+                Schema.SObjectType.Program__c.getName(),
+                new List<String>{
+                    Schema.SObjectType.Program__c.fields.LastModifiedById.getName()
+                },
+                'update'
+            );
+        System.assert(!nonUpdateableField, 'Non updateable system field, expect false');
+    }
+
+    @IsTest
     private static void testHasFLSAccessUpsertGoodField() {
         Boolean editableField = PermissionValidator.getInstance()
             .hasFLSAccessForFields('Contact', new List<String>{ 'FirstName' }, 'upsert');
+        System.assert(editableField, 'Editable field, expect true');
+    }
+
+    @IsTest
+    private static void testHasFLSAccessUpdateGoodField() {
+        Boolean editableField = PermissionValidator.getInstance()
+            .hasFLSAccessForFields('Contact', new List<String>{ 'FirstName' }, 'update');
         System.assert(editableField, 'Editable field, expect true');
     }
 
@@ -102,7 +122,7 @@ private class PermissionValidator_TEST {
     private static void testHasFLSAccessNoFLSField() {
         Boolean noFLSField;
         System.runAs(TestUtil.getTestUser()) {
-            // test user has no custom object permissions
+            // test user's "Standard User" profile has no access to Contact.DoNotCall
             noFLSField = PermissionValidator.getInstance()
                 .hasFLSAccessForFields(
                     'Contact',
@@ -110,7 +130,61 @@ private class PermissionValidator_TEST {
                     'read'
                 );
         }
-        System.assert(!noFLSField, 'Custom field name, expect false');
+        System.assert(!noFLSField, 'Inaccessible field name, expect false');
+    }
+
+    @IsTest
+    private static void testHasFLSAccessInsertNonCreatableFieldByField() {
+        Boolean nonCreatableField = PermissionValidator.getInstance()
+            .hasFLSAccessForFields(Contact.LastModifiedById, 'insert');
+        System.debug(JSON.serialize(Contact.LastModifiedById.getDescribe()));
+        System.assert(!nonCreatableField, 'Can not insert system field, expect false');
+    }
+
+    @IsTest
+    private static void testHasFLSAccessUpsertNonUpdateableByField() {
+        Boolean nonUpdateableField = PermissionValidator.getInstance()
+            .hasFLSAccessForFields(Program__c.LastModifiedById, 'upsert');
+        System.assert(!nonUpdateableField, 'Non updateable system field, expect false');
+    }
+
+    @IsTest
+    private static void testHasFLSAccessUpdateNonUpdateableByField() {
+        Boolean nonUpdateableField = PermissionValidator.getInstance()
+            .hasFLSAccessForFields(Program__c.LastModifiedById, 'update');
+        System.assert(!nonUpdateableField, 'Non updateable system field, expect false');
+    }
+
+    @IsTest
+    private static void testHasFLSAccessUpsertGoodFieldByField() {
+        Boolean editableField = PermissionValidator.getInstance()
+            .hasFLSAccessForFields(Contact.FirstName, 'upsert');
+        System.assert(editableField, 'Editable field, expect true');
+    }
+
+    @IsTest
+    private static void testHasFLSAccessUpdateGoodFieldByField() {
+        Boolean editableField = PermissionValidator.getInstance()
+            .hasFLSAccessForFields(Contact.FirstName, 'update');
+        System.assert(editableField, 'Editable field, expect true');
+    }
+
+    @IsTest
+    private static void testHasFLSAccessReadGoodFieldByField() {
+        Boolean readableField = PermissionValidator.getInstance()
+            .hasFLSAccessForFields(Contact.FirstName, 'read');
+        System.assert(readableField, 'Readable field, expect true');
+    }
+
+    @IsTest
+    private static void testHasFLSAccessNoFLSFieldByField() {
+        Boolean noFLSField;
+        System.runAs(TestUtil.getTestUser()) {
+            // test user's "Standard User" profile has no access to Contact.DoNotCall
+            noFLSField = PermissionValidator.getInstance()
+                .hasFLSAccessForFields(Contact.DoNotCall, 'read');
+        }
+        System.assert(!noFLSField, 'Inaccessible field name, expect false');
     }
 
     @IsTest

--- a/force-app/main/default/classes/ServiceScheduleCreatorController.cls
+++ b/force-app/main/default/classes/ServiceScheduleCreatorController.cls
@@ -60,9 +60,9 @@ public with sharing class ServiceScheduleCreatorController {
     }
 
     @AuraEnabled(cacheable=true)
-    public static Boolean checkAddParticipantsFieldPermissions() {
+    public static Boolean checkAddParticipantsPermissions() {
         try {
-            return service.checkAddParticipantsFieldPermissions();
+            return service.checkAddParticipantsPermissions();
         } catch (Exception ex) {
             throw Util.getAuraHandledException(ex);
         }

--- a/force-app/main/default/classes/ServiceScheduleCreatorController.cls
+++ b/force-app/main/default/classes/ServiceScheduleCreatorController.cls
@@ -59,6 +59,15 @@ public with sharing class ServiceScheduleCreatorController {
         }
     }
 
+    @AuraEnabled(cacheable=true)
+    public static Boolean checkAddParticipantsFieldPermissions() {
+        try {
+            return service.checkAddParticipantsFieldPermissions();
+        } catch (Exception ex) {
+            throw Util.getAuraHandledException(ex);
+        }
+    }
+
     @AuraEnabled
     public static ServiceScheduleModel processSchedule(ServiceScheduleModel model) {
         try {

--- a/force-app/main/default/classes/ServiceScheduleCreatorController_TEST.cls
+++ b/force-app/main/default/classes/ServiceScheduleCreatorController_TEST.cls
@@ -95,6 +95,51 @@ public with sharing class ServiceScheduleCreatorController_TEST {
     }
 
     @IsTest
+    private static void shouldCallServiceToCheckFLS() {
+        String methodName = 'checkAddParticipantsFieldPermissions';
+        Boolean expected = true;
+        serviceStub.withReturnValue(methodName, expected);
+        ServiceScheduleCreatorController.service = (ServiceScheduleService) serviceStub.createMock();
+
+        Test.startTest();
+        Boolean actual = ServiceScheduleCreatorController.checkAddParticipantsFieldPermissions();
+        Test.stopTest();
+
+        serviceStub.assertCalled(methodName);
+        System.assertEquals(
+            expected,
+            actual,
+            'Expected the controller to return the same value returned by the service.'
+        );
+    }
+
+    @IsTest
+    private static void shouldRethrowExceptionFromServiceOnFLSCheck() {
+        String methodName = 'checkAddParticipantsFieldPermissions';
+
+        serviceStub.withThrowException(methodName);
+        ServiceScheduleCreatorController.service = (ServiceScheduleService) serviceStub.createMock();
+        Exception actualException;
+        Boolean actual;
+        Test.startTest();
+        try {
+            actual = ServiceScheduleCreatorController.checkAddParticipantsFieldPermissions();
+        } catch (Exception ex) {
+            actualException = ex;
+        }
+        Test.stopTest();
+
+        System.assertEquals(
+            serviceStub.testExceptionMessage,
+            actualException.getMessage(),
+            'Expected the controller to rethrow the exception from the service.'
+        );
+        System.assertEquals(null, actual);
+
+        serviceStub.assertCalled(methodName);
+    }
+
+    @IsTest
     private static void shouldGetNewSessionFromService() {
         DateTime startDateTime = System.now();
         DateTime endDateTime = startDateTime.addHours(1);

--- a/force-app/main/default/classes/ServiceScheduleCreatorController_TEST.cls
+++ b/force-app/main/default/classes/ServiceScheduleCreatorController_TEST.cls
@@ -96,13 +96,13 @@ public with sharing class ServiceScheduleCreatorController_TEST {
 
     @IsTest
     private static void shouldCallServiceToCheckFLS() {
-        String methodName = 'checkAddParticipantsFieldPermissions';
+        String methodName = 'checkAddParticipantsPermissions';
         Boolean expected = true;
         serviceStub.withReturnValue(methodName, expected);
         ServiceScheduleCreatorController.service = (ServiceScheduleService) serviceStub.createMock();
 
         Test.startTest();
-        Boolean actual = ServiceScheduleCreatorController.checkAddParticipantsFieldPermissions();
+        Boolean actual = ServiceScheduleCreatorController.checkAddParticipantsPermissions();
         Test.stopTest();
 
         serviceStub.assertCalled(methodName);
@@ -115,7 +115,7 @@ public with sharing class ServiceScheduleCreatorController_TEST {
 
     @IsTest
     private static void shouldRethrowExceptionFromServiceOnFLSCheck() {
-        String methodName = 'checkAddParticipantsFieldPermissions';
+        String methodName = 'checkAddParticipantsPermissions';
 
         serviceStub.withThrowException(methodName);
         ServiceScheduleCreatorController.service = (ServiceScheduleService) serviceStub.createMock();
@@ -123,7 +123,7 @@ public with sharing class ServiceScheduleCreatorController_TEST {
         Boolean actual;
         Test.startTest();
         try {
-            actual = ServiceScheduleCreatorController.checkAddParticipantsFieldPermissions();
+            actual = ServiceScheduleCreatorController.checkAddParticipantsPermissions();
         } catch (Exception ex) {
             actualException = ex;
         }

--- a/force-app/main/default/classes/ServiceScheduleService.cls
+++ b/force-app/main/default/classes/ServiceScheduleService.cls
@@ -43,7 +43,7 @@ public with sharing class ServiceScheduleService {
         return serviceSelector.getExistingParticipantContactIdsByScheduleId(scheduleId);
     }
 
-    public Boolean checkAddParticipantsFieldPermissions() {
+    public Boolean checkAddParticipantsPermissions() {
         Boolean canReadServiceSchedule = PermissionValidator.getInstance()
             .hasObjectAccess(
                 ServiceSchedule__c.SObjectType,

--- a/force-app/main/default/classes/ServiceScheduleService.cls
+++ b/force-app/main/default/classes/ServiceScheduleService.cls
@@ -43,6 +43,45 @@ public with sharing class ServiceScheduleService {
         return serviceSelector.getExistingParticipantContactIdsByScheduleId(scheduleId);
     }
 
+    public Boolean checkAddParticipantsFieldPermissions() {
+        Boolean canReadServiceSchedule = PermissionValidator.getInstance()
+            .hasObjectAccess(
+                ServiceSchedule__c.SObjectType,
+                PermissionValidator.CRUDAccessType.READABLE
+            );
+        Boolean canReadProgramEngagement = PermissionValidator.getInstance()
+            .hasObjectAccess(
+                ProgramEngagement__c.SObjectType,
+                PermissionValidator.CRUDAccessType.READABLE
+            );
+        Boolean canCreateServiceParticipant = PermissionValidator.getInstance()
+            .hasObjectAccess(
+                ServiceParticipant__c.SObjectType,
+                PermissionValidator.CRUDAccessType.CREATEABLE
+            );
+        List<Schema.SObjectField> fieldsRequireReadAccess = new List<Schema.SObjectField>{
+            ServiceSchedule__c.Service__c,
+            ServiceSchedule__c.Name,
+            ProgramEngagement__c.Contact__c,
+            Contact.Name
+        };
+        List<Schema.SObjectField> fieldsRequireInsertAccess = new List<Schema.SObjectField>{
+            ServiceParticipant__c.Name,
+            ServiceParticipant__c.ServiceSchedule__c,
+            ServiceParticipant__c.Service__c,
+            ServiceParticipant__c.ProgramEngagement__c,
+            ServiceParticipant__c.Contact__c
+        };
+
+        return PermissionValidator.getInstance()
+                .hasFLSAccessForFields(fieldsRequireReadAccess, 'read') &&
+            PermissionValidator.getInstance()
+                .hasFLSAccessForFields(fieldsRequireInsertAccess, 'insert') &&
+            canReadServiceSchedule &&
+            canReadProgramEngagement &&
+            canCreateServiceParticipant;
+    }
+
     public void addParticipants(List<ProgramEngagement__c> engagements, Id scheduleId) {
         ServiceSchedule__c schedule = serviceSelector.getScheduleById(scheduleId);
         domain.insertParticipants(engagements, schedule);

--- a/force-app/main/default/classes/ServiceScheduleService_TEST.cls
+++ b/force-app/main/default/classes/ServiceScheduleService_TEST.cls
@@ -19,6 +19,7 @@ public with sharing class ServiceScheduleService_TEST {
         ProgramEngagementSelector.class
     );
     private static BasicStub serviceSelectorStub = new BasicStub(ServiceSelector.class);
+    private static BasicStub permValidatorStub = new BasicStub(PermissionValidator.class);
 
     @TestSetup
     private static void setupTestData() {
@@ -773,6 +774,44 @@ public with sharing class ServiceScheduleService_TEST {
 
         serviceSelectorStub.assertCalledWith(selectorMethod, Id.class, scheduleId);
         System.assertEquals(expected, actual);
+    }
+
+    @IsTest
+    private static void shouldCallPermissionValidator() {
+        String fieldAccessMethodName = 'hasFLSAccessForFields';
+        String objectAccessMethodName = 'hasObjectAccess';
+
+        permValidatorStub.withReturnValue(
+            objectAccessMethodName,
+            new List<Type>{ SObjectType.class, PermissionValidator.CRUDAccessType.class },
+            true
+        );
+        permValidatorStub.withReturnValue(
+            fieldAccessMethodName,
+            new List<Type>{ List<Schema.SObjectField>.class, String.class },
+            true
+        );
+        PermissionValidator.instance = (PermissionValidator) permValidatorStub.createMock();
+
+        Boolean expected = true;
+
+        Test.startTest();
+        Boolean actual = service.checkAddParticipantsFieldPermissions();
+        Test.stopTest();
+
+        permValidatorStub.assertCalled(
+            fieldAccessMethodName,
+            new List<Type>{ List<Schema.SObjectField>.class, String.class }
+        );
+        permValidatorStub.assertCalled(
+            objectAccessMethodName,
+            new List<Type>{ SObjectType.class, PermissionValidator.CRUDAccessType.class }
+        );
+        System.assertEquals(
+            expected,
+            actual,
+            'Field permissions not returned from Perm Validator as expected.'
+        );
     }
 
     @IsTest

--- a/force-app/main/default/classes/ServiceScheduleService_TEST.cls
+++ b/force-app/main/default/classes/ServiceScheduleService_TEST.cls
@@ -796,7 +796,7 @@ public with sharing class ServiceScheduleService_TEST {
         Boolean expected = true;
 
         Test.startTest();
-        Boolean actual = service.checkAddParticipantsFieldPermissions();
+        Boolean actual = service.checkAddParticipantsPermissions();
         Test.stopTest();
 
         permValidatorStub.assertCalled(

--- a/force-app/main/default/labels/CustomLabels.labels-meta.xml
+++ b/force-app/main/default/labels/CustomLabels.labels-meta.xml
@@ -258,6 +258,13 @@
         <value>Next</value>
     </labels>
     <labels>
+        <fullName>No_Permission_Message</fullName>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>You don't have access to this information. Ask your admin for help.</shortDescription>
+        <value>You don't have access to this information. Ask your admin for help.</value>
+    </labels>
+    <labels>
         <fullName>No_Service_On_BSDT</fullName>
         <language>en_US</language>
         <protected>true</protected>

--- a/force-app/main/default/lwc/participantAdder/participantAdder.html
+++ b/force-app/main/default/lwc/participantAdder/participantAdder.html
@@ -13,23 +13,33 @@
             {labels.addServiceParticipants}
         </h2>
     </header>
-
     <template if:true={isLoaded}>
-        <div class="slds-modal__content slds-p-around_medium" id="modal-content-id-1">
-            <c-participant-selector
-                service-id={serviceId}
-                schedule-id={recordId}
-                existing-contact-ids={existingParticipants.data}
-                service-schedule-model={serviceScheduleModel}
-            ></c-participant-selector>
-            <template if:true={errorMessage}>
+        <template if:false={hasPermissions}>
+            <div class="slds-var-p-around_small">
                 <c-scoped-notification
-                    theme="error"
-                    title={errorMessage}
-                    class="slds-var-p-around_small"
-                ></c-scoped-notification
-            ></template>
-        </div>
+                    theme="warning"
+                    title={labels.noPermissions}
+                ></c-scoped-notification>
+            </div>
+        </template>
+
+        <template if:true={hasPermissions}>
+            <div class="slds-modal__content slds-p-around_medium" id="modal-content-id-1">
+                <c-participant-selector
+                    service-id={serviceId}
+                    schedule-id={recordId}
+                    existing-contact-ids={existingParticipants.data}
+                    service-schedule-model={serviceScheduleModel}
+                ></c-participant-selector>
+                <template if:true={errorMessage}>
+                    <c-scoped-notification
+                        theme="error"
+                        title={errorMessage}
+                        class="slds-var-p-around_small"
+                    ></c-scoped-notification
+                ></template>
+            </div>
+        </template>
     </template>
 
     <footer class="slds-modal__footer">

--- a/force-app/main/default/lwc/participantAdder/participantAdder.js
+++ b/force-app/main/default/lwc/participantAdder/participantAdder.js
@@ -15,7 +15,7 @@ import { ShowToastEvent } from "lightning/platformShowToastEvent";
 import getExistingParticipantContactIds from "@salesforce/apex/ServiceScheduleCreatorController.getExistingParticipantContactIds";
 import getServiceScheduleModel from "@salesforce/apex/ServiceScheduleCreatorController.getServiceScheduleModel";
 import addParticipants from "@salesforce/apex/ServiceScheduleCreatorController.addParticipants";
-import checkFieldPermissions from "@salesforce/apex/ServiceScheduleCreatorController.checkAddParticipantsFieldPermissions";
+import checkPermissions from "@salesforce/apex/ServiceScheduleCreatorController.checkAddParticipantsPermissions";
 
 import SUCCESS_LABEL from "@salesforce/label/c.Success";
 import SAVE_LABEL from "@salesforce/label/c.Save";
@@ -43,7 +43,7 @@ export default class ParticipantAdder extends LightningElement {
         noPermissions: NO_PERMISSIONS_MESSAGE_LABEL,
     };
 
-    @wire(checkFieldPermissions, {})
+    @wire(checkPermissions, {})
     wiredPermissions(result) {
         if (!(result.data || result.error)) {
             return;
@@ -145,7 +145,7 @@ export default class ParticipantAdder extends LightningElement {
         this.dispatchEvent(event);
     }
 
-    get isDisabled() {
-        return !this.isLoaded;
+    get isSaveDisabled() {
+        return !this.isLoaded || !this.hasPermissions;
     }
 }

--- a/force-app/main/default/lwc/participantAdder/participantAdder.js
+++ b/force-app/main/default/lwc/participantAdder/participantAdder.js
@@ -15,6 +15,7 @@ import { ShowToastEvent } from "lightning/platformShowToastEvent";
 import getExistingParticipantContactIds from "@salesforce/apex/ServiceScheduleCreatorController.getExistingParticipantContactIds";
 import getServiceScheduleModel from "@salesforce/apex/ServiceScheduleCreatorController.getServiceScheduleModel";
 import addParticipants from "@salesforce/apex/ServiceScheduleCreatorController.addParticipants";
+import checkFieldPermissions from "@salesforce/apex/ServiceScheduleCreatorController.checkAddParticipantsFieldPermissions";
 
 import SUCCESS_LABEL from "@salesforce/label/c.Success";
 import SAVE_LABEL from "@salesforce/label/c.Save";
@@ -23,6 +24,7 @@ import CANCEL_LABEL from "@salesforce/label/c.Cancel";
 import LOADING_LABEL from "@salesforce/label/c.Loading";
 import SERVICE_FIELD from "@salesforce/schema/ServiceSchedule__c.Service__c";
 import SAVE_SUCCESS from "@salesforce/label/c.Add_Service_Participants_Success";
+import NO_PERMISSIONS_MESSAGE_LABEL from "@salesforce/label/c.No_Permission_Message";
 
 export default class ParticipantAdder extends LightningElement {
     @api recordId;
@@ -30,6 +32,7 @@ export default class ParticipantAdder extends LightningElement {
     isLoaded = false;
     serviceScheduleModel;
     existingParticipants;
+    hasPermissions;
     labels = {
         save: SAVE_LABEL,
         success: SUCCESS_LABEL,
@@ -37,7 +40,18 @@ export default class ParticipantAdder extends LightningElement {
         cancel: CANCEL_LABEL,
         loading: LOADING_LABEL,
         successMessage: SAVE_SUCCESS,
+        noPermissions: NO_PERMISSIONS_MESSAGE_LABEL,
     };
+
+    @wire(checkFieldPermissions, {})
+    wiredPermissions(result) {
+        if (!(result.data || result.error)) {
+            return;
+        }
+        if (result.data) {
+            this.hasPermissions = result.data;
+        }
+    }
 
     @wire(getRecord, {
         recordId: "$recordId",


### PR DESCRIPTION
# Critical Changes

# Changes
- 'Add More Participants' quick action will display a warning if the user doesn't have necessary CRUD and FLS.
ServiceSchedule__c - READ
ProgramEngagement__c - READ
ServiceParticipant__c - CREATE
FLS Read access:
            ServiceSchedule__c.Service__c,
            ServiceSchedule__c.Name,
            ProgramEngagement__c.Contact__c,
            Contact.Name
FLS Edit access:
            ServiceParticipant__c.Name,
            ServiceParticipant__c.ServiceSchedule__c,
            ServiceParticipant__c.Service__c,
            ServiceParticipant__c.ProgramEngagement__c,
            ServiceParticipant__c.Contact__c

# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
- [x] Place holder data is incorporated (Refer to [Case Management Sample Data document](https://quip.com/cbFcAPJF8t0z))
- [ ] Base axe-core JEST test included for any new LWC (No critical violations)
- [x] CRUD/FLS is enforced in Apex
- [x] Permission sets & field sets are updated to account for CRUD/FLS/TABS for new object metadata
- [x] All modified classes are unit tested (Apex) at 100% coverage
- [x] UX approval or UX not necessary
- [x] PR contains draft release notes
- [x] Attach work item to the pull request with [Lurch](https://salesforce.quip.com/50ZRA5LEWVzH) `**Lurch:attach W-000000` or `**Lurch:add`
- [x] All **acceptance criteria** have been met
    - [x] Developer
    - [x] Code Reviewer
    - [x] QA
- [x] QE story level testing completed


