### PR TITLE
Update description of stage field on program engagement

### DIFF
--- a/force-app/main/default/objects/ProgramEngagement__c/fields/Stage__c.field-meta.xml
+++ b/force-app/main/default/objects/ProgramEngagement__c/fields/Stage__c.field-meta.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Stage__c</fullName>
-    <description>These Picklist values describe a Contact&#39;s stage of engagement in a Program and are displayed in a Path. Values are determined by your Admin.</description>
+    <description>A Contact&#39;s stage in a Program Engagement. Picklist values are determined by your Admin. Don&#39;t delete or modify the API Name of the Active And Enrolled picklist values as they are referenced in PMM reports.</description>
     <externalId>false</externalId>
     <inlineHelpText>These Picklist values describe a Contact&#39;s stage of engagement in a Program and are displayed in a Path. Values are determined by your Admin.</inlineHelpText>
     <label>Stage</label>


### PR DESCRIPTION
# Critical Changes

# Changes
Modified the existing description of stage field on program engagement to the following so subscriber's don't change the API name of the picklist values :
    A Contact's Stage in a Program Engagement. Picklist values are determined by your admin. Don't delete or modify the API Name of the Active and Enrolled picklist values as they are referenced in PMM reports.
# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
~~- [ ] Any net new LWC work has Sa11y tests & 50% or above lines JEST test coverage  ~~
~~- [ ] CRUD/FLS is enforced in Apex~~
~~- [ ] Permission sets are updated to account for CRUD|FLS|Tab|Classes~~
~~- [ ] Field sets are updated to account for new fields~~
~~- [ ] UX approval or UX not necessary~~
- [x] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: W-0000000: Work Name (https://github.com/SalesforceFoundation/PMM/pull/303)
- [ ] All **acceptance criteria** have been met
    - [x] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [x] PR contains draft release notes
- [ ] QE story level testing completed