### PR TITLE
[Robot] updated auto-populate tests on PE

### DIFF
--- a/robot/pmm/tests/browser/ProgramEngagement/autopopulate_pe_fields.robot
+++ b/robot/pmm/tests/browser/ProgramEngagement/autopopulate_pe_fields.robot
@@ -24,6 +24,16 @@ Setup Test Data
     Set suite variable             ${today}
     ${created_date} =              Get Current Date               result_format=%Y-%m-%d
     Set suite variable             ${created_date}
+    ${future_date} =               Get Current Date               result_format=%Y-%m-%d            increment=5 days
+    Set suite variable             ${future_date}
+    ${earlier_date} =              Get Current Date               result_format=%Y-%m-%d            increment=-5 days
+    Set suite variable             ${earlier_date}
+    ${program1} =                  API Create Program            ${ns}StartDate__c=${future_date}
+    Set suite variable             ${program1}
+    ${program2} =                  API Create Program            ${ns}StartDate__c=${created_date}
+    Set suite variable             ${program2}
+    ${program3} =                  API Create Program            ${ns}StartDate__c=${earlier_date}
+    Set suite variable             ${program3}
 
 *** Test Cases ***
 Autopopulate fields when stage is set to Applied
@@ -78,4 +88,55 @@ Autopopulate fields when stage is set to Withdrawn
      Wait Until Modal Is Closed
      Verify Details                          End Date                         contains               ${today}
      Verify Details                          Program Engagement Name          contains               Anonymous ${created_date}: ${program}[Name]           
+     Save Current Record ID For Deletion     ${ns}ProgramEngagement__c
+
+Autopopulate fields when stage is set to Active with Program start date is later than today
+     [Documentation]                         Validates that start date is not set to today when stage is 'Active' and Program
+     ...                                     start date is later than 'Today'
+     [tags]                                  W-8746330   feature:Program Engagement
+     Go To PMM App
+     Go To Page                              Listing                         ${ns}ProgramEngagement__c
+     Click Object Button                     New
+     Wait For Modal                          New                             Program Engagement
+     Populate Modal Form                     Program Engagement Name= ${program_engagement_name}
+     Select Value From Dropdown              Stage               Active
+     Populate Lightning fields               Program=${program1}[Name]                                   
+     ...                                     Role=Service Provider
+     Click Dialog Button                     Save
+     Wait Until Modal Is Closed
+     Verify Details                          Start Date                      does not contain               ${today}
+     Save Current Record ID For Deletion     ${ns}ProgramEngagement__c
+
+Autopopulate fields when stage is set to Active with Program start date is today
+     [Documentation]                         Validates that start date is set to today when stage is 'Active' and Program
+     ...                                     start date is than 'Today'
+     [tags]                                  W-8746330   feature:Program Engagement
+     Go To PMM App
+     Go To Page                              Listing                         ${ns}ProgramEngagement__c
+     Click Object Button                     New
+     Wait For Modal                          New                             Program Engagement
+     Populate Modal Form                     Program Engagement Name= ${program_engagement_name}
+     Select Value From Dropdown              Stage               Active
+     Populate Lightning fields               Program=${program2}[Name]                                   
+     ...                                     Role=Service Provider
+     Click Dialog Button                     Save
+     Wait Until Modal Is Closed
+     Verify Details                          Start Date                      contains               ${today}
+     Save Current Record ID For Deletion     ${ns}ProgramEngagement__c
+
+Autopopulate fields when stage is set to Active with Program start date is earlier than today
+     [Documentation]                         Validates that application date is not set to today when stage is 'Active' and Program
+     ...                                     start date is earlier than 'Today'
+     [tags]                                  W-8746330   feature:Program Engagement
+     Go To PMM App
+     Go To Page                              Listing                         ${ns}ProgramEngagement__c
+     Click Object Button                     New
+     Wait For Modal                          New                             Program Engagement
+     Populate Modal Form                     Program Engagement Name= ${program_engagement_name}
+     Select Value From Dropdown              Stage               Active
+     Populate Lightning fields               Program=${program3}[Name]                                   
+     ...                                     Role=Service Provider
+     Click Dialog Button                     Save
+     Wait Until Modal Is Closed
+     Verify Details                          Application Date                 does not contain               ${today}
      Save Current Record ID For Deletion     ${ns}ProgramEngagement__c

--- a/robot/pmm/tests/browser/ProgramEngagement/autopopulate_pe_fields.robot
+++ b/robot/pmm/tests/browser/ProgramEngagement/autopopulate_pe_fields.robot
@@ -12,6 +12,7 @@ Suite Teardown  Capture Screenshot and Delete Records and Close Browser
 
 *** Keywords ***
 Setup Test Data
+    [Documentation]                Creates program with start date set to today/later than today/earlier than today using API
     ${ns} =                        Get PMM Namespace Prefix
     Set suite variable             ${ns}
     ${program_engagement_name} =   Generate Random String


### PR DESCRIPTION
W-8746330 - Auto populate field when PE stage is Active 

- Program Engagement - Auto-populate field when program start date is later than today and stage is 'Active'
- Program Engagement - Auto-populate field when program start date is today and stage is 'Active'
- Program Engagement - Auto-populate field when program start date is earlier than today and stage is 'Active'

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
- [ ] Any net new LWC work has Sa11y tests & 50% or above lines JEST test coverage  
- [ ] CRUD/FLS is enforced in Apex
- [ ] Permission sets are updated to account for CRUD|FLS|Tab|Classes
- [ ] Field sets are updated to account for new fields
- [ ] UX approval or UX not necessary
- [ ] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: W-0000000: Work Name (https://github.com/SalesforceFoundation/PMM/pull/303)
- [ ] All **acceptance criteria** have been met
    - [ ] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [ ] PR contains draft release notes
- [ ] QE story level testing completed