### PR TITLE
BSDT Manual Save

### DIFF
--- a/force-app/main/default/classes/AttendanceService_TEST.cls
+++ b/force-app/main/default/classes/AttendanceService_TEST.cls
@@ -331,7 +331,9 @@ public with sharing class AttendanceService_TEST {
             JSON.serialize(
                 new Map<String, Object>{
                     'Id' => contactId,
-                    'Service_Deliveries__r' => new Map<String, Object>{
+                    Util.prefixNamespace(
+                        'Service_Deliveries__r'
+                    ) => new Map<String, Object>{
                         'totalSize' => 2,
                         'done' => true,
                         'records' => new List<ServiceDelivery__c>{
@@ -407,7 +409,9 @@ public with sharing class AttendanceService_TEST {
             JSON.serialize(
                 new Map<String, Object>{
                     'Id' => serviceId,
-                    'ServiceDeliveries__r' => new Map<String, Object>{
+                    Util.prefixNamespace(
+                        'ServiceDeliveries__r'
+                    ) => new Map<String, Object>{
                         'totalSize' => 2,
                         'done' => true,
                         'records' => new List<ServiceDelivery__c>{

--- a/force-app/main/default/labels/CustomLabels.labels-meta.xml
+++ b/force-app/main/default/labels/CustomLabels.labels-meta.xml
@@ -513,6 +513,13 @@
         <value>Update</value>
     </labels>
     <labels>
+        <fullName>Edited</fullName>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>Edited</shortDescription>
+        <value>Edited</value>
+    </labels>
+    <labels>
         <fullName>Save</fullName>
         <language>en_US</language>
         <protected>true</protected>

--- a/force-app/main/default/lwc/bulkServiceDeliveryUI/bulkServiceDeliveryUI.html
+++ b/force-app/main/default/lwc/bulkServiceDeliveryUI/bulkServiceDeliveryUI.html
@@ -21,10 +21,8 @@
                                 default-values={defaultValues}
                                 field-set={fieldSet}
                                 index={delivery.index}
-                                onsubmit={handleSubmit}
-                                onsuccess={handleSuccess}
-                                ondelete={handleDelete}
-                                onerror={handleRowError}
+                                onsuccess={handleRowSuccess}
+                                ondelete={handleRowDelete}
                                 row-count={rowCount}
                                 has-contact-field={hasContactField}
                                 has-program-engagement-field={hasProgramEngagementField}
@@ -44,11 +42,11 @@
                     disabled={isAddEntryDisabled}
                 ></lightning-button>
                 <lightning-button
-                    onclick={handleDone}
+                    onclick={handleSave}
                     variant="brand"
-                    label={labels.done}
-                    disabled={isDoneDisabled}
-                    title={doneTitleLabel}
+                    label={labels.save}
+                    disabled={isSaveDisabled}
+                    title={labels.save}
                 ></lightning-button>
             </div>
         </lightning-card>

--- a/force-app/main/default/lwc/bulkServiceDeliveryUI/bulkServiceDeliveryUI.js
+++ b/force-app/main/default/lwc/bulkServiceDeliveryUI/bulkServiceDeliveryUI.js
@@ -195,11 +195,15 @@ export default class BulkServiceDeliveryUI extends NavigationMixin(LightningElem
         this.targetSaveCount = 0;
 
         rows.forEach(row => {
-            if (row.isDirty) {
+            if (row.isDirty || row.isError) {
                 this.targetSaveCount++;
             }
             row.saveRow();
         });
+
+        if (this.targetSaveCount === 0) {
+            this.dispatchEvent(new CustomEvent("done"));
+        }
     }
 
     // eslint-disable-next-line no-unused-vars

--- a/force-app/main/default/lwc/bulkServiceDeliveryUI/bulkServiceDeliveryUI.js
+++ b/force-app/main/default/lwc/bulkServiceDeliveryUI/bulkServiceDeliveryUI.js
@@ -186,7 +186,6 @@ export default class BulkServiceDeliveryUI extends NavigationMixin(LightningElem
         if (this.serviceDeliveries.length <= 0) {
             this.addDelivery();
         }
-        this.handleDeleteError(event.detail);
     }
 
     handleSave() {

--- a/force-app/main/default/lwc/serviceDeliveryModal/serviceDeliveryModal.html
+++ b/force-app/main/default/lwc/serviceDeliveryModal/serviceDeliveryModal.html
@@ -12,6 +12,7 @@
         <c-bulk-service-delivery-u-i
             default-values={defaultValues}
             ondone={hideModal}
+            hide-footer="true"
         ></c-bulk-service-delivery-u-i>
     </c-modal>
 </template>

--- a/force-app/main/default/lwc/serviceDeliveryRow/serviceDeliveryRow.html
+++ b/force-app/main/default/lwc/serviceDeliveryRow/serviceDeliveryRow.html
@@ -119,12 +119,9 @@
                         </lightning-layout-item>
                     </lightning-layout>
                 </lightning-layout-item>
-                <lightning-layout-item size="2">
+                <lightning-layout-item size="2" class="slds-var-p-left_small">
                     <lightning-layout>
-                        <lightning-layout-item
-                            size="8"
-                            class="slds-p-top_xx-small slds-text-align_right"
-                        >
+                        <lightning-layout-item size="8" class="slds-p-top_xx-small">
                             <template if:true={isSaving}>
                                 <div
                                     class="slds-is-relative slds-p-top_large slds-text-align_right slds-m-left_x-large"
@@ -136,7 +133,7 @@
                                     ></lightning-spinner>
                                 </div>
                             </template>
-                            <template if:true={isSaved} role="alert">
+                            <template if:true={showSavedIcon} role="alert">
                                 <lightning-icon
                                     tabindex="0"
                                     icon-name="utility:success"
@@ -147,10 +144,21 @@
                                 ></lightning-icon>
                                 <span class="slds-p-left_small">{labels.saved}</span>
                             </template>
-                            <template if:true={isError} role="alert">
+                            <template if:true={showModifiedIcon} role="alert">
                                 <lightning-icon
                                     tabindex="0"
                                     icon-name="utility:warning"
+                                    alternative-text="Edited"
+                                    size="x-small"
+                                    variant="warning"
+                                    title="Edited"
+                                ></lightning-icon>
+                                <span class="slds-p-left_small">Edited</span>
+                            </template>
+                            <template if:true={isError} role="alert">
+                                <lightning-icon
+                                    tabindex="0"
+                                    icon-name="utility:error"
                                     alternative-text={labels.error}
                                     size="x-small"
                                     variant="error"

--- a/force-app/main/default/lwc/serviceDeliveryRow/serviceDeliveryRow.html
+++ b/force-app/main/default/lwc/serviceDeliveryRow/serviceDeliveryRow.html
@@ -148,12 +148,12 @@
                                 <lightning-icon
                                     tabindex="0"
                                     icon-name="utility:warning"
-                                    alternative-text="Edited"
+                                    alternative-text={labels.edited}
                                     size="x-small"
                                     variant="warning"
-                                    title="Edited"
+                                    title={labels.edited}
                                 ></lightning-icon>
-                                <span class="slds-p-left_small">Edited</span>
+                                <span class="slds-p-left_small">{labels.edited}</span>
                             </template>
                             <template if:true={isError} role="alert">
                                 <lightning-icon

--- a/force-app/main/default/lwc/serviceDeliveryRow/serviceDeliveryRow.js
+++ b/force-app/main/default/lwc/serviceDeliveryRow/serviceDeliveryRow.js
@@ -57,7 +57,7 @@ export default class ServiceDeliveryRow extends LightningElement {
     @api hasContactField;
     @api hasProgramEngagementField;
     @track isSaving;
-    @track isError;
+    @api isError;
     @track isSaved;
     @track rowError;
     @track unitOfMeasureValue = quantity;

--- a/force-app/main/default/lwc/serviceDeliveryRow/serviceDeliveryRow.js
+++ b/force-app/main/default/lwc/serviceDeliveryRow/serviceDeliveryRow.js
@@ -148,6 +148,8 @@ export default class ServiceDeliveryRow extends LightningElement {
         ) {
             this.unitOfMeasureValue =
                 result.data.fields[SERVICE_UNIT_OF_MEASUREMENT_FIELD.fieldApiName].value;
+        } else {
+            this.resetQuantityLabel();
         }
     }
 
@@ -209,7 +211,15 @@ export default class ServiceDeliveryRow extends LightningElement {
             event.target.fieldName === this.fields.programEngagement.fieldApiName
         ) {
             this.handleProgramEngagementInputChange(event);
+        } else if (event.target.fieldName === this.fields.service.fieldApiName) {
+            this.handleServiceInputChange(event.target.fieldName, event.target.value);
         }
+    }
+
+    handleServiceInputChange(fieldName, fieldVal) {
+        this.serviceId = fieldVal;
+        this.handleEnableFieldOnInputChange(fieldName);
+        this.enableDisableFieldsOnSaveAndInputChange();
     }
 
     handleContactInputChange(event) {
@@ -281,8 +291,7 @@ export default class ServiceDeliveryRow extends LightningElement {
         }
 
         if (fieldName === this.fields.service.fieldApiName) {
-            this.serviceId = fieldVal;
-            this.enableDisableFieldsOnSaveAndInputChange();
+            this.handleServiceInputChange(fieldName, fieldVal);
         }
     }
 

--- a/force-app/main/default/lwc/serviceDeliveryRow/serviceDeliveryRow.js
+++ b/force-app/main/default/lwc/serviceDeliveryRow/serviceDeliveryRow.js
@@ -34,6 +34,7 @@ import noServiceWarning from "@salesforce/label/c.No_Services_For_Program_Engage
 import newProgramEngagement from "@salesforce/label/c.New_Program_Engagement";
 import quantity from "@salesforce/label/c.Quantity";
 import fieldAccessError from "@salesforce/label/c.Util_UnsupportedField";
+import edited from "@salesforce/label/c.Edited";
 
 import CONTACT_FIELD from "@salesforce/schema/ServiceDelivery__c.Contact__c";
 import SERVICE_FIELD from "@salesforce/schema/ServiceDelivery__c.Service__c";
@@ -114,6 +115,7 @@ export default class ServiceDeliveryRow extends LightningElement {
         error,
         quantity,
         fieldAccessError,
+        edited,
     };
     fields = {
         contact: CONTACT_FIELD,


### PR DESCRIPTION
# Critical Changes

# Changes
You can now save any additions or edits to your Bulk Service Deliveries with a Save button, versus previous auto-save functionality. If a row can't save, you're prompted to edit and save them again. You can also edit saved rows at any time. 

# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
- [ ] ~~Any net new LWC work has Sa11y tests & 50% or above lines JEST test coverage~~
- [ ] ~~CRUD/FLS is enforced in Apex~~
- [ ] ~~Permission sets are updated to account for CRUD|FLS|Tab|Classes~~
- [ ] ~~Field sets are updated to account for new fields~~
- [x] UX approval or UX not necessary
- [x] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: W-0000000: Work Name (https://github.com/SalesforceFoundation/PMM/pull/303)
- [ ] All **acceptance criteria** have been met
    - [x] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [x] PR contains draft release notes
- [ ] QE story level testing completed