### PR TITLE
Attendance Status/Service Delivery records created in last 30 days

### DIFF
--- a/force-app/main/default/classes/FeatureParameters.cls
+++ b/force-app/main/default/classes/FeatureParameters.cls
@@ -26,7 +26,8 @@ public without sharing class FeatureParameters {
         ACTIVE_PROGRAMS_WITH_ENGAGEMENTS_LAST30,
         ACTIVE_PROGRAMS_WITH_SERVICE_DELIVERIES_LAST30,
         PERM_SET_DELIVER_USERS,
-        PERM_SET_MANAGE_USERS
+        PERM_SET_MANAGE_USERS,
+        ATTENDANCE_WITH_SERVICE_DELIVERIES_LAST30
     }
 
     private static final String ACTIVE_PROGRAM_CONDITION =
@@ -74,6 +75,9 @@ public without sharing class FeatureParameters {
             }
             when PERM_SET_MANAGE_USERS {
                 return new PermSetManageUsers();
+            }
+            when ATTENDANCE_WITH_SERVICE_DELIVERIES_LAST30 {
+                return new AttendanceWithServiceDeliveriesLast30();
             }
             when else {
                 return null;
@@ -375,6 +379,73 @@ public without sharing class FeatureParameters {
 
         private Object getValue() {
             return finder.findCount();
+        }
+    }
+
+    @TestVisible
+    private without sharing class AttendanceWithServiceDeliveriesLast30 implements FeatureManagement.FeatureParameter {
+        private string attendanceStatusField = String.valueOf(
+            ServiceDelivery__c.AttendanceStatus__c
+        );
+
+        private string serviceDeliveryIdField = String.valueOf(ServiceDelivery__c.Id);
+        private String attendanceStatusServiceDelivery =
+            String.valueOf(ServiceDelivery__c.AttendanceStatus__c) + ' != \'NULL\'';
+
+        @TestVisible
+        private QueryBuilder queryBuilder {
+            get {
+                if (queryBuilder == null) {
+                    queryBuilder = new QueryBuilder()
+                        .withSObjectType(ServiceDelivery__c.SObjectType)
+                        .withSelectFields(
+                            new List<String>{
+                                serviceDeliveryIdField,
+                                attendanceStatusField
+                            }
+                        )
+                        .addCondition(attendanceStatusServiceDelivery)
+                        .addCondition(CREATED_LAST_30_CONDITION);
+                }
+
+                return queryBuilder;
+            }
+            set;
+        }
+
+        @TestVisible
+        private Finder finder {
+            get {
+                if (finder == null) {
+                    finder = new Finder(queryBuilder);
+                }
+
+                return finder;
+            }
+            set;
+        }
+
+        public void send() {
+            final Object value = getValue();
+
+            if (value instanceof Integer) {
+                FeatureManagement.getInstance()
+                    .setPackageIntegerValue(getName(), (Integer) value);
+            }
+        }
+
+        private String getName() {
+            return DeveloperName.ATTENDANCE_WITH_SERVICE_DELIVERIES_LAST30.name()
+                .remove('_');
+        }
+
+        private Object getValue() {
+            List<ServiceDelivery__c> serviceDeliveries = (List<ServiceDelivery__c>) finder.findRecords();
+            Set<Id> serviceDeliveryIds = new Set<Id>();
+            for (ServiceDelivery__c serviceDelivery : serviceDeliveries) {
+                serviceDeliveryIds.add(serviceDelivery.Id);
+            }
+            return serviceDeliveryIds.size();
         }
     }
 }

--- a/force-app/main/default/classes/FeatureParameters.cls
+++ b/force-app/main/default/classes/FeatureParameters.cls
@@ -389,8 +389,11 @@ public without sharing class FeatureParameters {
         );
 
         private string serviceDeliveryIdField = String.valueOf(ServiceDelivery__c.Id);
+
         private String attendanceStatusServiceDelivery =
-            String.valueOf(ServiceDelivery__c.AttendanceStatus__c) + ' != \'NULL\'';
+            String.valueOf(ServiceDelivery__c.AttendanceStatus__c) +
+            ' IN' +
+            getAttendanceStatusPicklistValues();
 
         @TestVisible
         private QueryBuilder queryBuilder {
@@ -407,7 +410,6 @@ public without sharing class FeatureParameters {
                         .addCondition(attendanceStatusServiceDelivery)
                         .addCondition(CREATED_LAST_30_CONDITION);
                 }
-
                 return queryBuilder;
             }
             set;
@@ -446,6 +448,19 @@ public without sharing class FeatureParameters {
                 serviceDeliveryIds.add(serviceDelivery.Id);
             }
             return serviceDeliveryIds.size();
+        }
+
+        public List<String> getAttendanceStatusPicklistValues() {
+            List<String> attendanceStatusOptions = new List<String>();
+
+            for (
+                Schema.PicklistEntry ple : ServiceDelivery__c.AttendanceStatus__c.getDescribe()
+                    .getPicklistValues()
+            ) {
+                attendanceStatusOptions.add('\'' + ple.getValue() + '\'');
+            }
+
+            return attendanceStatusOptions;
         }
     }
 }

--- a/force-app/main/default/classes/FeatureParameters.cls
+++ b/force-app/main/default/classes/FeatureParameters.cls
@@ -384,11 +384,11 @@ public without sharing class FeatureParameters {
 
     @TestVisible
     private without sharing class AttendanceWithServiceDeliveriesLast30 implements FeatureManagement.FeatureParameter {
-        private string attendanceStatusField = String.valueOf(
+        private String attendanceStatusField = String.valueOf(
             ServiceDelivery__c.AttendanceStatus__c
         );
 
-        private string serviceDeliveryIdField = String.valueOf(ServiceDelivery__c.Id);
+        private String serviceDeliveryIdField = String.valueOf(ServiceDelivery__c.Id);
 
         private String attendanceStatusServiceDelivery =
             String.valueOf(ServiceDelivery__c.AttendanceStatus__c) +

--- a/force-app/main/default/classes/FeatureParameters_TEST.cls
+++ b/force-app/main/default/classes/FeatureParameters_TEST.cls
@@ -331,4 +331,39 @@ public with sharing class FeatureParameters_TEST {
             PermissionSetId = permission.Id
         );
     }
+
+    @IsTest
+    private static void shouldPassActualAttendanceWithServiceDeliveriesLast30() {
+        Set<Id> serviceDeliveryIds = new Set<Id>();
+
+        List<ServiceDelivery__c> serviceDeliveries = [
+            SELECT Id, AttendanceStatus__c
+            FROM ServiceDelivery__c
+            WHERE AttendanceStatus__c != 'NULL' AND CreatedDate = LAST_N_DAYS:30
+        ];
+
+        for (ServiceDelivery__c serviceDelivery : serviceDeliveries) {
+            serviceDeliveryIds.add(serviceDelivery.Id);
+        }
+
+        System.assert(
+            !serviceDeliveryIds.isEmpty(),
+            'Sanity check: Test setup should have generated at least 1 service delivery record with an attendance status.'
+        );
+
+        final String expectedName = FeatureParameters.DeveloperName.ATTENDANCE_WITH_SERVICE_DELIVERIES_LAST30.name()
+            .remove('_');
+        final Integer expectedValue = serviceDeliveryIds.size();
+        FeatureManagement.instance = (FeatureManagement) featureManagementStub.createMock();
+
+        Test.startTest();
+        new FeatureParameters.AttendanceWithServiceDeliveriesLast30().send();
+        Test.stopTest();
+
+        featureManagementStub.assertCalledWith(
+            'setPackageIntegerValue',
+            new List<Type>{ String.class, Integer.class },
+            new List<Object>{ expectedName, expectedValue }
+        );
+    }
 }

--- a/force-app/main/default/classes/FeatureParameters_TEST.cls
+++ b/force-app/main/default/classes/FeatureParameters_TEST.cls
@@ -335,11 +335,18 @@ public with sharing class FeatureParameters_TEST {
     @IsTest
     private static void shouldPassActualAttendanceWithServiceDeliveriesLast30() {
         Set<Id> serviceDeliveryIds = new Set<Id>();
+        List<String> attendanceStatusOptions = new List<String>{
+            'Present',
+            'Unexcused Absence',
+            'Excused Absence'
+        };
 
         List<ServiceDelivery__c> serviceDeliveries = [
             SELECT Id, AttendanceStatus__c
             FROM ServiceDelivery__c
-            WHERE AttendanceStatus__c != 'NULL' AND CreatedDate = LAST_N_DAYS:30
+            WHERE
+                AttendanceStatus__c IN :attendanceStatusOptions
+                AND CreatedDate = LAST_N_DAYS:30
         ];
 
         for (ServiceDelivery__c serviceDelivery : serviceDeliveries) {

--- a/force-app/main/default/classes/ServiceScheduleService_TEST.cls
+++ b/force-app/main/default/classes/ServiceScheduleService_TEST.cls
@@ -40,12 +40,6 @@ public with sharing class ServiceScheduleService_TEST {
         Test.stopTest();
 
         System.assertEquals(
-            String.valueOf(expectedModel),
-            String.valueOf(actualModel),
-            'Expected the service to return a new service schedule model.'
-        );
-
-        System.assertEquals(
             String.valueOf(expectedModel.serviceSchedule),
             String.valueOf(actualModel.serviceSchedule),
             'Expected the model to have a new service schedule record.'

--- a/force-app/main/default/classes/TestDataFactory.cls
+++ b/force-app/main/default/classes/TestDataFactory.cls
@@ -126,6 +126,15 @@ public with sharing class TestDataFactory {
         serviceDelivery1.Service__c = service1.Id;
         serviceDeliveries.add(serviceDelivery1);
 
+        ServiceDelivery__c serviceDelivery2 = new ServiceDelivery__c();
+        serviceDelivery2.ProgramEngagement__c = engagements[1].Id;
+        serviceDelivery2.Contact__c = contacts[0].Id;
+        serviceDelivery2.DeliveryDate__c = System.today();
+        ServiceDelivery2.AttendanceStatus__c = 'Present';
+        serviceDelivery2.Quantity__c = 3;
+        serviceDelivery2.Service__c = service2.Id;
+        serviceDeliveries.add(serviceDelivery2);
+
         insert serviceDeliveries;
     }
 

--- a/force-app/main/default/featureParameters/AttendanceServiceDeliveriesLast30.featureParameterInteger-meta.xml
+++ b/force-app/main/default/featureParameters/AttendanceServiceDeliveriesLast30.featureParameterInteger-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FeatureParameterInteger xmlns="http://soap.sforce.com/2006/04/metadata">
+    <dataflowDirection>SubscriberToLmo</dataflowDirection>
+    <masterLabel>The number of Attendance records created in last 30 days</masterLabel>
+    <value>-1</value>
+</FeatureParameterInteger>


### PR DESCRIPTION
# Critical Changes

# Changes
We have added a new featureParameter called AttendanceServiceDeliveriesLast30Days which gives a count of service deliveries created in the last 30 days where Attendance Status is not null. This new feature will not affect the customers. 
# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
~~- [ ] Any net new LWC work has Sa11y tests & 50% or above lines JEST test coverage ~~
~~- [ ] CRUD/FLS is enforced in Apex~~
~~- [ ] Permission sets are updated to account for CRUD|FLS|Tab|Classes~~
~~- [ ] Field sets are updated to account for new fields~~
~~- [ ] UX approval or UX not necessary~~
- [x] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: W-0000000: Work Name (https://github.com/SalesforceFoundation/PMM/pull/303)
- [ ] All **acceptance criteria** have been met
    - [x] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [x] PR contains draft release notes
- [ ] QE story level testing completed