### PR TITLE
[Robot] Enable robot tests for non admin users

### DIFF
--- a/robot/pmm/resources/locators_49.py
+++ b/robot/pmm/resources/locators_49.py
@@ -1,4 +1,4 @@
-""" Locators for summer'20 """
+""" Locators for summer'21 """
 
 from locators_51 import pmm_lex_locators
 import copy

--- a/robot/pmm/resources/locators_49.py
+++ b/robot/pmm/resources/locators_49.py
@@ -1,4 +1,4 @@
-""" Locators for summer'21 """
+""" Locators for summer'20 """
 
 from locators_51 import pmm_lex_locators
 import copy

--- a/robot/pmm/resources/locators_50.py
+++ b/robot/pmm/resources/locators_50.py
@@ -1,4 +1,4 @@
-""" Locators for summer'21 """
+""" Locators for winter'21 """
 
 from locators_51 import pmm_lex_locators
 import copy

--- a/robot/pmm/resources/locators_50.py
+++ b/robot/pmm/resources/locators_50.py
@@ -1,4 +1,4 @@
-""" Locators for winter'21 """
+""" Locators for summer'21 """
 
 from locators_51 import pmm_lex_locators
 import copy

--- a/robot/pmm/tests/browser/Attendance/dim_attendance.robot
+++ b/robot/pmm/tests/browser/Attendance/dim_attendance.robot
@@ -46,7 +46,7 @@ Dim attendance rows and validate service deliveries are not created
     [tags]                          W-8613706    perm:admin   perm:manage    perm:deliver   feature:Attendance
     Go To PMM App
     Go To Page                      Details         ServiceSession__c        object_id=${service_session1}[Id]
-    Page Should Contain             Track Attendance
+    Page Should Contain Text        Track Attendance
     Dim attendance Row              1         Select
     Click Button                    Submit
     Verify Toast Message            There are no Service Delivery records to update.
@@ -58,7 +58,7 @@ Validate Dim attendance icon is displayed only for newly added rows
     [tags]                          W-8613706    perm:admin   perm:manage   perm:deliver   feature:Attendance
     Go To PMM App
     Go To Page                      Details         ServiceSession__c        object_id=${service_session3}[Id]
-    Page Should Contain             Track Attendance
+    Page Should Contain Text            Track Attendance
     Populate Attendance Field           1      Hours                10
     Populate Attendance Dropdown        1      Attendance Status    Present
     Click Button                        Submit

--- a/robot/pmm/tests/browser/Attendance/dim_attendance.robot
+++ b/robot/pmm/tests/browser/Attendance/dim_attendance.robot
@@ -46,7 +46,7 @@ Dim attendance rows and validate service deliveries are not created
     [tags]                          W-8613706    perm:admin   perm:manage    perm:deliver   feature:Attendance
     Go To PMM App
     Go To Page                      Details         ServiceSession__c        object_id=${service_session1}[Id]
-    Page Should Contain Text        Track Attendance
+    Page Should Contain             Track Attendance
     Dim attendance Row              1         Select
     Click Button                    Submit
     Verify Toast Message            There are no Service Delivery records to update.
@@ -58,7 +58,7 @@ Validate Dim attendance icon is displayed only for newly added rows
     [tags]                          W-8613706    perm:admin   perm:manage   perm:deliver   feature:Attendance
     Go To PMM App
     Go To Page                      Details         ServiceSession__c        object_id=${service_session3}[Id]
-    Page Should Contain Text        Track Attendance
+    Page Should Contain             Track Attendance
     Populate Attendance Field           1      Hours                10
     Populate Attendance Dropdown        1      Attendance Status    Present
     Click Button                        Submit

--- a/robot/pmm/tests/browser/Attendance/dim_attendance.robot
+++ b/robot/pmm/tests/browser/Attendance/dim_attendance.robot
@@ -19,7 +19,7 @@ Setup Test Data
     Set suite variable              ${ns}
     ${contact1}                     API Create Contact
     Set suite variable              ${contact1}
-    ${contact2}                     API Create Contact      FirstName=ztest robot contact
+    ${contact2}                     API Create Contact      FirstName=test robot contact
     Set suite variable              ${contact2}
     ${program} =                    API Create Program
     Set suite variable              ${program}
@@ -27,14 +27,18 @@ Setup Test Data
     Set suite variable              ${service}
     ${service_schedule} =           API Create Service Schedule         ${service}[Id]
     Set suite variable              ${service_schedule}
+    ${service_schedule1} =          API Create Service Schedule         ${service}[Id]
+    Set suite variable              ${service_schedule1}
     ${service_session1} =           API Create Service Session          ${service_schedule}[Id]     Pending
     Set suite variable              ${service_session1}
-    ${service_session2} =           API Create Service Session          ${service_schedule}[Id]     Pending
+    ${service_session2} =           API Create Service Session          ${service_schedule1}[Id]     Pending
     Set suite variable              ${service_session2}
-    ${service_session3} =           API Create Service Session          ${service_schedule}[Id]     Pending
+    ${service_session3} =           API Create Service Session          ${service_schedule}[Id]    Pending
     Set suite variable              ${service_session3}
     ${service_participant1} =       API Create Service Participant      ${contact1}[Id]   ${service_schedule}[Id]  ${service}[Id]
     Set suite variable              ${service_participant1}
+    ${service_participant2} =       API Create Service Participant      ${contact1}[Id]   ${service_schedule1}[Id]  ${service}[Id]
+    Set suite variable              ${service_participant2}
 
 *** Test Cases ***
 Dim attendance rows and validate service deliveries are not created
@@ -42,10 +46,29 @@ Dim attendance rows and validate service deliveries are not created
     [tags]                          W-8613706    perm:admin   perm:manage    perm:deliver   feature:Attendance
     Go To PMM App
     Go To Page                      Details         ServiceSession__c        object_id=${service_session1}[Id]
-    Page Should Contain Text        ${contact1}[Name]
+    Page Should Contain             Track Attendance
     Dim attendance Row              1         Select
     Click Button                    Submit
     Verify Toast Message            There are no Service Delivery records to update.
+    Page Should Contain Text        ${contact1}[Name]
+
+Validate Dim attendance icon is displayed only for newly added rows
+    [Documentation]                 This test updates the attendance row and Submits. Creates a new Service participant and validates
+    ...                             that the dim icon is displayed only for the newly added row.
+    [tags]                          W-8613706    perm:admin   perm:manage   perm:deliver   feature:Attendance
+    Go To PMM App
+    Go To Page                      Details         ServiceSession__c        object_id=${service_session3}[Id]
+    Page Should Contain             Track Attendance
+    Populate Attendance Field           1      Hours                10
+    Populate Attendance Dropdown        1      Attendance Status    Present
+    Click Button                        Submit
+    API Create Service Participant  ${contact2}[Id]   ${service_schedule}[Id]  ${service}[Id]
+    Reload Page
+    Click Button                    Update
+    Dim Attendance Row              1       Is not displayed
+    Dim Attendance Row              2       Is displayed
+    Page Should Contain             ${contact1}[Name]
+    Page Should Contain             ${contact2}[Name]
 
 Dim attendance row and validate that the Quantity and Attendance Status is reset
     [Documentation]                 This test updates the attendance row, clicks on the Dim icon and validates that
@@ -60,19 +83,3 @@ Dim attendance row and validate that the Quantity and Attendance Status is reset
     Click Button                        Submit
     Validate Attendance Info In Row     1     Hours                 does not contain    10
     Validate Attendance Info In Row     1     Attendance Status     does not contain    Present
-
-Validate Dim attendance icon is displayed only for newly added rows
-    [Documentation]                 This test updates the attendance row and Submits. Creates a new Service participant and validates
-    ...                             that the dim icon is displayed only for the newly added row.
-    [tags]                          W-8613706    perm:admin   perm:manage   perm:deliver   feature:Attendance
-    Go To PMM App
-    Go To Page                      Details         ServiceSession__c        object_id=${service_session3}[Id]
-    Page Should Contain Text        ${contact1}[Name]
-    Populate Attendance Field           1      Hours                10
-    Populate Attendance Dropdown        1      Attendance Status    Present
-    Click Button                        Submit
-    API Create Service Participant  ${contact2}[Id]   ${service_schedule}[Id]  ${service}[Id]
-    Reload Page
-    Click Button                    Update
-    Dim Attendance Row              1       Is not displayed
-    Dim Attendance Row              2       Is displayed

--- a/robot/pmm/tests/browser/Attendance/dim_attendance.robot
+++ b/robot/pmm/tests/browser/Attendance/dim_attendance.robot
@@ -46,7 +46,7 @@ Dim attendance rows and validate service deliveries are not created
     [tags]                          W-8613706    perm:admin   perm:manage    perm:deliver   feature:Attendance
     Go To PMM App
     Go To Page                      Details         ServiceSession__c        object_id=${service_session1}[Id]
-    Page Should Contain             Track Attendance
+    Page Should Contain Text        Track Attendance
     Dim attendance Row              1         Select
     Click Button                    Submit
     Verify Toast Message            There are no Service Delivery records to update.
@@ -58,7 +58,7 @@ Validate Dim attendance icon is displayed only for newly added rows
     [tags]                          W-8613706    perm:admin   perm:manage   perm:deliver   feature:Attendance
     Go To PMM App
     Go To Page                      Details         ServiceSession__c        object_id=${service_session3}[Id]
-    Page Should Contain             Track Attendance
+    Page Should Contain Text        Track Attendance
     Populate Attendance Field           1      Hours                10
     Populate Attendance Dropdown        1      Attendance Status    Present
     Click Button                        Submit

--- a/robot/pmm/tests/browser/Attendance/dim_attendance.robot
+++ b/robot/pmm/tests/browser/Attendance/dim_attendance.robot
@@ -41,7 +41,7 @@ Dim attendance rows and validate service deliveries are not created
     [Documentation]                 This test Dims an attendance row and validates that the toast message is displayed
     [tags]                          W-8613706    perm:admin   perm:manage    perm:deliver   feature:Attendance
     Go To PMM App
-    Go To Page                      Details         ${ns}ServiceSession__c        object_id=${service_session1}[Id]
+    Go To Page                      Details         ServiceSession__c        object_id=${service_session1}[Id]
     Page Should Contain Text        ${contact1}[Name]
     Dim attendance Row              1         Select
     Click Button                    Submit
@@ -52,7 +52,7 @@ Dim attendance row and validate that the Quantity and Attendance Status is reset
     ...                             the data is reset when clicked on Submit
     [tags]                          W-8613706    perm:admin   perm:manage     perm:deliver   feature:Attendance
     Go To PMM App
-    Go To Page                          Details         ${ns}ServiceSession__c        object_id=${service_session2}[Id]
+    Go To Page                          Details         ServiceSession__c        object_id=${service_session2}[Id]
     Page Should Contain Text            ${contact1}[Name]
     Populate Attendance Field           1      Hours                10
     Populate Attendance Dropdown        1      Attendance Status    Present
@@ -66,7 +66,7 @@ Validate Dim attendance icon is displayed only for newly added rows
     ...                             that the dim icon is displayed only for the newly added row.
     [tags]                          W-8613706    perm:admin   perm:manage   perm:deliver   feature:Attendance
     Go To PMM App
-    Go To Page                      Details         ${ns}ServiceSession__c        object_id=${service_session3}[Id]
+    Go To Page                      Details         ServiceSession__c        object_id=${service_session3}[Id]
     Page Should Contain Text        ${contact1}[Name]
     Populate Attendance Field           1      Hours                10
     Populate Attendance Dropdown        1      Attendance Status    Present

--- a/robot/pmm/tests/browser/Attendance/dim_attendance.robot
+++ b/robot/pmm/tests/browser/Attendance/dim_attendance.robot
@@ -5,10 +5,12 @@ Library        cumulusci.robotframework.PageObjects
 ...            robot/pmm/resources/ServiceSessionPageObject.py
 ...            robot/pmm/resources/BulkServiceDeliveryPageObject.py
 Suite Setup     Run Keywords
-...             Open Test Browser
+...             Open test browser            useralias=${test_user}             AND
 ...             Setup Test Data
 Suite Teardown  Capture Screenshot and Delete Records and Close Browser
 
+*** Variables ***
+${test_user}             UUser
 
 *** Keywords ***
 Setup Test Data
@@ -37,7 +39,7 @@ Setup Test Data
 *** Test Cases ***
 Dim attendance rows and validate service deliveries are not created
     [Documentation]                 This test Dims an attendance row and validates that the toast message is displayed
-    [tags]                          W-8613706 feature:Attendance
+    [tags]                          W-8613706    perm:admin   perm:manage    perm:deliver   feature:Attendance
     Go To PMM App
     Go To Page                      Details         ${ns}ServiceSession__c        object_id=${service_session1}[Id]
     Page Should Contain Text        ${contact1}[Name]
@@ -48,7 +50,7 @@ Dim attendance rows and validate service deliveries are not created
 Dim attendance row and validate that the Quantity and Attendance Status is reset
     [Documentation]                 This test updates the attendance row, clicks on the Dim icon and validates that
     ...                             the data is reset when clicked on Submit
-    [tags]                          W-8613706 feature:Attendance
+    [tags]                          W-8613706    perm:admin   perm:manage     perm:deliver   feature:Attendance
     Go To PMM App
     Go To Page                          Details         ${ns}ServiceSession__c        object_id=${service_session2}[Id]
     Page Should Contain Text            ${contact1}[Name]
@@ -62,7 +64,7 @@ Dim attendance row and validate that the Quantity and Attendance Status is reset
 Validate Dim attendance icon is displayed only for newly added rows
     [Documentation]                 This test updates the attendance row and Submits. Creates a new Service participant and validates
     ...                             that the dim icon is displayed only for the newly added row.
-    [tags]                          W-8613706 feature:Attendance
+    [tags]                          W-8613706    perm:admin   perm:manage   perm:deliver   feature:Attendance
     Go To PMM App
     Go To Page                      Details         ${ns}ServiceSession__c        object_id=${service_session3}[Id]
     Page Should Contain Text        ${contact1}[Name]

--- a/robot/pmm/tests/browser/Attendance/empty_attendance.robot
+++ b/robot/pmm/tests/browser/Attendance/empty_attendance.robot
@@ -5,10 +5,12 @@ Library        cumulusci.robotframework.PageObjects
 ...            robot/pmm/resources/ServiceSessionPageObject.py
 ...            robot/pmm/resources/BulkServiceDeliveryPageObject.py
 Suite Setup     Run Keywords
-...             Open Test Browser
+...             Open test browser            useralias=${test_user}             AND
 ...             Setup Test Data
 Suite Teardown  Capture Screenshot and Delete Records and Close Browser
 
+*** Variables ***
+${test_user}             UUser
 
 *** Keywords ***
 Setup Test Data
@@ -28,7 +30,7 @@ Setup Test Data
 *** Test Cases ***
 Validate Empty Attendance State
     [Documentation]                 This test confirms that the service session empty state message shows in track attendance
-    [tags]                          W-8607484  feature:Attendance
+    [tags]                          W-8607484   perm:admin   perm:manage   perm:deliver   feature:Attendance
     Go To PMM App
     Go To Page                      Details         ${ns}ServiceSession__c        object_id=${service_session1}[Id]
     Page Should Contain             No participants yet

--- a/robot/pmm/tests/browser/Attendance/empty_attendance.robot
+++ b/robot/pmm/tests/browser/Attendance/empty_attendance.robot
@@ -30,8 +30,8 @@ Setup Test Data
 *** Test Cases ***
 Validate Empty Attendance State
     [Documentation]                 This test confirms that the service session empty state message shows in track attendance
-    [tags]                          W-8607484   perm:admin   perm:manage   perm:deliver   feature:Attendance
+    [tags]                          W-8607484   perm:admin   perm:manage    perm:deliver      feature:Attendance
     Go To PMM App
-    Go To Page                      Details         ${ns}ServiceSession__c        object_id=${service_session1}[Id]
+    Go To Page                      Details         ServiceSession__c        object_id=${service_session1}[Id]
     Page Should Contain             No participants yet
     

--- a/robot/pmm/tests/browser/Attendance/update_attendance.robot
+++ b/robot/pmm/tests/browser/Attendance/update_attendance.robot
@@ -45,10 +45,7 @@ Update attendance when service session status is Pending
     [Documentation]                 This test updates attendance for a service session record with Pending Status
     [tags]                          W-8607484   perm:admin   perm:manage    feature:Attendance
     Go To PMM App
-    Go To Page                      Details         ${ns}ServiceSession__c        object_id=${service_session1}[Id]
-    Page Should Contain Text        ${contact1}[Name]
-    Page Should Contain Text        ${contact2}[Name]
-    Page Should Contain Text        ${contact3}[Name]          
+    Go To Page                      Details         ServiceSession__c        object_id=${service_session1}[Id]         
     Populate Attendance Field           1      Hours                10
     Populate Attendance Dropdown        1      Attendance Status    Present
     Populate Attendance Field           2      Hours                10
@@ -60,15 +57,15 @@ Update attendance when service session status is Pending
     Reload Page
     Page Should Contain             Present
     Verify Details                  Status          contains        Complete
+    Page Should Contain Text        ${contact1}[Name]
+    Page Should Contain Text        ${contact2}[Name]
+    Page Should Contain Text        ${contact3}[Name] 
     
 Update attendance when service session status is Complete
     [Documentation]                 This test updates attendance for a service session record with Complete Status
     [tags]                          W-8611541    perm:admin   perm:manage     feature:Attendance
     Go To PMM App
-    Go To Page                      Details         ${ns}ServiceSession__c        object_id=${service_session2}[Id]
-    Page Should Contain Text        ${contact1}[Name]
-    Page Should Contain Text        ${contact2}[Name]
-    Page Should Contain Text        ${contact3}[Name]
+    Go To Page                      Details         ServiceSession__c        object_id=${service_session2}[Id]
     Click Button                    Update
     Page Should Contain             Track Attendance         
     Populate Attendance Field           1      Hours                10
@@ -79,3 +76,6 @@ Update attendance when service session status is Complete
     Verify Toast Message            Saved 3 Service Delivery records.
     Page Should Contain             Present
     Page Should Contain             Created Date
+    Page Should Contain Text        ${contact1}[Name]
+    Page Should Contain Text        ${contact2}[Name]
+    Page Should Contain Text        ${contact3}[Name]

--- a/robot/pmm/tests/browser/Attendance/update_attendance.robot
+++ b/robot/pmm/tests/browser/Attendance/update_attendance.robot
@@ -5,10 +5,12 @@ Library        cumulusci.robotframework.PageObjects
 ...            robot/pmm/resources/ServiceSessionPageObject.py
 ...            robot/pmm/resources/BulkServiceDeliveryPageObject.py
 Suite Setup     Run Keywords
-...             Open Test Browser
+...             Open test browser            useralias=${test_user}             AND
 ...             Setup Test Data
 Suite Teardown  Capture Screenshot and Delete Records and Close Browser
 
+*** Variables ***
+${test_user}             UUser
 
 *** Keywords ***
 Setup Test Data
@@ -41,7 +43,7 @@ Setup Test Data
 *** Test Cases ***
 Update attendance when service session status is Pending
     [Documentation]                 This test updates attendance for a service session record with Pending Status
-    [tags]                          W-8607484  feature:Attendance
+    [tags]                          W-8607484   perm:admin   perm:manage    feature:Attendance
     Go To PMM App
     Go To Page                      Details         ${ns}ServiceSession__c        object_id=${service_session1}[Id]
     Page Should Contain Text        ${contact1}[Name]
@@ -61,7 +63,7 @@ Update attendance when service session status is Pending
     
 Update attendance when service session status is Complete
     [Documentation]                 This test updates attendance for a service session record with Complete Status
-    [tags]                          W-8611541  feature:Attendance
+    [tags]                          W-8611541    perm:admin   perm:manage     feature:Attendance
     Go To PMM App
     Go To Page                      Details         ${ns}ServiceSession__c        object_id=${service_session2}[Id]
     Page Should Contain Text        ${contact1}[Name]

--- a/robot/pmm/tests/browser/Bulk_Service_Delivery/Add_service_deliveries.robot
+++ b/robot/pmm/tests/browser/Bulk_Service_Delivery/Add_service_deliveries.robot
@@ -7,9 +7,12 @@ Library        cumulusci.robotframework.PageObjects
 ...            robot/pmm/resources/ServiceDeliveryPageObject.py
 ...            robot/pmm/resources/ProgramEngagementPageObject.py
 Suite Setup     Run Keywords
-...             Open Test Browser
+...             Open test browser            useralias=${test_user}             AND
 ...             Setup Test Data
 Suite Teardown  Capture Screenshot and Delete Records and Close Browser
+
+*** Variables ***
+${test_user}             UUser
 
 *** Keywords ***
 Setup Test Data
@@ -54,7 +57,7 @@ Add service delivery on bulk service delivery
     [Documentation]             This test adds two service deliveries on bulk service delivery and 
     ...                         navigates to service delivery listview and verifies that the service delivery 
     ...                         records are displayed
-    [tags]                      W-040316   feature:Service Delivery
+    [tags]                      W-040316    perm:admin   perm:manage    perm:deliver   feature:Service Delivery
     Go To PMM App
     Go To Page                  Custom                              Bulk_Service_Deliveries
     Populate Bsdt Lookup        1           Client                  ${contact1}[FirstName] ${contact1}[LastName]
@@ -82,7 +85,7 @@ Add service delivery on bulk service delivery
 Verify error message when there are no services associated with the program
     [Documentation]             This test verifies that an error message is displayed when there are no
     ...                         services associated with the program.
-    [tags]                      W-040316   feature:Service Delivery
+    [tags]                      W-040316     perm:admin   perm:manage     perm:deliver   feature:Service Delivery
     Go To Page                  Custom                              Bulk_Service_Deliveries
     Populate Bsdt Lookup        1           Client                  ${contact3}[FirstName] ${contact3}[LastName]
     Populate Bsdt Dropdown      1           Program Engagement      ${program_engagement3}[Name]
@@ -92,7 +95,7 @@ Verify error message when there are no services associated with the program
 Delete service delivery on bsdt
     [Documentation]             This test creates a service delivery on BSDT and then deletes it, verifies
     ...                         that a warning dialog is displayed when deleted.
-    [tags]                      W-042916   feature:Service Delivery
+    [tags]                      W-042916     perm:admin   perm:manage     perm:deliver   feature:Service Delivery
     Go To Page                  Custom                              Bulk_Service_Deliveries
     Populate Bsdt Lookup        1           Client                  ${contact1}[FirstName] ${contact1}[LastName]
     Populate Bsdt Dropdown      1           Program Engagement      ${program_engagement1}[Name]

--- a/robot/pmm/tests/browser/Bulk_Service_Delivery/add_pe_on_BSDT.robot
+++ b/robot/pmm/tests/browser/Bulk_Service_Delivery/add_pe_on_BSDT.robot
@@ -7,10 +7,12 @@ Library        cumulusci.robotframework.PageObjects
 ...            robot/pmm/resources/ServiceDeliveryPageObject.py
 ...            robot/pmm/resources/ProgramEngagementPageObject.py
 Suite Setup     Run Keywords
-...             Open Test Browser
+...             Open test browser            useralias=${test_user}             AND
 ...             Setup Test Data
 Suite Teardown  Capture Screenshot and Delete Records and Close Browser
 
+*** Variables ***
+${test_user}             UUser
 
 *** Keywords ***
 Setup Test Data
@@ -39,7 +41,7 @@ Setup Test Data
 Create program engagement from BSDT
     [Documentation]                         This test adds service deliveries on bulk service delivery by creating
     ...                                     a new PE on bsdt page
-    [tags]                                  W-040316   feature:Service Delivery
+    [tags]                                  W-040316    perm:admin   perm:manage    perm:deliver   feature:Service Delivery
     Go To PMM App
     Go To Page                              Custom                              Bulk_Service_Deliveries
     Populate Bsdt Lookup                    1           Client                  ${contact}[FirstName] ${contact}[LastName]

--- a/robot/pmm/tests/browser/Contact/create_contact.robot
+++ b/robot/pmm/tests/browser/Contact/create_contact.robot
@@ -5,9 +5,12 @@ Library         cumulusci.robotframework.PageObjects
 ...             robot/pmm/resources/pmm.py
 ...             robot/pmm/resources/ContactPageObject.py
 Suite Setup     Run Keywords
-...             Open Test Browser
+...             Open test browser            useralias=${test_user}             AND
 ...             Setup Test Data
 Suite Teardown  Capture Screenshot and Delete Records and Close Browser
+
+*** Variables ***
+${test_user}             UUser
 
 *** Keywords ***
 Setup Test Data
@@ -22,6 +25,7 @@ Setup Test Data
 *** Test Cases ***
 Create a Contact 
     [Documentation]                        This test creates a Contact and verifies the details of the contact
+    [tags]                                 perm:admin   perm:manage      perm:deliver    feature:Contact
     Go To PMM App
     Go To Page                             Listing                              Contact
     Click Object Button                    New

--- a/robot/pmm/tests/browser/Contact/quickactions.robot
+++ b/robot/pmm/tests/browser/Contact/quickactions.robot
@@ -7,9 +7,12 @@ Library         cumulusci.robotframework.PageObjects
 ...             robot/pmm/resources/ProgramEngagementPageObject.py
 ...             robot/pmm/resources/ServiceDeliveryPageObject.py
 Suite Setup     Run Keywords
-...             Open Test Browser
+...             Open test browser            useralias=${test_user}             AND
 ...             Setup Test Data
 Suite Teardown  Capture Screenshot and Delete Records and Close Browser
+
+*** Variables ***
+${test_user}             UUser
 
 *** Keywords ***
 Setup Test Data
@@ -35,7 +38,7 @@ Setup Test Data
 *** Test Cases ***
 Add contact to program quick action
      [Documentation]                  Add a contact to a program using quick action and verify the record
-     [tags]                           W-037575  feature:Program Engagement
+     [tags]                           W-037575    perm:admin   perm:manage      perm:deliver    feature:Program Engagement
      Go To PMM App
      Go To Page                       Details                                 Contact              object_id=${contact}[Id]
      page should contain              ${contact}[Name]
@@ -56,7 +59,7 @@ Add contact to program quick action
      
 Add service delivery on a contact
      [Documentation]                  Add a service delivery on a contact and verify the record
-     [tags]                           W-037575  feature:Service Delivery
+     [tags]                           W-037575    perm:admin   perm:manage     perm:deliver    feature:Service Delivery
      Go To Page                       Details                                 Contact                  object_id=${contact}[Id]
      page should contain              ${contact}[Name]
      Click Quick Action Button        Create New Service Delivery

--- a/robot/pmm/tests/browser/Program/add_service.robot
+++ b/robot/pmm/tests/browser/Program/add_service.robot
@@ -29,6 +29,8 @@ Setup Test Data
 *** Test Cases ***
 
 Create Service from Program Object
+    [Documentation]                  On Program detail record, clicks New button on Service related list, populates the field on 
+    ...                              the dialog and Saves. Validates that the Service related list is updated with the new record
     [tags]                                  perm:admin   perm:manage     feature:Service
      Go To PMM App
      Go To Page                             Details                 Program__c            object_id=${program}[Id]

--- a/robot/pmm/tests/browser/Program/add_service.robot
+++ b/robot/pmm/tests/browser/Program/add_service.robot
@@ -6,9 +6,12 @@ Library        cumulusci.robotframework.PageObjects
 ...            robot/pmm/resources/ProgramPageObject.py
 ...            robot/pmm/resources/ServicePageObject.py
 Suite Setup     Run Keywords
-...             Open Test Browser
+...             Open test browser            useralias=${test_user}             AND
 ...             Setup Test Data
 Suite Teardown  Capture Screenshot and Delete Records and Close Browser
+
+*** Variables ***
+${test_user}             UUser
 
 *** Keywords ***
 Setup Test Data
@@ -26,6 +29,7 @@ Setup Test Data
 *** Test Cases ***
 
 Create Service from Program Object
+    [tags]                                  perm:admin   perm:manage     feature:Service
      Go To PMM App
      Go To Page                             Details                 Program__c            object_id=${program}[Id]
      Page Should Contain                    ${program}[Name]

--- a/robot/pmm/tests/browser/Program/add_service.robot
+++ b/robot/pmm/tests/browser/Program/add_service.robot
@@ -29,8 +29,6 @@ Setup Test Data
 *** Test Cases ***
 
 Create Service from Program Object
-    [Documentation]                  On Program detail record, clicks New button on Service related list, populates the field on 
-    ...                              the dialog and Saves. Validates that the Service related list is updated with the new record
     [tags]                                  perm:admin   perm:manage     feature:Service
      Go To PMM App
      Go To Page                             Details                 Program__c            object_id=${program}[Id]

--- a/robot/pmm/tests/browser/Program/create_program.robot
+++ b/robot/pmm/tests/browser/Program/create_program.robot
@@ -31,7 +31,7 @@ Setup Test Data
 Create a Program via UI
     [Documentation]                        This test creates Program and verifies that the Program record
     ...                                    has all the values from the form
-    [tags]                                 perm:admin   perm:manage
+    [tags]                                 perm:admin   perm:manage         feature:Program
     Go To PMM App
     Go To Page                              Listing                               ${ns}Program__c
     Click Object Button                     New

--- a/robot/pmm/tests/browser/Program/create_program.robot
+++ b/robot/pmm/tests/browser/Program/create_program.robot
@@ -5,9 +5,12 @@ Library        cumulusci.robotframework.PageObjects
 ...            robot/pmm/resources/pmm.py
 ...            robot/pmm/resources/ProgramPageObject.py
 Suite Setup     Run Keywords
-...             Open Test Browser
+...             Open test browser            useralias=${test_user}             AND
 ...             Setup Test Data
 Suite Teardown  Capture Screenshot and Delete Records and Close Browser
+
+*** Variables ***
+${test_user}             UUser
 
 *** Keywords ***
 Setup Test Data
@@ -23,12 +26,12 @@ Setup Test Data
     Set suite variable      ${description}
 
 
-
 *** Test Cases ***
 
 Create a Program via UI
     [Documentation]                        This test creates Program and verifies that the Program record
     ...                                    has all the values from the form
+    [tags]                                 perm:admin   perm:manage
     Go To PMM App
     Go To Page                              Listing                               ${ns}Program__c
     Click Object Button                     New
@@ -52,7 +55,7 @@ Create a Program via UI
 Date validation on new program dialog
     [Documentation]                        This test opens the new program dialog and enters a end date earlier than start date
     ...                                    and verifies that an error message is displayed
-    [tags]                                 W-041962  feature:Program
+    [tags]                                 W-041962    perm:admin   perm:manage    feature:Program
     Go To PMM App
     Go To Page                             Listing                               ${ns}Program__c
     Click Object Button                    New

--- a/robot/pmm/tests/browser/Program/pe_quickaction.robot
+++ b/robot/pmm/tests/browser/Program/pe_quickaction.robot
@@ -38,9 +38,7 @@ Setup Test Data
 
 *** Test Cases ***
 Add contact to program quick action on Program
-     [Documentation]                  Add a contact to a program using quick action and verify that the Program Engagement
-     ...                              related list is updated.
-     [tags]                           perm:admin    perm:manage    perm:deliver           feature: Program Engagement
+     [tags]                           perm:admin    perm:manage    perm:deliver
      Go To PMM App
      Go To Page                       Details                                 Program__c                    object_id=${program}[Id]
      page should contain              ${program}[Name]

--- a/robot/pmm/tests/browser/Program/pe_quickaction.robot
+++ b/robot/pmm/tests/browser/Program/pe_quickaction.robot
@@ -38,7 +38,9 @@ Setup Test Data
 
 *** Test Cases ***
 Add contact to program quick action on Program
-     [tags]                           perm:admin    perm:manage    perm:deliver
+     [Documentation]                  Add a contact to a program using quick action and verify that the Program Engagement
+     ...                              related list is updated.
+     [tags]                           perm:admin    perm:manage    perm:deliver      feature:Program Engagment
      Go To PMM App
      Go To Page                       Details                                 Program__c                    object_id=${program}[Id]
      page should contain              ${program}[Name]

--- a/robot/pmm/tests/browser/Program/pe_quickaction.robot
+++ b/robot/pmm/tests/browser/Program/pe_quickaction.robot
@@ -6,10 +6,12 @@ Library        cumulusci.robotframework.PageObjects
 ...            robot/pmm/resources/ProgramPageObject.py
 ...            robot/pmm/resources/ProgramEngagementPageObject.py
 Suite Setup     Run Keywords
-...             Open Test Browser
+...             Open test browser            useralias=${test_user}             AND
 ...             Setup Test Data
 Suite Teardown  Capture Screenshot and Delete Records and Close Browser
 
+*** Variables ***
+${test_user}             UUser
 
 *** Keywords ***
 Setup Test Data
@@ -36,6 +38,7 @@ Setup Test Data
 
 *** Test Cases ***
 Add contact to program quick action on Program
+     [tags]                           perm:admin    perm:manage    perm:deliver
      Go To PMM App
      Go To Page                       Details                                 Program__c                    object_id=${program}[Id]
      page should contain              ${program}[Name]
@@ -59,7 +62,7 @@ Add contact to program quick action on Program
 Validate cohort and PE look up to the same program
      [Documentation]                This test loads the program record, clicks on add contact to program quick action. Verifies that
      ...                            an error message is displayed when program cohort and PE do not lookup to the same program
-     [tags]                         W-042769  feature:Program Engagement
+     [tags]                         W-042769    perm:admin   perm:manage     perm:deliver   feature:Program Engagement
      Go To Page                     Details                                  Program__c           object_id=${program}[Id]
      Verify Details                 Program Name                             contains             ${program}[Name]
      Click Quick Action Button      Add Contact to Program
@@ -73,7 +76,7 @@ Validate cohort and PE look up to the same program
 Autopopulate fields when stage is set to Applied and Start Date is today
      [Documentation]                Autopopulates PE name with anonymous and verifies that application date is not set to today when  
      ...                            the stage is set as applied and start date is set to today on new program engagment dialog
-     [tags]                         W-037569   feature:Program Engagement
+     [tags]                         W-037569    perm:admin   perm:manage    perm:deliver     feature:Program Engagement
      Go To Page                              Details                                  Program__c           object_id=${program}[Id]
      Verify Details                          Program Name                             contains             ${program}[Name]
      Click Quick Action Button               Add Contact to Program 

--- a/robot/pmm/tests/browser/Program/pe_quickaction.robot
+++ b/robot/pmm/tests/browser/Program/pe_quickaction.robot
@@ -38,7 +38,9 @@ Setup Test Data
 
 *** Test Cases ***
 Add contact to program quick action on Program
-     [tags]                           perm:admin    perm:manage    perm:deliver
+     [Documentation]                  Add a contact to a program using quick action and verify that the Program Engagement
+     ...                              related list is updated.
+     [tags]                           perm:admin    perm:manage    perm:deliver           feature: Program Engagement
      Go To PMM App
      Go To Page                       Details                                 Program__c                    object_id=${program}[Id]
      page should contain              ${program}[Name]

--- a/robot/pmm/tests/browser/ProgramCohort/Create_Program_Cohort.robot
+++ b/robot/pmm/tests/browser/ProgramCohort/Create_Program_Cohort.robot
@@ -6,17 +6,14 @@ Library        cumulusci.robotframework.PageObjects
 ...            robot/pmm/resources/ProgramPageObject.py
 ...            robot/pmm/resources/ProgramCohortPageObject.py
 Suite Setup     Run Keywords
-#...             Initialize test user         AND
-...             Open test browser 
-#...             Open test browser            useralias=UUser           AND
+...             Open test browser            useralias=${test_user}             AND
 ...             Setup Test Data
-#Suite Teardown  Capture Screenshot and Delete Records and Close Browser
+Suite Teardown  Capture Screenshot and Delete Records and Close Browser
+
+*** Variables ***
+${test_user}             UUser
 
 *** Keywords ***
-#Initialize test user
-  #   ${test_user}=              Set Variable      UUser
-   #  Set Suite Variable         ${test_user}
-
 Setup Test Data                   
     ${ns} =                     Get PMM Namespace Prefix
     Set suite variable          ${ns}
@@ -32,7 +29,7 @@ Setup Test Data
 Create Program Cohort
      [Documentation]                        This test creates a program cohort and verifies the cohort
      ...                                    record matches the values entered in the form
-     [tags]                                 W-037572    feature:Program Cohort
+     [tags]                                 W-037572     perm:admin   perm:manage     feature:Program Cohort
      Go To PMM App
      Go To Page                             Listing                 ${ns}ProgramCohort__c   
      Click Object Button                    New
@@ -56,7 +53,7 @@ Create Program Cohort
 Date validation for cohort when Start date is later than end date
      [Documentation]                        This test opens the new program cohort dialog and enters a end date earlier than start date
      ...                                    and verifies that an error message is displayed
-     [tags]                                 W-037572  feature:Program Cohort
+     [tags]                                 W-037572    perm:admin   perm:manage      feature:Program Cohort
      Go To Page                             Listing                 ${ns}ProgramCohort__c   
      Click Object Button                    New
      Wait For Modal                         New                     Program Cohort
@@ -74,7 +71,7 @@ Date validation when cohort dates are not within program date range
      [Documentation]                        This test opens the program record, edits the start and end dates and opens new program
      ...                                    cohort dialog from related list and verifes that an error message is displayed when cohort date 
      ...                                    range is outside the program date range 
-     [tags]                                 W-037572  feature:Program Cohort
+     [tags]                                 W-037572    perm:admin   perm:manage      feature:Program Cohort
      Go To Page                             Details                                 Program__c                   object_id=${program1}[Id]
      Click Quick Action Button              Edit
      Verify Current Page Title              Edit ${program1}[Name]
@@ -91,7 +88,3 @@ Date validation when cohort dates are not within program date range
      Click Dialog Button                    Save
      Verify Modal Error                     End Date must be within the Program Start and End Dates
      Verify Modal Error                     Start Date must be within the range of the related Program Start and End Dates.
-
-Program detail test
-     Go To Page                             Details                                 Program__c                   object_id=${program1}[Id]
-     sleep                                   2s

--- a/robot/pmm/tests/browser/ProgramCohort/Create_Program_Cohort.robot
+++ b/robot/pmm/tests/browser/ProgramCohort/Create_Program_Cohort.robot
@@ -6,12 +6,18 @@ Library        cumulusci.robotframework.PageObjects
 ...            robot/pmm/resources/ProgramPageObject.py
 ...            robot/pmm/resources/ProgramCohortPageObject.py
 Suite Setup     Run Keywords
-...             Open Test Browser
+#...             Initialize test user         AND
+...             Open test browser 
+#...             Open test browser            useralias=UUser           AND
 ...             Setup Test Data
-Suite Teardown  Capture Screenshot and Delete Records and Close Browser
+#Suite Teardown  Capture Screenshot and Delete Records and Close Browser
 
 *** Keywords ***
-Setup Test Data
+#Initialize test user
+  #   ${test_user}=              Set Variable      UUser
+   #  Set Suite Variable         ${test_user}
+
+Setup Test Data                   
     ${ns} =                     Get PMM Namespace Prefix
     Set suite variable          ${ns}
     ${program_cohort} =         Generate Random String
@@ -86,4 +92,6 @@ Date validation when cohort dates are not within program date range
      Verify Modal Error                     End Date must be within the Program Start and End Dates
      Verify Modal Error                     Start Date must be within the range of the related Program Start and End Dates.
 
-     
+Program detail test
+     Go To Page                             Details                                 Program__c                   object_id=${program1}[Id]
+     sleep                                   2s

--- a/robot/pmm/tests/browser/ProgramEngagement/ProgramEngagement.robot
+++ b/robot/pmm/tests/browser/ProgramEngagement/ProgramEngagement.robot
@@ -6,9 +6,13 @@ Library        cumulusci.robotframework.PageObjects
 ...            robot/pmm/resources/ProgramEngagementPageObject.py
 ...            robot/pmm/resources/ProgramPageObject.py
 Suite Setup     Run Keywords
-...             Open Test Browser
+...             Open test browser            useralias=${test_user}             AND
 ...             Setup Test Data
 Suite Teardown  Capture Screenshot and Delete Records and Close Browser
+
+*** Variables ***
+${test_user}             UUser
+
 
 *** Keywords ***
 Setup Test Data
@@ -30,15 +34,15 @@ Setup Test Data
 *** Test Cases ***
 Create Program Engagement
      [Documentation]                         Creates a Program Engagement on Program Record by clicking "New" button in Related list.
-     [tags]                                  W-037565   feature:Program Engagement
+     [tags]                                  W-037565      pperm:admin   perm:manage       perm:deliver    feature:Program Engagement
      Go To PMM App
      Go To Page                              Listing                                ${ns}ProgramEngagement__c
      Click Object Button                     New
      Wait For Modal                          New                                    Program Engagement
      Populate Field                          Program Engagement Name                ${program_engagement_name}
+     Populate Lookup Field                   Program                                ${program}[Name]
+     Populate Lookup Field                   Client                                 ${contact}[FirstName] ${contact}[LastName]
      Populate Lightning Fields               Stage=Applied
-     ...                                     Client=${contact}[FirstName] ${contact}[LastName]
-     ...                                     Program=${program}[Name]
      ...                                     Role=Volunteer
      Click Dialog Button                     Save
      Wait Until Modal Is Closed
@@ -53,14 +57,14 @@ Create Program Engagement
 Create Program Engagement with Auto Name Override
     [Documentation]                         Creates a Program Engagement on Program Record by clicking "New" button in Related list
      ...                                    and Checking Auto-Name Override checkbox. Verify PE name is same as what user added.
-    [tags]                                  W-037577   feature:Program Engagement
+    [tags]                                  W-037577        perm:admin   perm:manage      perm:deliver    feature:Program Engagement
      Go To Page                             Listing                                ${ns}ProgramEngagement__c
      Click Object Button                    New
      Wait For Modal                         New                                    Program Engagement
      Populate Field                         Program Engagement Name                ${program_engagement_name}
+     Populate Lookup Field                  Program                                ${program}[Name]
+     Populate Lookup Field                  Client                                 ${contact}[FirstName] ${contact}[LastName]
      Populate Lightning fields              Stage=Applied
-     ...                                    Client=${contact}[FirstName] ${contact}[LastName]
-     ...                                    Program=${program}[Name]
      ...                                    Role=Volunteer
      Set Checkbox                           Auto-Name Override                      checked
      Click Dialog Button                    Save
@@ -72,14 +76,14 @@ Create Program Engagement with Auto Name Override
 Date validation for PE when start date is later than end date
      [Documentation]                        This test opens the new program engagement dialog and enters a end date earlier than start date
      ...                                    and verifies that an error message is displayed
-     [tags]                                 W-042238   feature:Program Engagement
+     [tags]                                 W-042238   perm:admin   perm:manage       perm:deliver    feature:Program Engagement
      Go To Page                             Listing                                ${ns}ProgramEngagement__c
      Click Object Button                    New
      Wait For Modal                         New                                    Program Engagement
      Populate Modal Form                    Program Engagement Name= ${program_engagement_name}
+     Populate Lookup Field                  Program                                ${program}[Name]
+     Populate Lookup Field                  Client                                 ${contact}[FirstName] ${contact}[LastName]
      Populate Lightning fields              Stage=Applied
-     ...                                    Client=${contact}[FirstName] ${contact}[LastName]
-     ...                                    Program=${program}[Name]
      ...                                    Role=Volunteer
      ...                                    Start Date=25
      ...                                    End Date=10
@@ -91,7 +95,7 @@ Date validation when program engagement dates are not within program date range
      [Documentation]                        This test opens the program record, edits the start and end dates and goes to the PE listing
      ...                                    page, clicks on new and verifes that an error message is displayed when PE date 
      ...                                    range is outside the program date range 
-     [tags]                                 W-042238   feature:Program Engagement
+     [tags]                                 W-042238   perm:admin   perm:manage     perm:deliver    feature:Program Engagement
      Go To Page                             Details                                 Program__c                   object_id=${program}[Id]
      Click Quick Action Button              Edit
      Verify Current Page Title              Edit ${program}[Name]
@@ -103,9 +107,9 @@ Date validation when program engagement dates are not within program date range
      Click Object Button                    New
      Wait For Modal                         New                                    Program Engagement
      Populate Modal Form                    Program Engagement Name= ${program_engagement_name}
+     Populate Lookup Field                  Program                                ${program}[Name]
+     Populate Lookup Field                  Client                                 ${contact}[FirstName] ${contact}[LastName]
      Populate Lightning fields              Stage=Applied
-     ...                                    Client=${contact}[FirstName] ${contact}[LastName]
-     ...                                    Program=${program}[Name]
      ...                                    Role=Volunteer
      Select From Date Picker                Start Date                               10
      Select From Date Picker                End Date                                 25
@@ -117,14 +121,14 @@ Date validation when program engagement dates are not within program date range
 Validate program cohort on new PE dialog
      [Documentation]                        This test opens the new program engagement dialog, enters a cohort that does not lookup to the
      ...                                    program entered the dialog, validates that an error message is displayed when saved
-     [tags]                                 W-042238   feature:Program Engagement
+     [tags]                                 W-042238    perm:admin   perm:manage     perm:deliver     feature:Program Engagement
      Go To Page                             Listing                                ${ns}ProgramEngagement__c
      Click Object Button                    New
      Wait For Modal                         New                                    Program Engagement
      Populate Field                         Program Engagement Name                ${program_engagement_name}
+     Populate Lookup Field                  Program                                ${program}[Name]
+     Populate Lookup Field                  Program Cohort                         ${program cohort1}[Name]
      Populate Lightning Fields              Stage=Applied
-     ...                                    Program=${program}[Name]
-     ...                                    Program Cohort=${program cohort1}[Name]
      ...                                    Role=Volunteer
      Click Dialog Button                    Save
      Verify Modal Error                     Select a Program Cohort that matches the Program.

--- a/robot/pmm/tests/browser/ProgramEngagement/autopopulate_pe_fields.robot
+++ b/robot/pmm/tests/browser/ProgramEngagement/autopopulate_pe_fields.robot
@@ -6,9 +6,12 @@ Library        cumulusci.robotframework.PageObjects
 ...            robot/pmm/resources/ProgramEngagementPageObject.py
 ...            robot/pmm/resources/ProgramPageObject.py
 Suite Setup     Run Keywords
-...             Open Test Browser
+...             Open test browser            useralias=${test_user}             AND
 ...             Setup Test Data
 Suite Teardown  Capture Screenshot and Delete Records and Close Browser
+
+*** Variables ***
+${test_user}             UUser
 
 *** Keywords ***
 Setup Test Data
@@ -42,14 +45,14 @@ Setup Test Data
 Autopopulate fields when stage is set to Applied
      [Documentation]                         Autopopulates application date and PE name with anonymous when the stage is set as 
      ...                                     applied on new program engagment dialog
-     [tags]                                  W-037569   feature:Program Engagement
+     [tags]                                  W-037569    perm:admin   perm:manage    perm:deliver   feature:Program Engagement
      Go To PMM App
      Go To Page                              Listing                         ${ns}ProgramEngagement__c
      Click Object Button                     New
      Wait For Modal                          New                             Program Engagement
      Populate Modal Form                     Program Engagement Name= ${program_engagement_name}
+     Populate Lookup Field                   Program                        ${program}[Name]
      Populate Lightning fields               Stage=Applied
-     ...                                     Program=${program}[Name]
      ...                                     Role=Volunteer
      Click Dialog Button                     Save
      Wait Until Modal Is Closed
@@ -60,14 +63,14 @@ Autopopulate fields when stage is set to Applied
 Autopopulate fields when stage is set to Completed
      [Documentation]                         Autopopulates end date and PE name with anonymous when the stage is set as 
      ...                                     completed on new program engagment dialog
-     [tags]                                  W-037569   feature:Program Engagement
+     [tags]                                  W-037569       perm:admin   perm:manage     perm:deliver      feature:Program Engagement
      Go To PMM App
      Go To Page                              Listing                         ${ns}ProgramEngagement__c
      Click Object Button                     New
      Wait For Modal                          New                             Program Engagement
      Populate Modal Form                     Program Engagement Name= ${program_engagement_name}
+     Populate Lookup Field                   Program                        ${program}[Name]
      Populate Lightning fields               Stage=Completed
-     ...                                     Program=${program}[Name]
      ...                                     Role=Volunteer
      Click Dialog Button                     Save
      Wait Until Modal Is Closed
@@ -78,14 +81,14 @@ Autopopulate fields when stage is set to Completed
 Autopopulate fields when stage is set to Withdrawn
      [Documentation]                         Autopopulates end date and PE name with anonymous when the stage is set as 
      ...                                     withdrawn on new program engagment dialog
-     [tags]                                  W-037569   feature:Program Engagement
+     [tags]                                  W-037569     perm:admin   perm:manage     perm:deliver   feature:Program Engagement
      Go To PMM App
      Go To Page                              Listing                         ${ns}ProgramEngagement__c
      Click Object Button                     New
      Wait For Modal                          New                             Program Engagement
      Populate Modal Form                     Program Engagement Name= ${program_engagement_name}
+     Populate Lookup Field                   Program                        ${program}[Name]
      Populate Lightning fields               Stage=Withdrawn
-     ...                                     Program=${program}[Name]
      ...                                     Role=Service Provider
      Click Dialog Button                     Save
      Wait Until Modal Is Closed
@@ -96,15 +99,15 @@ Autopopulate fields when stage is set to Withdrawn
 Autopopulate fields when stage is set to Active with Program start date is later than today
      [Documentation]                         Validates that start date is not set to today when stage is 'Active' and Program
      ...                                     start date is later than 'Today'
-     [tags]                                  W-8746330   feature:Program Engagement
+     [tags]                                  W-8746330      perm:admin   perm:manage     perm:deliver    feature:Program Engagement
      Go To PMM App
      Go To Page                              Listing                         ${ns}ProgramEngagement__c
      Click Object Button                     New
      Wait For Modal                          New                             Program Engagement
      Populate Modal Form                     Program Engagement Name= ${program_engagement_name}
      Select Value From Dropdown              Stage               Active
-     Populate Lightning fields               Program=${program1}[Name]                                   
-     ...                                     Role=Service Provider
+     Populate Lookup Field                   Program                        ${program1}[Name]
+     Populate Lightning fields               Role=Service Provider
      Click Dialog Button                     Save
      Wait Until Modal Is Closed
      Verify Details                          Start Date                      does not contain               ${today}
@@ -113,15 +116,15 @@ Autopopulate fields when stage is set to Active with Program start date is later
 Autopopulate fields when stage is set to Active with Program start date is today
      [Documentation]                         Validates that start date is set to today when stage is 'Active' and Program
      ...                                     start date is than 'Today'
-     [tags]                                  W-8746330   feature:Program Engagement
+     [tags]                                  W-8746330      perm:admin   perm:manage     perm:deliver    feature:Program Engagement
      Go To PMM App
      Go To Page                              Listing                         ${ns}ProgramEngagement__c
      Click Object Button                     New
      Wait For Modal                          New                             Program Engagement
      Populate Modal Form                     Program Engagement Name= ${program_engagement_name}
      Select Value From Dropdown              Stage               Active
-     Populate Lightning fields               Program=${program2}[Name]                                   
-     ...                                     Role=Service Provider
+     Populate Lookup Field                   Program                        ${program2}[Name]
+     Populate Lightning fields               Role=Service Provider
      Click Dialog Button                     Save
      Wait Until Modal Is Closed
      Verify Details                          Start Date                      contains               ${today}
@@ -130,15 +133,15 @@ Autopopulate fields when stage is set to Active with Program start date is today
 Autopopulate fields when stage is set to Applied with Program start date is earlier than today
      [Documentation]                         Validates that application date is not set to today when stage is 'Active' and Program
      ...                                     start date is earlier than 'Today'
-     [tags]                                  W-8746330   feature:Program Engagement
+     [tags]                                  W-8746330      perm:admin   perm:manage     perm:deliver    feature:Program Engagement
      Go To PMM App
      Go To Page                              Listing                         ${ns}ProgramEngagement__c
      Click Object Button                     New
      Wait For Modal                          New                             Program Engagement
      Populate Modal Form                     Program Engagement Name= ${program_engagement_name}
      Select Value From Dropdown              Stage               Applied
-     Populate Lightning fields               Program=${program3}[Name]                                   
-     ...                                     Role=Service Provider
+     Populate Lookup Field                   Program                        ${program3}[Name]
+     Populate Lightning fields               Role=Service Provider
      Populate Field                          Start Date               ${start_date}
      Click Dialog Button                     Save
      Wait Until Modal Is Closed

--- a/robot/pmm/tests/browser/ProgramEngagement/quick_actions_sd.robot
+++ b/robot/pmm/tests/browser/ProgramEngagement/quick_actions_sd.robot
@@ -6,9 +6,12 @@ Library         cumulusci.robotframework.PageObjects
 ...             robot/pmm/resources/ProgramEngagementPageObject.py
 ...             robot/pmm/resources/ServiceDeliveryPageObject.py
 Suite Setup     Run Keywords
-...             Open Test Browser
+...             Open test browser            useralias=${test_user}             AND
 ...             Setup Test Data
 Suite Teardown  Capture Screenshot and Delete Records and Close Browser
+
+*** Variables ***
+${test_user}             UUser
 
 *** Keywords ***
 Setup Test Data
@@ -33,13 +36,13 @@ Setup Test Data
 Create a new service delivery using quick action
      [Documentation]                This test loads the program engagement record, clicks on the new service delivery quick action and creates
      ...                            new service delivery record.
-     [tags]                         W-037572  feature:Service Delivery
+     [tags]                         W-037572        perm:admin   perm:manage       perm:deliver    feature:Service Delivery
      Go To PMM App
      Go To Page                     Details                        ProgramEngagement__c      object_id=${program_engagement}[Id]
      Verify Details                 Program Engagement Name        contains                   ${contact}[FirstName] ${contact}[LastName] ${today}: ${program}[Name]
      Click Quick Action Button      Create New Service Delivery
-     Populate Modal Form            Service=${service}[Name]
-     ...                            Quantity=${quantity}
+     Populate Lookup Field          Service                        ${service}[Name]
+     Populate Modal Form            Quantity=${quantity}
      Select Button On Modal         Save
      Wait Until Modal Is Closed
      Current Page Should Be         Details                         ProgramEngagement__c

--- a/robot/pmm/tests/browser/Service/new_service.robot
+++ b/robot/pmm/tests/browser/Service/new_service.robot
@@ -27,8 +27,10 @@ Setup Test Data
     Set suite variable          ${program}
 
 *** Test Cases ***
-Create Service from top nav
-    [tags]                                  perm:admin   perm:manage 
+Create a new Service
+    [Documentation]                        This test creates a new Service record and verifies that the Service record
+    ...                                    has all the values in the dialog.
+    [tags]                                  perm:admin   perm:manage        feature:Service
      Go To PMM App
      Go To Page                             Listing                     ${ns}Service__c
      Click Object Button                    New

--- a/robot/pmm/tests/browser/Service/new_service.robot
+++ b/robot/pmm/tests/browser/Service/new_service.robot
@@ -5,9 +5,12 @@ Library        cumulusci.robotframework.PageObjects
 ...            robot/pmm/resources/pmm.py
 ...            robot/pmm/resources/ServicePageObject.py
 Suite Setup     Run Keywords
-...             Open Test Browser
+...             Open test browser            useralias=${test_user}             AND
 ...             Setup Test Data
 Suite Teardown  Capture Screenshot and Delete Records and Close Browser
+
+*** Variables ***
+${test_user}             UUser
 
 *** Keywords ***
 Setup Test Data
@@ -25,6 +28,7 @@ Setup Test Data
 
 *** Test Cases ***
 Create Service from top nav
+    [tags]                                  perm:admin   perm:manage 
      Go To PMM App
      Go To Page                             Listing                     ${ns}Service__c
      Click Object Button                    New
@@ -33,9 +37,9 @@ Create Service from top nav
      Populate Field                         Service Name                ${service_name}
      Populate Field                         Description                 ${Description}
      Populate Field                         Unit of Measurement         ${unit_of_measurement}
-     Populate Lightning Fields              Program=${program}[Name]
-     ...                                    Status=Active
-     click Dialog button                    Save
+     Populate Lookup Field                  Program                     ${program}[Name]
+     Populate Lightning Fields              Status=Active
+     Click Dialog button                    Save
      Wait Until Modal Is Closed
      verify details                         Program            contains          ${program}[Name]
      verify details                         Service Name       contains          ${service_name}

--- a/robot/pmm/tests/browser/Service/new_service.robot
+++ b/robot/pmm/tests/browser/Service/new_service.robot
@@ -27,10 +27,8 @@ Setup Test Data
     Set suite variable          ${program}
 
 *** Test Cases ***
-Create a new Service
-    [Documentation]                        This test creates a new Service record and verifies that the Service record
-    ...                                    has all the values in the dialog.
-    [tags]                                  perm:admin   perm:manage        feature:Service
+Create Service from top nav
+    [tags]                                  perm:admin   perm:manage 
      Go To PMM App
      Go To Page                             Listing                     ${ns}Service__c
      Click Object Button                    New

--- a/robot/pmm/tests/browser/Service/new_service.robot
+++ b/robot/pmm/tests/browser/Service/new_service.robot
@@ -28,7 +28,9 @@ Setup Test Data
 
 *** Test Cases ***
 Create Service from top nav
-    [tags]                                  perm:admin   perm:manage 
+    [Documentation]                        This test creates Service record and verifies that the Service record
+    ...                                    has all the values from the form
+    [tags]                                  perm:admin   perm:manage    feature:Service
      Go To PMM App
      Go To Page                             Listing                     ${ns}Service__c
      Click Object Button                    New

--- a/robot/pmm/tests/browser/Service/quickactions_service.robot
+++ b/robot/pmm/tests/browser/Service/quickactions_service.robot
@@ -6,9 +6,12 @@ Library         cumulusci.robotframework.PageObjects
 ...             robot/pmm/resources/ServiceDeliveryPageObject.py
 ...             robot/pmm/resources/ServicePageObject.py
 Suite Setup     Run Keywords
-...             Open Test Browser
+...             Open test browser            useralias=${test_user}             AND
 ...             Setup Test Data
 Suite Teardown  Capture Screenshot and Delete Records and Close Browser
+
+*** Variables ***
+${test_user}             UUser
 
 *** Keywords ***
 Setup Test Data
@@ -38,7 +41,7 @@ Setup Test Data
 Create a new service delivery on service using quick action
      [Documentation]                This test loads the service record, clicks on the new service delivery quick action and creates
      ...                            new service delivery record.
-     [tags]                         W-042516  feature:Service Delivery
+     [tags]                         W-042516      perm:admin   perm:manage    perm:deliver    feature:Service Delivery
      Go To PMM App
      Go To Page                     Details                        Service__c           object_id=${service}[Id]
      Verify Details                 Service Name                   contains                  ${service}[Name]
@@ -57,7 +60,7 @@ Create a new service delivery on service using quick action
 Validate service and program engagement lookup to same program
      [Documentation]                This test loads the program engagement record, clicks on the new service delivery quick action and
      ...                            validates an error message is displayed when service and program engagement do not lookup to the same program
-     [tags]                         W-042516  feature:Service Delivery
+     [tags]                         W-042516      perm:admin   perm:manage    perm:deliver   feature:Service Delivery
      Go To Page                     Details                        Service__c           object_id=${service}[Id]
      Verify Details                 Service Name                   contains                  ${service}[Name]
      Click Quick Action Button      Create New Service Delivery

--- a/robot/pmm/tests/browser/ServiceDeliveries/new_service_delivery.robot
+++ b/robot/pmm/tests/browser/ServiceDeliveries/new_service_delivery.robot
@@ -38,7 +38,7 @@ Setup Test Data
 Create a Service Delivery via UI
     [Documentation]                        This test creates Service Delivery record and verifies that the Service Delivery record
     ...                                    has all the values from the form
-    [tags]                                 perm:admin   perm:manage     perm:deliver     feature:Service Deliver
+    [tags]                                 perm:admin   perm:manage     perm:deliver     feature:Service Delivery
     Go To PMM App
     Go To Page                             Listing                                 ${ns}ServiceDelivery__c
     Click Object Button                    New
@@ -62,7 +62,7 @@ Create a Service Delivery via UI
 Create a Service Delivery via UI with Auto Name Override
     [Documentation]                        This test creates Service Delivery record with auto name override selected and verifies
     ...                                    user entered name is saved as the service delivery name
-    [tags]                                 perm:admin   perm:manage    perm:deliver
+    [tags]                                 perm:admin   perm:manage    perm:deliver         feature:Service Delivery
     Go To Page                             Listing                                ${ns}ServiceDelivery__c
     Click Object Button                    New
     Wait For Modal                         New                                    Service Delivery

--- a/robot/pmm/tests/browser/ServiceDeliveries/new_service_delivery.robot
+++ b/robot/pmm/tests/browser/ServiceDeliveries/new_service_delivery.robot
@@ -38,7 +38,7 @@ Setup Test Data
 Create a Service Delivery via UI
     [Documentation]                        This test creates Service Delivery record and verifies that the Service Delivery record
     ...                                    has all the values from the form
-    [tags]                                 perm:admin   perm:manage     perm:deliver     feature:Service Delivery
+    [tags]                                 perm:admin   perm:manage     perm:deliver     feature:Service Deliver
     Go To PMM App
     Go To Page                             Listing                                 ${ns}ServiceDelivery__c
     Click Object Button                    New
@@ -62,7 +62,7 @@ Create a Service Delivery via UI
 Create a Service Delivery via UI with Auto Name Override
     [Documentation]                        This test creates Service Delivery record with auto name override selected and verifies
     ...                                    user entered name is saved as the service delivery name
-    [tags]                                 perm:admin   perm:manage    perm:deliver         feature:Service Delivery
+    [tags]                                 perm:admin   perm:manage    perm:deliver
     Go To Page                             Listing                                ${ns}ServiceDelivery__c
     Click Object Button                    New
     Wait For Modal                         New                                    Service Delivery

--- a/robot/pmm/tests/browser/ServiceDeliveries/new_service_delivery.robot
+++ b/robot/pmm/tests/browser/ServiceDeliveries/new_service_delivery.robot
@@ -5,10 +5,12 @@ Library        cumulusci.robotframework.PageObjects
 ...            robot/pmm/resources/pmm.py
 ...            robot/pmm/resources/ServiceDeliveryPageObject.py
 Suite Setup     Run Keywords
-...             Open Test Browser
+...             Open test browser            useralias=${test_user}             AND
 ...             Setup Test Data
 Suite Teardown  Capture Screenshot and Delete Records and Close Browser
 
+*** Variables ***
+${test_user}             UUser
 
 *** Keywords ***
 Setup Test Data
@@ -36,16 +38,17 @@ Setup Test Data
 Create a Service Delivery via UI
     [Documentation]                        This test creates Service Delivery record and verifies that the Service Delivery record
     ...                                    has all the values from the form
+    [tags]                                 perm:admin   perm:manage     perm:deliver     feature:Service Deliver
     Go To PMM App
     Go To Page                             Listing                                 ${ns}ServiceDelivery__c
     Click Object Button                    New
     Wait For Modal                         New                                     Service Delivery
     Populate Field                         Service Delivery Name                   ${service_delivery_name}
     Populate Field                         Quantity                                ${quantity}
-    Populate Lightning Fields              Service=${service}[Name]
-    ...                                    Client=${contact}[FirstName] ${contact}[LastName]
-    ...                                    Program Engagement=${program_engagement}[Name]
-    ...                                    Delivery Date=Today                                
+    Populate Lookup Field                  Service                                 ${service}[Name]
+    Populate Lookup Field                  Client                                  ${contact}[FirstName] ${contact}[LastName]
+    Populate Lookup Field                  Program Engagement                      ${program_engagement}[Name]
+    Populate Lightning Fields              Delivery Date=Today                                
     Click Dialog Button                    Save
     Wait Until Modal Is Closed
     Current Page Should Be                 Details                                 ServiceDelivery__c
@@ -59,15 +62,16 @@ Create a Service Delivery via UI
 Create a Service Delivery via UI with Auto Name Override
     [Documentation]                        This test creates Service Delivery record with auto name override selected and verifies
     ...                                    user entered name is saved as the service delivery name
+    [tags]                                 perm:admin   perm:manage    perm:deliver
     Go To Page                             Listing                                ${ns}ServiceDelivery__c
     Click Object Button                    New
     Wait For Modal                         New                                    Service Delivery
     Populate Field                         Service Delivery Name                   ${service_delivery_name}
     Populate Field                         Quantity                                ${quantity}
-    Populate Lightning Fields              Service=${service}[Name]
-    ...                                    Client=${contact}[FirstName] ${contact}[LastName]
-    ...                                    Program Engagement=${program_engagement}[Name]
-    ...                                    Delivery Date=Today
+    Populate Lookup Field                  Service                                 ${service}[Name]
+    Populate Lookup Field                  Client                                  ${contact}[FirstName] ${contact}[LastName]
+    Populate Lookup Field                  Program Engagement                      ${program_engagement}[Name]
+    Populate Lightning Fields              Delivery Date=Today
     Set Checkbox                           Auto-name Override                      checked
     Click Dialog Button                    Save
     Wait Until Modal Is Closed
@@ -80,14 +84,14 @@ Create a Service Delivery via UI with Auto Name Override
 Validate contact and account lookup to the same household
     [Documentation]                        This test loads the new service delivery dialog and validates that an error message is displayed
     ...                                    when contact and account do not lookup to the same household
-    [tags]                                 W-042516  feature:Service Delivery
+    [tags]                                 W-042516   perm:admin   perm:manage    perm:deliver    feature:Service Delivery
     Go To Page                             Listing                                ${ns}ServiceDelivery__c
     Click Object Button                    New
     Wait For Modal                         New                                    Service Delivery
     Populate Field                         Service Delivery Name                  ${service_delivery_name}
-    Populate Lightning Fields              Service=${service}[Name]
-    ...                                    Client=${contact}[FirstName] ${contact}[LastName]
-    ...                                    Household Account=${account1}[Name]
+    Populate Lookup Field                  Service                                ${service}[Name]
+    Populate Lookup Field                  Client                                 ${contact}[FirstName] ${contact}[LastName]
+    Populate Lookup Field                  Household Account                      ${account1}[Name]
     Click Dialog Button                    Save
     Verify Modal Error                     Select an Account that matches the related Contact.
     

--- a/robot/pmm/tests/browser/ServiceParticipant/new_service_participant.robot
+++ b/robot/pmm/tests/browser/ServiceParticipant/new_service_participant.robot
@@ -4,10 +4,12 @@ Resource       robot/pmm/resources/pmm.robot
 Library        cumulusci.robotframework.PageObjects
 ...            robot/pmm/resources/ServiceParticipantPageObject.py
 Suite Setup     Run Keywords
-...             Open Test Browser
+...             Open test browser            useralias=${test_user}             AND
 ...             Setup Test Data
 Suite Teardown  Capture Screenshot and Delete Records and Close Browser
 
+*** Variables ***
+${test_user}             UUser
 
 *** Keywords ***
 Setup Test Data
@@ -31,16 +33,16 @@ Setup Test Data
 Create a new service participant
     [Documentation]                         Navigates to service participant listing page, clicks 'New' on the listing page and
     ...                                     creates a new record, validates the details on the service participant record
-    [tags]                                  W-8289333        feature:Service Participant
+    [tags]                                  W-8289333     perm:admin     perm:manage     perm:deliver      feature:Service Participant
      Go To PMM App
      Go To Page                              Listing                                ${ns}ServiceParticipant__c
      Click Object Button                     New
      Wait For Modal                          New                                    Service Participant
      Populate Field                          Service Participant Name               ${service_participant_name}
-     Populate Lightning Fields               Contact=${contact}[Name]
-     ...                                     Status=Waitlisted
-     ...                                     Service=${service}[Name]
-     ...                                     Program Engagement=${program_engagement}[Name]     
+     Populate Lookup Field                   Service                                ${service}[Name]
+     Populate Lookup Field                   Contact                                ${contact}[Name]
+     Populate Lookup Field                   Program Engagement                     ${program_engagement}[Name]
+     Populate Lightning Fields               Status=Waitlisted
      Click Dialog Button                     Save
      Wait Until Modal Is Closed
      Verify Details                          Service Participant Name        contains       ${service_participant_name}

--- a/robot/pmm/tests/browser/ServiceSchedule/new_service_schedule.robot
+++ b/robot/pmm/tests/browser/ServiceSchedule/new_service_schedule.robot
@@ -5,10 +5,12 @@ Library        cumulusci.robotframework.PageObjects
 ...            robot/pmm/resources/ServiceSchedulePageObject.py
 ...            robot/pmm/resources/ServicePageObject.py
 Suite Setup     Run Keywords
-...             Open Test Browser
+...             Open test browser            useralias=${test_user}             AND
 ...             Setup Test Data
 Suite Teardown  Capture Screenshot and Delete Records and Close Browser
 
+*** Variables ***
+${test_user}             UUser
 
 *** Keywords ***
 Setup Test Data
@@ -42,7 +44,7 @@ Setup Test Data
 Create a New Service Schedule
     [Documentation]                        Navigates to service schedule listing page, clicks 'New' on the listing page and
     ...                                    creates a new record using the wizard, validates the details on the service schedule record
-    [tags]                                 W-8294332        feature:Service Schedule
+    [tags]                                 W-8294332     perm:admin   perm:manage         feature:Service Schedule
     Go To PMM App
     Go To Page                              Details                        Service__c           object_id=${service}[Id]
     Click Wrapper Related List Button       Service Schedules              New
@@ -50,8 +52,8 @@ Create a New Service Schedule
     Verify Wizard Screen Title              Service Schedule Information
     Populate Field                          Service Schedule Name               ${service_schedule_name}
     Populate Field                          Participant Capacity                10
-    Populate Lightning Fields               Primary Service Provider=${contact}[Name]
-    ...                                     Date=Today
+    Populate Lookup Field                   Primary Service Provider            ${contact}[Name]
+    Populate Lightning Fields               Date=Today
     Click Dialog Button                     Next
     Verify Wizard Screen Title              Review Service Sessions
     Click Dialog Button                     Next

--- a/robot/pmm/tests/browser/ServiceSchedule/service_schedule_layout.robot
+++ b/robot/pmm/tests/browser/ServiceSchedule/service_schedule_layout.robot
@@ -5,9 +5,12 @@ Library        cumulusci.robotframework.PageObjects
 ...            robot/pmm/resources/ServiceSchedulePageObject.py
 ...            robot/pmm/resources/ServicePageObject.py
 Suite Setup     Run Keywords
-...             Open Test Browser
+...             Open test browser            useralias=${test_user}             AND
 ...             Setup Test Data
 Suite Teardown  Capture Screenshot and Delete Records and Close Browser
+
+*** Variables ***
+${test_user}             UUser
 
 *** Keywords ***
 Setup Test Data
@@ -37,7 +40,7 @@ Add Service Participant quick action
     [Documentation]                        Navigates to service schedule details page, creates two PE using API and clicks on Add service
     ...                                    Participants quick action, add more participants and Save. Validates that the contact name is 
     ...                                    displayed on the service schedule page
-    [tags]                                 W-8720124        feature:Service Schedule
+    [tags]                                 W-8720124     perm:admin   perm:manage         feature:Service Schedule
     Go To PMM App   
     Go To Page                              Details                        ServiceSchedule__c           object_id=${service_schedule}[Id]
     API Create Program Engagement   ${Program}[Id]  ${contact2}[Id]

--- a/robot/pmm/tests/browser/ServiceSchedule/service_schedule_screen2.robot
+++ b/robot/pmm/tests/browser/ServiceSchedule/service_schedule_screen2.robot
@@ -5,10 +5,12 @@ Library        cumulusci.robotframework.PageObjects
 ...            robot/pmm/resources/ServiceSchedulePageObject.py
 ...            robot/pmm/resources/ServicePageObject.py
 Suite Setup     Run Keywords
-...             Open Test Browser
+...             Open test browser            useralias=${test_user}             AND
 ...             Setup Test Data
 Suite Teardown  Capture Screenshot and Delete Records and Close Browser
 
+*** Variables ***
+${test_user}             UUser
 
 *** Keywords ***
 Setup Test Data
@@ -29,7 +31,7 @@ Max number of service session
     [Documentation]                 Validates that only 500 sessions are created when entering a higher value on Screen1.
     ...                             Validates that a warning message is displayed on Screen2  and is removed when one service session
     ...                             is deleted.
-    [tags]                           W-8559800       feature:Service Schedule
+    [tags]                           W-8559800      perm:admin   perm:manage       feature:Service Schedule
     Go To PMM App   
     Go To Page                              Details                        Service__c           object_id=${service}[Id]
     Click Wrapper Related List Button       Service Schedules              New

--- a/robot/pmm/tests/browser/ServiceSchedule/service_schedule_screen3.robot
+++ b/robot/pmm/tests/browser/ServiceSchedule/service_schedule_screen3.robot
@@ -5,9 +5,13 @@ Library        cumulusci.robotframework.PageObjects
 ...            robot/pmm/resources/ServiceSchedulePageObject.py
 ...            robot/pmm/resources/ServicePageObject.py
 Suite Setup     Run Keywords
-...             Open Test Browser
+...             Open test browser            useralias=${test_user}             AND
 ...             Setup Test Data
 Suite Teardown  Capture Screenshot and Delete Records and Close Browser
+
+*** Variables ***
+${test_user}             UUser
+
 
 *** Keywords ***
 Setup Test Data
@@ -39,7 +43,7 @@ Setup Test Data
 Add/remove service participants on Screen3
     [Documentation]                        On service schedule wizard, add/remove service participants on screen 3 and validate that the
     ...                                    added participants are displayed on screen 4 and when the wizard is saved
-    [tags]                                 W-8449817       feature:Service Schedule
+    [tags]                                 W-8449817    perm:admin    perm:manage        feature:Service Schedule
     Go To PMM App
     Go To Page                              Details                        Service__c           object_id=${service}[Id]
     Click Wrapper Related List Button       Service Schedules              New

--- a/robot/pmm/tests/browser/ServiceSchedule/service_schedule_screen4.robot
+++ b/robot/pmm/tests/browser/ServiceSchedule/service_schedule_screen4.robot
@@ -5,9 +5,12 @@ Library        cumulusci.robotframework.PageObjects
 ...            robot/pmm/resources/ServiceSchedulePageObject.py
 ...            robot/pmm/resources/ServicePageObject.py
 Suite Setup     Run Keywords
-...             Open Test Browser
+...             Open test browser            useralias=${test_user}             AND
 ...             Setup Test Data
 Suite Teardown  Capture Screenshot and Delete Records and Close Browser
+
+*** Variables ***
+${test_user}             UUser
 
 *** Keywords ***
 Setup Test Data
@@ -24,7 +27,7 @@ Setup Test Data
 Verify screen4 when no sessions and participants are added
     [Documentation]                        On service schedule wizard, uncheck create service sessions checkbox and do not add service participants
     ...                                    and validate the message displayed on Screen 4
-    [tags]                                 W-8515142       feature:Service Schedule
+    [tags]                                 W-8515142    perm:admin   perm:manage        feature:Service Schedule
     Go To PMM App
     Go To Page                              Details                        Service__c           object_id=${service}[Id]
     Click Wrapper Related List Button       Service Schedules              New

--- a/robot/pmm/tests/browser/ServiceSchedule/view_perms_layout.robot
+++ b/robot/pmm/tests/browser/ServiceSchedule/view_perms_layout.robot
@@ -5,9 +5,12 @@ Library        cumulusci.robotframework.PageObjects
 ...            robot/pmm/resources/ServiceSchedulePageObject.py
 ...            robot/pmm/resources/ServicePageObject.py
 Suite Setup     Run Keywords
-...             Open Test Browser       
+...             Open test browser            useralias=${test_user}        AND
 ...             Setup Test Data
 Suite Teardown  Capture Screenshot and Delete Records and Close Browser
+
+*** Variables ***
+${test_user}             UUser
 
 *** Keywords ***
 Setup Test Data
@@ -36,8 +39,7 @@ Setup Test Data
 View Perms Add Service Participant quick action
     [Documentation]                        Logged in as a non admin user with view perm sets, navigates to service schedule details page, clicks on Add service
     ...                                    Participants quick action, and validates that a warning message is displayed
-    [tags]                                 unstable        feature:view_perms
-    Open Test Browser                      useralias=rosa
+    [tags]                                 unstable         perm:view      feature:Service Schedule
     Go To PMM App   
     Go To Page                              Details                        ServiceSchedule__c           object_id=${service_schedule}[Id]
     Click Quick Action Button               Add More Participants

--- a/robot/pmm/tests/browser/ServiceSchedule/view_perms_layout.robot
+++ b/robot/pmm/tests/browser/ServiceSchedule/view_perms_layout.robot
@@ -1,0 +1,44 @@
+*** Settings ***
+
+Resource       robot/pmm/resources/pmm.robot
+Library        cumulusci.robotframework.PageObjects
+...            robot/pmm/resources/ServiceSchedulePageObject.py
+...            robot/pmm/resources/ServicePageObject.py
+Suite Setup     Run Keywords
+...             Open Test Browser       
+...             Setup Test Data
+Suite Teardown  Capture Screenshot and Delete Records and Close Browser
+
+*** Keywords ***
+Setup Test Data
+    [Documentation]                 Creates a Service Schedule, Service Participant and PE using API.
+    ${ns} =                         Get PMM Namespace Prefix
+    Set suite variable              ${ns}
+    ${contact1}                     API Create Contact
+    Set suite variable              ${contact1}
+    ${contact2}                     API Create Contact
+    Set suite variable              ${contact2}
+    ${contact3}                     API Create Contact
+    Set suite variable              ${contact3}
+    ${program} =                    API Create Program
+    Set suite variable              ${program}
+    ${service} =                    API Create Service                  ${Program}[Id]
+    Set suite variable              ${service}
+    ${service_schedule} =           API Create Service Schedule         ${service}[Id]
+    Set suite variable              ${service_schedule}
+    ${program_engagement} =         API Create Program Engagement   ${Program}[Id]     ${contact1}[Id]
+    Set suite variable              ${program_engagement}
+    ${service_participant1} =       API Create Service Participant  ${contact1}[Id]   ${service_schedule}[Id]  ${service}[Id]
+    Set suite variable              ${service_participant1}
+
+
+*** Test Cases ***
+View Perms Add Service Participant quick action
+    [Documentation]                        Logged in as a non admin user with view perm sets, navigates to service schedule details page, clicks on Add service
+    ...                                    Participants quick action, and validates that a warning message is displayed
+    [tags]                                 unstable        feature:view_perms
+    Open Test Browser                      useralias=rosa
+    Go To PMM App   
+    Go To Page                              Details                        ServiceSchedule__c           object_id=${service_schedule}[Id]
+    Click Quick Action Button               Add More Participants
+    Page Should Contain                     You don't have access to this information. Ask your admin for help.

--- a/robot/pmm/tests/browser/ServiceSession/new_service_session.robot
+++ b/robot/pmm/tests/browser/ServiceSession/new_service_session.robot
@@ -4,9 +4,12 @@ Resource       robot/pmm/resources/pmm.robot
 Library        cumulusci.robotframework.PageObjects
 ...            robot/pmm/resources/ServiceSessionPageObject.py
 Suite Setup     Run Keywords
-...             Open Test Browser
+...             Open test browser            useralias=${test_user}             AND
 ...             Setup Test Data
 Suite Teardown  Capture Screenshot and Delete Records and Close Browser
+
+*** Variables ***
+${test_user}             UUser
 
 
 *** Keywords ***
@@ -30,15 +33,15 @@ Setup Test Data
 Create a new service session
     [Documentation]                        Navigates to service session listing page, clicks 'New' on the listing page and
     ...                                    creates a new record, validates the details on the service session record
-    [tags]                                 W-8294332        feature:Service Session
+    [tags]                                 W-8294332     perm:admin   perm:manage         feature:Service Session
      Go To PMM App
      Go To Page                              Listing                                ${ns}ServiceSession__c
      Click Object Button                     New
      Load Page Object                        New                                    ServiceSession__c
      Populate Field                          Service Session Name                   ${service_session_name}
-     Populate Lightning Fields               Service Schedule=${service_schedule}[Name]
-     ...                                     Status=Complete
-     ...                                     Primary Service Provider=${contact}[Name]
+     Populate Lookup Field                   Service Schedule                       ${service_schedule}[Name]
+     Populate Lookup Field                   Primary Service Provider               ${contact}[Name]
+     Populate Lightning Fields               Status=Complete
      Select Session Date                     Session Start          Today
      Click Dialog Button                     Save
      Wait Until Modal Is Closed


### PR DESCRIPTION
1. Enable test for non admin users
2. Added test for View Perm set: Add More Service Participants quick action

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
- [ ] Any net new LWC work has Sa11y tests & 50% or above lines JEST test coverage  
- [ ] CRUD/FLS is enforced in Apex
- [ ] Permission sets are updated to account for CRUD|FLS|Tab|Classes
- [ ] Field sets are updated to account for new fields
- [ ] UX approval or UX not necessary
- [ ] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: W-0000000: Work Name (https://github.com/SalesforceFoundation/PMM/pull/303)
- [ ] All **acceptance criteria** have been met
    - [ ] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [ ] PR contains draft release notes
- [ ] QE story level testing completed