### PR TITLE
Participant Selector - "Add"/"Add All" buttons

### DIFF
--- a/force-app/main/default/classes/ServiceScheduleModel.cls
+++ b/force-app/main/default/classes/ServiceScheduleModel.cls
@@ -176,6 +176,7 @@ public with sharing class ServiceScheduleModel {
         'searchThisList' => System.Label.Search_this_list,
         'none' => System.Label.None,
         'add' => System.Label.Add,
+        'addAll' => System.Label.Add_All,
         'noRecordsFound' => System.Label.No_Records_Found,
         'noRecordsSelected' => System.Label.No_Records_Selected,
         'filterByCohort' => String.format(

--- a/force-app/main/default/classes/ServiceScheduleModel.cls
+++ b/force-app/main/default/classes/ServiceScheduleModel.cls
@@ -175,6 +175,7 @@ public with sharing class ServiceScheduleModel {
         'selectedRecords' => System.Label.Selected_Records,
         'searchThisList' => System.Label.Search_this_list,
         'none' => System.Label.None,
+        'add' => System.Label.Add,
         'noRecordsFound' => System.Label.No_Records_Found,
         'noRecordsSelected' => System.Label.No_Records_Selected,
         'filterByCohort' => String.format(

--- a/force-app/main/default/labels/CustomLabels.labels-meta.xml
+++ b/force-app/main/default/labels/CustomLabels.labels-meta.xml
@@ -527,6 +527,13 @@
         <value>New Program Engagement record created.</value>
     </labels>
     <labels>
+        <fullName>Add</fullName>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>Add</shortDescription>
+        <value>Add</value>
+    </labels>
+    <labels>
         <fullName>Save_New</fullName>
         <language>en_US</language>
         <protected>true</protected>

--- a/force-app/main/default/labels/CustomLabels.labels-meta.xml
+++ b/force-app/main/default/labels/CustomLabels.labels-meta.xml
@@ -534,6 +534,13 @@
         <value>Add</value>
     </labels>
     <labels>
+        <fullName>Add_All</fullName>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>Add All</shortDescription>
+        <value>Add All</value>
+    </labels>
+    <labels>
         <fullName>Save_New</fullName>
         <language>en_US</language>
         <protected>true</protected>

--- a/force-app/main/default/lwc/participantSelector/participantSelector.html
+++ b/force-app/main/default/lwc/participantSelector/participantSelector.html
@@ -54,13 +54,8 @@
                                 >
                                     <lightning-layout-item
                                         size="3"
-                                        class="slds-var-p-left_small slds-var-p-bottom_medium"
-                                    >
-                                        {selectedRecordCountMessage}
-                                    </lightning-layout-item>
-                                    <lightning-layout-item
-                                        size="3"
                                         class="slds-var-p-right_small slds-var-p-bottom_small"
+                                        alignment-bump="left"
                                     >
                                         <lightning-input
                                             name="enter-search"
@@ -69,6 +64,16 @@
                                             onchange={handleInputChange}
                                             value={searchValue}
                                         ></lightning-input>
+                                    </lightning-layout-item>
+                                    <lightning-layout-item
+                                        class="slds-var-p-right_small slds-var-p-bottom_small"
+                                    >
+                                        <lightning-button
+                                            label={labels.addAll}
+                                            title={labels.addAll}
+                                            variant="neutral"
+                                            onclick={handleSelectAll}
+                                        ></lightning-button>
                                     </lightning-layout-item>
                                     <lightning-layout-item
                                         size="12"

--- a/force-app/main/default/lwc/participantSelector/participantSelector.html
+++ b/force-app/main/default/lwc/participantSelector/participantSelector.html
@@ -81,11 +81,12 @@
                                             <lightning-datatable
                                                 data={filteredEngagements}
                                                 key-field="Id"
-                                                columns={columns}
+                                                columns={selectorColumns}
                                                 column-widths-mode="auto"
                                                 show-row-number-column
                                                 resize-column-disabled
-                                                onrowselection={handleRowSelected}
+                                                hide-checkbox-column
+                                                onrowaction={handleSelectParticipant}
                                             ></lightning-datatable>
                                             <div
                                                 class="slds-theme_shade slds-align_absolute-center slds-border_top"

--- a/force-app/main/default/lwc/participantSelector/participantSelector.html
+++ b/force-app/main/default/lwc/participantSelector/participantSelector.html
@@ -80,7 +80,7 @@
                                         if:false={noRecordsFound}
                                     >
                                         <div
-                                            style="height: 266px"
+                                            style="height: 331px"
                                             class="slds-border_top slds-var-m-top_xx-small"
                                         >
                                             <lightning-datatable
@@ -93,16 +93,6 @@
                                                 hide-checkbox-column
                                                 onrowaction={handleSelectParticipant}
                                             ></lightning-datatable>
-                                            <div
-                                                class="slds-theme_shade slds-align_absolute-center slds-border_top"
-                                            >
-                                                <lightning-button
-                                                    variant="brand"
-                                                    label={labels.addServiceParticipants}
-                                                    class="slds-var-p-around_medium"
-                                                    onclick={handleSelectParticipants}
-                                                ></lightning-button>
-                                            </div>
                                         </div>
                                     </lightning-layout-item>
                                     <lightning-layout-item

--- a/force-app/main/default/lwc/participantSelector/participantSelector.js
+++ b/force-app/main/default/lwc/participantSelector/participantSelector.js
@@ -21,6 +21,7 @@ export default class ParticipantSelector extends LightningElement {
     @api selectedParticipants = [];
     @api existingContactIds = [];
     @api columns;
+    selectorColumns;
 
     selectedRowCount = 0;
     searchValue;
@@ -192,6 +193,21 @@ export default class ParticipantSelector extends LightningElement {
             };
             this.columns.push(column);
         }
+
+        this.selectorColumns = [...this.columns];
+
+        this.selectorColumns.push({
+            fieldName: "",
+            type: "button",
+            hideDefaultActions: true,
+            typeAttributes: {
+                name: "add",
+                label: this.labels.add,
+                title: this.labels.add,
+                variant: "neutral",
+                iconPosition: "left",
+            },
+        });
     }
 
     setSelectedColumns() {
@@ -222,9 +238,17 @@ export default class ParticipantSelector extends LightningElement {
         this.selectedRowCount = event.detail.selectedRows.length;
     }
 
+    handleSelectParticipant(event) {
+        this.handleSelect([event.detail.row]);
+    }
+
     handleSelectParticipants() {
+        this.handleSelect(this.selectedRows);
+    }
+
+    handleSelect(programEngagements) {
         let tempContacts = [...this.availableEngagements];
-        this.selectedRows.forEach(row => {
+        programEngagements.forEach(row => {
             let index = tempContacts.findIndex(element => element.Id === row.Id);
             tempContacts.splice(index, 1);
 

--- a/force-app/main/default/lwc/participantSelector/participantSelector.js
+++ b/force-app/main/default/lwc/participantSelector/participantSelector.js
@@ -238,6 +238,10 @@ export default class ParticipantSelector extends LightningElement {
         this.selectedRowCount = event.detail.selectedRows.length;
     }
 
+    handleSelectAll() {
+        this.handleSelect([...this.availableEngagements]);
+    }
+
     handleSelectParticipant(event) {
         this.handleSelect([event.detail.row]);
     }


### PR DESCRIPTION
# Critical Changes

# Changes
- Participant selector in the New Service Schedule wizard now uses a separate "Add" action button on each row for a one-click add, instead of needing to select rows and then hit the "Add Service Participants" button. There is also a new "Add All" button.

# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
- [ ] Any net new LWC work has Sa11y tests & 50% or above lines JEST test coverage  
- [ ] ~~CRUD/FLS is enforced in Apex~~
- [ ] ~~Permission sets are updated to account for CRUD|FLS|Tab|Classes~~
- [ ] ~~Field sets are updated to account for new fields~~
- [ ] UX approval or UX not necessary
- [x] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: W-0000000: Work Name (https://github.com/SalesforceFoundation/PMM/pull/303)
- [ ] All **acceptance criteria** have been met
    - [x] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [x] PR contains draft release notes
- [ ] QE story level testing completed