### PR TITLE
Add/Add All buttons for Participant Selector

### DIFF
--- a/force-app/main/default/labels/CustomLabels.labels-meta.xml
+++ b/force-app/main/default/labels/CustomLabels.labels-meta.xml
@@ -597,6 +597,20 @@
         <value>New Program Engagement record created.</value>
     </labels>
     <labels>
+        <fullName>Add</fullName>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>Add</shortDescription>
+        <value>Add</value>
+    </labels>
+    <labels>
+        <fullName>Add_All</fullName>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>Add All</shortDescription>
+        <value>Add All</value>
+    </labels>
+    <labels>
         <fullName>Save_New</fullName>
         <language>en_US</language>
         <protected>true</protected>

--- a/force-app/main/default/lwc/participantSelector/participantSelector.html
+++ b/force-app/main/default/lwc/participantSelector/participantSelector.html
@@ -54,13 +54,8 @@
                                 >
                                     <lightning-layout-item
                                         size="3"
-                                        class="slds-var-p-left_small slds-var-p-bottom_medium"
-                                    >
-                                        {selectedRecordCountMessage}
-                                    </lightning-layout-item>
-                                    <lightning-layout-item
-                                        size="3"
                                         class="slds-var-p-right_small slds-var-p-bottom_small"
+                                        alignment-bump="left"
                                     >
                                         <lightning-input
                                             name="enter-search"
@@ -71,32 +66,33 @@
                                         ></lightning-input>
                                     </lightning-layout-item>
                                     <lightning-layout-item
+                                        class="slds-var-p-right_small slds-var-p-bottom_small"
+                                    >
+                                        <lightning-button
+                                            label={labels.addAll}
+                                            title={labels.addAll}
+                                            variant="neutral"
+                                            onclick={handleSelectAll}
+                                        ></lightning-button>
+                                    </lightning-layout-item>
+                                    <lightning-layout-item
                                         size="12"
                                         if:false={noRecordsFound}
                                     >
                                         <div
-                                            style="height: 266px"
+                                            style="height: 331px"
                                             class="slds-border_top slds-var-m-top_xx-small"
                                         >
                                             <lightning-datatable
                                                 data={filteredEngagements}
                                                 key-field="Id"
-                                                columns={columns}
+                                                columns={selectorColumns}
                                                 column-widths-mode="auto"
                                                 show-row-number-column
                                                 resize-column-disabled
-                                                onrowselection={handleRowSelected}
+                                                hide-checkbox-column
+                                                onrowaction={handleSelectParticipant}
                                             ></lightning-datatable>
-                                            <div
-                                                class="slds-theme_shade slds-align_absolute-center slds-border_top"
-                                            >
-                                                <lightning-button
-                                                    variant="brand"
-                                                    label={title}
-                                                    class="slds-var-p-around_medium"
-                                                    onclick={handleSelectParticipants}
-                                                ></lightning-button>
-                                            </div>
                                         </div>
                                     </lightning-layout-item>
                                     <lightning-layout-item

--- a/force-app/main/default/lwc/participantSelector/participantSelector.js
+++ b/force-app/main/default/lwc/participantSelector/participantSelector.js
@@ -25,6 +25,8 @@ import noRecordsFound from "@salesforce/label/c.No_Records_Found";
 import noRecordsSelected from "@salesforce/label/c.No_Records_Selected";
 import filterByRecord from "@salesforce/label/c.Filter_By_Record";
 import noContactsSelected from "@salesforce/label/c.No_Service_Participants_Created_Warning";
+import add from "@salesforce/label/c.Add";
+import addAll from "@salesforce/label/c.Add_All";
 export default class ParticipantSelector extends LightningElement {
     @api serviceId;
     @api serviceSchedule;
@@ -32,13 +34,13 @@ export default class ParticipantSelector extends LightningElement {
     @api selectedParticipants = [];
     @api columns;
     @api selectedRows;
+    selectorColumns;
 
     @track availableEngagements;
     @track filteredEngagements;
     @track engagements;
     @track cohorts;
 
-    selectedRowCount = 0;
     searchValue;
     noRecordsFound = false;
     cohortId;
@@ -61,6 +63,8 @@ export default class ParticipantSelector extends LightningElement {
         noRecordsFound,
         noRecordsSelected,
         noContactsSelected,
+        add,
+        addAll,
     };
 
     @api
@@ -85,10 +89,6 @@ export default class ParticipantSelector extends LightningElement {
 
     get noRecordsSelected() {
         return this.selectedParticipants && this.selectedParticipants.length === 0;
-    }
-
-    get selectedRecordCountMessage() {
-        return this.labels.selectedRecords + ": " + this.selectedRowCount;
     }
 
     get participantCount() {
@@ -240,6 +240,21 @@ export default class ParticipantSelector extends LightningElement {
                 hideDefaultActions: true,
             };
             this.columns.push(column);
+
+            this.selectorColumns = [...this.columns];
+
+            this.selectorColumns.push({
+                fieldName: "",
+                type: "button",
+                hideDefaultActions: true,
+                typeAttributes: {
+                    name: "add",
+                    label: this.labels.add,
+                    title: this.labels.add,
+                    variant: "neutral",
+                    iconPosition: "left",
+                },
+            });
         }
     }
 
@@ -266,24 +281,28 @@ export default class ParticipantSelector extends LightningElement {
         this.applyFilters();
     }
 
-    handleRowSelected(event) {
-        this.selectedRows = event.detail.selectedRows;
-        this.selectedRowCount = event.detail.selectedRows.length;
+    handleSelectAll() {
+        this.handleSelect([...this.availableEngagements]);
+    }
+
+    handleSelectParticipant(event) {
+        this.handleSelect([event.detail.row]);
     }
 
     handleSelectParticipants() {
-        let tempContacts = [...this.availableEngagements];
-        this.selectedRows.forEach(row => {
-            let index = tempContacts.findIndex(element => element.Id === row.Id);
-            tempContacts.splice(index, 1);
+        this.handleSelect(this.selectedRows);
+    }
 
+    handleSelect(programEngagements) {
+        programEngagements.forEach(row => {
+            let index = this.availableEngagements.findIndex(
+                element => element.Id === row.Id
+            );
+            this.availableEngagements.splice(index, 1);
             this.selectedParticipants.push(row);
         });
 
         this.selectedParticipants = [...this.selectedParticipants];
-        this.availableEngagements = tempContacts;
-        this.selectedRows = undefined;
-        this.selectedRowCount = 0;
         this.applyFilters();
         this.sortData(this.selectedParticipants);
     }

--- a/force-app/main/default/lwc/participantSelector/participantSelector.js
+++ b/force-app/main/default/lwc/participantSelector/participantSelector.js
@@ -282,7 +282,7 @@ export default class ParticipantSelector extends LightningElement {
     }
 
     handleSelectAll() {
-        this.handleSelect([...this.availableEngagements]);
+        this.handleSelect([...this.filteredEngagements]);
     }
 
     handleSelectParticipant(event) {


### PR DESCRIPTION
# Critical Changes

# Changes
- When you select participants in the New Service Schedule wizard, you can now use an "Add" button on each row to add participants with a single click. We also added a new "Add All" button.

# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
- [ ] Any net new LWC work has Sa11y tests & 50% or above lines JEST test coverage  
- [ ] ~~CRUD/FLS is enforced in Apex~~
- [ ] ~~Permission sets are updated to account for CRUD|FLS|Tab|Classes~~
- [ ] ~~Field sets are updated to account for new fields~~
- [x] UX approval or UX not necessary
- [x] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: W-0000000: Work Name (https://github.com/SalesforceFoundation/PMM/pull/303)
- [ ] All **acceptance criteria** have been met
    - [x] Developer
    - [x] Code Reviewer
    - [x] QA
- [x] PR contains draft release notes
- [ ] QE story level testing completed