### PR TITLE
[Robot] Added tests for PMM homepage

### DIFF
--- a/robot/pmm/doc/Keywords.html
+++ b/robot/pmm/doc/Keywords.html
@@ -735,6 +735,27 @@
                                 <td class="kwdoc"></td>
                             </tr>
 
+                            <tr class="kwrow" id="pmm.robot.API Create Service Delivery">
+                                <td class="kwname">
+                                    API Create Service Delivery
+                                </td>
+                                <td class="kwargs">
+                                    <i>contact_id</i>,
+
+                                    <i>program_engagement_id</i>,
+
+                                    <i>service_id</i>,
+
+                                    <i>**fields</i>
+                                </td>
+                                <td class="kwdoc">
+                                    <p>
+                                        Creates a new Service Delivery record. Service
+                                        Delivery details are passed as key value pairs.
+                                    </p>
+                                </td>
+                            </tr>
+
                             <tr
                                 class="kwrow"
                                 id="pmm.robot.API Create Service Participant"
@@ -2878,7 +2899,7 @@
             </div>
         </div>
         <div class="footer">
-            Generated on Friday February 12, 11:40 AM - cumulusci v3.28.0
+            Generated on Tuesday March 23, 01:34 PM - cumulusci v3.31.0
         </div>
     </body>
 </html>

--- a/robot/pmm/resources/HomePageObject.py
+++ b/robot/pmm/resources/HomePageObject.py
@@ -1,9 +1,12 @@
+import time
+
 from cumulusci.robotframework.pageobjects import BasePage
 from cumulusci.robotframework.pageobjects import pageobject
+from pmm import pmm_lex_locators
 
 
 @pageobject("Home", "Homepage")
-class CasemanHomePage(BasePage):
+class PMMHomePage(BasePage):
     object_name = None
 
     def _go_to_page(self, **kwargs):
@@ -12,3 +15,11 @@ class CasemanHomePage(BasePage):
         url = "{}/lightning/page/home".format(url)
         self.selenium.go_to(url)
         self.salesforce.wait_until_loading_is_complete()
+        time.sleep(2)
+
+    def verify_component_on_homepage(self, component_name):
+        """ Validates the component is displayed on home page given component name """
+        locator = pmm_lex_locators["homepage"]["component_link"].format(component_name)
+        self.selenium.wait_until_page_contains_element(
+            locator, error=f"Component '{component_name}' is not displayed"
+        )

--- a/robot/pmm/resources/HomePageObject.py
+++ b/robot/pmm/resources/HomePageObject.py
@@ -1,0 +1,14 @@
+from cumulusci.robotframework.pageobjects import BasePage
+from cumulusci.robotframework.pageobjects import pageobject
+
+
+@pageobject("Home", "Homepage")
+class CasemanHomePage(BasePage):
+    object_name = None
+
+    def _go_to_page(self, **kwargs):
+        """To go to Home page"""
+        url = self.cumulusci.org.lightning_base_url
+        url = "{}/lightning/page/home".format(url)
+        self.selenium.go_to(url)
+        self.salesforce.wait_until_loading_is_complete()

--- a/robot/pmm/resources/locators_51.py
+++ b/robot/pmm/resources/locators_51.py
@@ -108,4 +108,7 @@ pmm_lex_locators = {
         "dim_icon": "//c-attendance-row[{}]//button[contains(@class,'slds-button')]/lightning-primitive-icon",
         "details": "//c-attendance-row[{}]//*[self::div or self::lightning-output-field][contains(@class,'slds-form-element_stacked')][.//*[text()='{}']]//div[@class='slds-form-element__control']/*[self::lightning-formatted-text or self::lightning-formatted-number]",
     },
+    "homepage": {
+        "component_link": '//article[contains(@class,"forceBaseCard")][.//span[contains(@title,"{}")]]',
+    },
 }

--- a/robot/pmm/resources/locators_51.py
+++ b/robot/pmm/resources/locators_51.py
@@ -32,7 +32,7 @@ pmm_lex_locators = {
         "quick_dropdown_popup": "//div[@class='select-options' and @role='menu']",
         "quick_dropdown_value": "//div[@class='select-options']//ul//li//a[@title='{}']",
         "dropdown_popup": "//div[contains(@class,'slds-listbox') and @role='listbox']",
-        "dropdown_value": "//lightning-base-combobox-item[contains(@class,'slds-media')]/span/following-sibling::span[@class='slds-media__body']/span[@title='{}']",
+        "dropdown_value": "//lightning-base-combobox-item[contains(@class,'slds-media')]//span[@class='slds-media__body']/span[@title='{}']",
         "button": "//lightning-button/button[text()='{}']",
         "lookup_field": "//div[contains(@class, 'autocompleteWrapper')]//input[@title='{}']",
         "lookup_value": "//div[contains(@class, 'listContent')]//div[contains(@class, 'slds-truncate') and @title='{}']",

--- a/robot/pmm/resources/pmm.py
+++ b/robot/pmm/resources/pmm.py
@@ -268,6 +268,7 @@ class pmm(object):
             locator = pmm_lex_locators["new_record"]["dropdown_field"].format(dropdown)
             popup_loc = pmm_lex_locators["new_record"]["dropdown_popup"]
             value_loc = pmm_lex_locators["new_record"]["dropdown_value"].format(value)
+        self.salesforce.scroll_element_into_view(locator)
         self.selenium.get_webelement(locator).click()
         self.selenium.wait_until_page_contains_element(
             popup_loc, error="Status field dropdown did not open"

--- a/robot/pmm/tests/browser/Attendance/dim_attendance.robot
+++ b/robot/pmm/tests/browser/Attendance/dim_attendance.robot
@@ -19,7 +19,7 @@ Setup Test Data
     Set suite variable              ${ns}
     ${contact1}                     API Create Contact
     Set suite variable              ${contact1}
-    ${contact2}                     API Create Contact      FirstName=test robot contact
+    ${contact2}                     API Create Contact      FirstName=ztest robot contact
     Set suite variable              ${contact2}
     ${program} =                    API Create Program
     Set suite variable              ${program}
@@ -61,8 +61,10 @@ Validate Dim attendance icon is displayed only for newly added rows
     Populate Attendance Dropdown        1      Attendance Status    Present
     Sleep                               2s
     Click Dialog Button             Submit
+    Verify Toast Message            Saved 1 Service Delivery records.
     API Create Service Participant  ${contact2}[Id]   ${service_schedule}[Id]  ${service}[Id]
     Reload Page
+    Page Should Contain             Service Session Name
     Click Dialog Button             Update
     Dim Attendance Row              1       Is not displayed
     Dim Attendance Row              2       Is displayed

--- a/robot/pmm/tests/browser/Bulk_Service_Delivery/Add_service_deliveries.robot
+++ b/robot/pmm/tests/browser/Bulk_Service_Delivery/Add_service_deliveries.robot
@@ -57,7 +57,7 @@ Add service delivery on bulk service delivery
     [Documentation]             This test adds two service deliveries on bulk service delivery and 
     ...                         navigates to service delivery listview and verifies that the service delivery 
     ...                         records are displayed
-    [tags]                      W-040316    perm:admin   perm:manage    perm:deliver   feature:Service Delivery
+    [tags]                      unstable    W-040316    perm:admin   perm:manage    perm:deliver   feature:Service Delivery
     Go To Page                  Custom                              Bulk_Service_Deliveries
     Populate Bsdt Lookup        1           Client                  ${contact1}[FirstName] ${contact1}[LastName]
     Populate Bsdt Dropdown      1           Program Engagement      ${program_engagement1}[Name]
@@ -84,7 +84,7 @@ Add service delivery on bulk service delivery
 Verify error message when there are no services associated with the program
     [Documentation]             This test verifies that an error message is displayed when there are no
     ...                         services associated with the program.
-    [tags]                      W-040316     perm:admin   perm:manage     perm:deliver   feature:Service Delivery
+    [tags]                      unstable    W-040316     perm:admin   perm:manage     perm:deliver   feature:Service Delivery
     Go To Page                  Custom                              Bulk_Service_Deliveries
     Populate Bsdt Lookup        1           Client                  ${contact3}[FirstName] ${contact3}[LastName]
     Populate Bsdt Dropdown      1           Program Engagement      ${program_engagement3}[Name]
@@ -94,7 +94,7 @@ Verify error message when there are no services associated with the program
 Delete service delivery on bsdt
     [Documentation]             This test creates a service delivery on BSDT and then deletes it, verifies
     ...                         that a warning dialog is displayed when deleted.
-    [tags]                      W-042916     perm:admin   perm:manage   feature:Service Delivery
+    [tags]                      unstable    W-042916     perm:admin   perm:manage   feature:Service Delivery
     Go To Page                  Custom                              Bulk_Service_Deliveries
     Populate Bsdt Lookup        1           Client                  ${contact1}[FirstName] ${contact1}[LastName]
     Populate Bsdt Dropdown      1           Program Engagement      ${program_engagement1}[Name]

--- a/robot/pmm/tests/browser/Bulk_Service_Delivery/add_pe_on_BSDT.robot
+++ b/robot/pmm/tests/browser/Bulk_Service_Delivery/add_pe_on_BSDT.robot
@@ -41,7 +41,7 @@ Setup Test Data
 Create program engagement from BSDT
     [Documentation]                         This test adds service deliveries on bulk service delivery by creating
     ...                                     a new PE on bsdt page
-    [tags]                                  W-040316    perm:admin   perm:manage    perm:deliver   feature:Service Delivery
+    [tags]                                  unstable    W-040316    perm:admin   perm:manage    perm:deliver   feature:Service Delivery
     Go To Page                              Custom                              Bulk_Service_Deliveries
     Populate Bsdt Lookup                    1           Client                  ${contact}[FirstName] ${contact}[LastName]
     Page Should Contain                     ${contact}[FirstName] ${contact}[LastName]

--- a/robot/pmm/tests/browser/HomePage/homepage_components.robot
+++ b/robot/pmm/tests/browser/HomePage/homepage_components.robot
@@ -1,0 +1,30 @@
+*** Settings ***
+
+Resource       robot/pmm/resources/pmm.robot
+Library        cumulusci.robotframework.PageObjects
+...            robot/pmm/resources/HomePageObject.py
+Suite Setup     Run Keywords
+...             Open test browser            useralias=${test_user}             AND
+...             Setup Test Data
+Suite Teardown  Capture Screenshot and Delete Records and Close Browser
+
+*** Variables ***
+${test_user}             UUser
+
+*** Keywords ***
+Setup Test Data
+    ${ns} =                     Get PMM Namespace Prefix
+    Set suite variable          ${ns}
+
+*** Test Cases ***
+Today's tasks on homepage
+    [Documentation]                 Go to homepage and validate 'Today's task' component is displayed
+    [tags]                          W-037575   perm:admin   perm:manage   perm:deliver   perm:view   feature:Homepage
+    Go to Page                      Home                    Homepage
+    Verify Component On HomePage    Today’s Tasks
+
+Recent Items on Homepage
+    [Documentation]                 Go to homepage and validate 'Recent Items' component is displayed
+    [tags]                          W-037575   perm:admin   perm:manage   perm:deliver   perm:view   feature:Homepage
+    Go to Page                      Home                    Homepage
+    Verify Component On HomePage    Recent Items

--- a/robot/pmm/tests/browser/HomePage/homepage_reports.robot
+++ b/robot/pmm/tests/browser/HomePage/homepage_reports.robot
@@ -6,7 +6,7 @@ Library        cumulusci.robotframework.PageObjects
 Suite Setup     Run Keywords
 ...             Open test browser            useralias=${test_user}             AND
 ...             Setup Test Data
-#Suite Teardown  Capture Screenshot and Delete Records and Close Browser
+Suite Teardown  Capture Screenshot and Delete Records and Close Browser
 
 *** Variables ***
 ${test_user}             UUser

--- a/robot/pmm/tests/browser/HomePage/homepage_reports.robot
+++ b/robot/pmm/tests/browser/HomePage/homepage_reports.robot
@@ -2,13 +2,11 @@
 
 Resource       robot/pmm/resources/pmm.robot
 Library        cumulusci.robotframework.PageObjects
-...            robot/pmm/resources/pmm.py
-...            robot/pmm/resources/ProgramPageObject.py
-...            robot/pmm/resources/ServicePageObject.py
+...            robot/pmm/resources/HomePageObject.py
 Suite Setup     Run Keywords
 ...             Open test browser            useralias=${test_user}             AND
 ...             Setup Test Data
-Suite Teardown  Capture Screenshot and Delete Records and Close Browser
+#Suite Teardown  Capture Screenshot and Delete Records and Close Browser
 
 *** Variables ***
 ${test_user}             UUser
@@ -20,3 +18,20 @@ Setup Test Data
 
 *** Test Cases ***
 Clients missing phone number report on Homepage
+    [Documentation]             Go to homepage and validate 'Clients missing phone number' report is displayed
+    [tags]                      W-8956949   perm:admin   perm:manage   perm:deliver   perm:view   feature:Homepage
+    Go to Page                  Home                    Homepage
+    Maximize Browser Window
+    Page Should Contain         Client Records Missing Phone
+
+Active Program Engagements report on Homepage
+    [Documentation]             Go to homepage and validate 'Active Program Engagements' report is displayed
+    [tags]                      W-8956949   perm:admin   perm:manage   perm:deliver   perm:view   feature:Homepage
+    Go to Page                  Home                    Homepage
+    Page Should Contain         All Active Program Engagements 
+
+Services Delivered report on Homepage
+    [Documentation]             Go to homepage and validate 'Services Delivered (Year to Date)' report is displayed
+    [tags]                      W-8956949   perm:admin   perm:manage   perm:deliver   perm:view   feature:Homepage
+    Go to Page                  Home                    Homepage
+    Page Should Contain         Services Delivered (Year to Date)

--- a/robot/pmm/tests/browser/HomePage/homepage_reports.robot
+++ b/robot/pmm/tests/browser/HomePage/homepage_reports.robot
@@ -1,0 +1,22 @@
+*** Settings ***
+
+Resource       robot/pmm/resources/pmm.robot
+Library        cumulusci.robotframework.PageObjects
+...            robot/pmm/resources/pmm.py
+...            robot/pmm/resources/ProgramPageObject.py
+...            robot/pmm/resources/ServicePageObject.py
+Suite Setup     Run Keywords
+...             Open test browser            useralias=${test_user}             AND
+...             Setup Test Data
+Suite Teardown  Capture Screenshot and Delete Records and Close Browser
+
+*** Variables ***
+${test_user}             UUser
+
+*** Keywords ***
+Setup Test Data
+    ${ns} =                     Get PMM Namespace Prefix
+    Set suite variable          ${ns}
+
+*** Test Cases ***
+Clients missing phone number report on Homepage

--- a/robot/pmm/tests/browser/ServiceSchedule/new_service_schedule.robot
+++ b/robot/pmm/tests/browser/ServiceSchedule/new_service_schedule.robot
@@ -44,7 +44,7 @@ Setup Test Data
 Create a New Service Schedule
     [Documentation]                        Navigates to service schedule listing page, clicks 'New' on the listing page and
     ...                                    creates a new record using the wizard, validates the details on the service schedule record
-    [tags]                                 W-8294332     perm:admin   perm:manage         feature:Service Schedule
+    [tags]                                 unstable    W-8294332     perm:admin   perm:manage       feature:Service Schedule
     Go To Page                              Details                        Service__c           object_id=${service}[Id]
     Click Wrapper Related List Button       Service Schedules              New
     Current Page Should Be                  New                            ServiceSchedule__c

--- a/robot/pmm/tests/browser/ServiceSchedule/service_schedule_layout.robot
+++ b/robot/pmm/tests/browser/ServiceSchedule/service_schedule_layout.robot
@@ -40,7 +40,7 @@ Add Service Participant quick action
     [Documentation]                        Navigates to service schedule details page, creates two PE using API and clicks on Add service
     ...                                    Participants quick action, add more participants and Save. Validates that the contact name is 
     ...                                    displayed on the service schedule page
-    [tags]                                 W-8720124     perm:admin   perm:manage     perm:deliver    feature:Service Schedule 
+    [tags]                                 unstable    W-8720124     perm:admin   perm:manage     perm:deliver    feature:Service Schedule 
     Go To Page                              Details                        ServiceSchedule__c           object_id=${service_schedule}[Id]
     API Create Program Engagement   ${Program}[Id]  ${contact2}[Id]
     API Create Program Engagement   ${Program}[Id]  ${contact3}[Id]

--- a/robot/pmm/tests/browser/ServiceSchedule/service_schedule_screen3.robot
+++ b/robot/pmm/tests/browser/ServiceSchedule/service_schedule_screen3.robot
@@ -43,7 +43,7 @@ Setup Test Data
 Add/remove service participants on Screen3
     [Documentation]                        On service schedule wizard, add/remove service participants on screen 3 and validate that the
     ...                                    added participants are displayed on screen 4 and when the wizard is saved
-    [tags]                                 W-8449817    perm:admin    perm:manage        feature:Service Schedule
+    [tags]                                 unstable    W-8449817    perm:admin    perm:manage     feature:Service Schedule
     Go To Page                              Details                        Service__c           object_id=${service}[Id]
     Click Wrapper Related List Button       Service Schedules              New
     Current Page Should Be                  New                            ServiceSchedule__c


### PR DESCRIPTION
W-8956949

Validates the following are displayed on homepage:
1. Clients with missing phone number report
2. All Active Program Engagements report
3. Services delivered (year to date) report
4. Recent Items component
5. Today's Tasks component


Also updated:
- 'Select Value From Dropdown' keyword and related locator to fix failing Program Engagement tests
- BSDT and Service Schedule tests labeled unstable while those components are being modified

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
- [ ] Any net new LWC work has Sa11y tests & 50% or above lines JEST test coverage  
- [ ] CRUD/FLS is enforced in Apex
- [ ] Permission sets are updated to account for CRUD|FLS|Tab|Classes
- [ ] Field sets are updated to account for new fields
- [ ] UX approval or UX not necessary
- [ ] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: W-0000000: Work Name (https://github.com/SalesforceFoundation/PMM/pull/303)
- [ ] All **acceptance criteria** have been met
    - [ ] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [ ] PR contains draft release notes
- [ ] QE story level testing completed