### PR TITLE
Add cause to error message; easily create Rosa user

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -146,6 +146,23 @@ flows:
                 options:
                     path: "data/scripts/update_all_records_as_recently_viewed.apex"
 
+    create_users_and_assign_permission_sets:
+        steps:
+            1:
+                task: dx
+                options:
+                    command: "force:user:create --setalias rosa --definitionfile unpackaged/users/rosa.json"
+                ignore_failure: True
+            2:
+                task: assign_permission_sets
+                options:
+                    api_names:
+                        - PMDM_View
+                        - PMDM_Deliver
+                        - PMDM_Manage
+                    user_alias: rosa
+                ignore_failure: True
+
     delete_data:
         steps:
             1:

--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -191,6 +191,8 @@ flows:
         steps:
             3:
                 flow: load_data
+            4:
+                flow: create_users_and_assign_permission_sets
 
     config_managed:
         steps:
@@ -198,6 +200,8 @@ flows:
                 flow: load_data
             4:
                 task: deploy_customer_profiles
+            5:
+                flow: create_users_and_assign_permission_sets
 
     config_qa:
         steps:

--- a/force-app/main/default/classes/Util.cls
+++ b/force-app/main/default/classes/Util.cls
@@ -9,7 +9,7 @@
 
 public with sharing class Util {
     public static AuraHandledException getAuraHandledException(Exception ex) {
-        String message = ex.getMessage();
+        String message = ex.getMessage() + ': ' + ex.getCause();
 
         AuraHandledException auraEx = new AuraHandledException(message);
         auraEx.setMessage(message);

--- a/force-app/main/default/classes/Util.cls
+++ b/force-app/main/default/classes/Util.cls
@@ -9,7 +9,8 @@
 
 public with sharing class Util {
     public static AuraHandledException getAuraHandledException(Exception ex) {
-        String message = ex.getMessage() + ': ' + ex.getCause();
+        String message =
+            ex.getMessage() + (ex.getCause() == null ? '' : ': ' + ex.getCause());
 
         AuraHandledException auraEx = new AuraHandledException(message);
         auraEx.setMessage(message);

--- a/unpackaged/users/rosa.json
+++ b/unpackaged/users/rosa.json
@@ -1,0 +1,11 @@
+{
+    "FirstName": "Rosa",
+    "LastName": "Sanchez",
+    "Alias": "rosa",
+    "TimeZoneSidKey": "America/Los_Angeles",
+    "LocaleSidKey": "en_US",
+    "EmailEncodingKey": "UTF-8",
+    "LanguageLocaleKey": "en_US",
+    "profileName": "Standard User",
+    "generatePassword": true
+}


### PR DESCRIPTION
# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
~~Any net new LWC work has Sa11y tests & 50% or above lines JEST test coverage~~
~~CRUD/FLS is enforced in Apex~~
~~Permission sets are updated to account for CRUD|FLS|Tab|Classes~~
~~Field sets are updated to account for new fields~~
- [ ] UX approval or UX not necessary
- [x] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: W-0000000: Work Name (https://github.com/SalesforceFoundation/PMM/pull/303)
- [ ] All **acceptance criteria** have been met
    - [x] Developer
    - [ ] Code Reviewer
    - [x] QA
~~PR contains draft release notes~~
- [ ] QE story level testing completed