### PR TITLE
[Robot] Verify Programs listview, create new SD using quick action button

### DIFF
--- a/robot/pmm/tests/browser/Program/create_program.robot
+++ b/robot/pmm/tests/browser/Program/create_program.robot
@@ -45,11 +45,19 @@ Create a Program via UI
     ...                                     Program Issue Area=Education
     Click Dialog button                            Save
     Wait Until Modal Is Closed  
-    verify details                         Program Name    contains    ${program_name}
-    verify page contains related list      Services
-    verify page contains related list      Program Engagements
-    verify page contains related list      Program Cohorts
-    verify page contains related list      Files
+    Verify Details                         Program Name    contains    ${program_name}
+    Verify Page Contains Related List      Services
+    Verify Page Contains Related List      Program Engagements
+    Verify Page Contains Related List      Program Cohorts
+    Verify Page Contains Related List      Files
+
+Verify Programs listview
+    [Documentation]                        This test opens the programs listview and verifies that it contains 
+    ...                                    the program name and short summary fields
+    [tags]                                 W-9056626    perm:admin   perm:manage   perm:deliver   perm:view   feature:Program
+    Go To Page                             Listing                               ${ns}Program__c
+    Page Should Contain                    Program Name
+    Page Should Contain                    Short Summary
 
 Date validation on new program dialog
     [Documentation]                        This test opens the new program dialog and enters a end date earlier than start date
@@ -57,10 +65,10 @@ Date validation on new program dialog
     [tags]                                 W-041962    perm:admin   perm:manage    feature:Program
     Go To Page                             Listing                               ${ns}Program__c
     Click Object Button                    New
-    verify current page title              New Program
-    Populate modal Form                    Program Name=${program_name}
+    Verify Current Page Title              New Program
+    Populate Modal Form                    Program Name=${program_name}
     Populate Lightning Fields              Status=Active
     ...                                    Start Date=25
     ...                                    End Date=10
     Click Dialog button                     Save
-    verify modal error                     Start Date must be before End Date
+    Verify Modal Error                     Start Date must be before End Date

--- a/robot/pmm/tests/browser/ServiceDeliveries/sd_quickaction.robot
+++ b/robot/pmm/tests/browser/ServiceDeliveries/sd_quickaction.robot
@@ -1,0 +1,58 @@
+*** Settings ***
+
+Resource        robot/pmm/resources/pmm.robot
+Library         cumulusci.robotframework.PageObjects
+...             robot/pmm/resources/pmm.py
+...             robot/pmm/resources/ServiceDeliveryPageObject.py
+Suite Setup     Run Keywords
+...             Open test browser            useralias=${test_user}             AND
+...             Setup Test Data
+Suite Teardown  Capture Screenshot and Delete Records and Close Browser
+
+*** Variables ***
+${test_user}             UUser
+
+*** Keywords ***
+Setup Test Data
+    ${ns} =                     Get PMM Namespace Prefix
+    Set suite variable          ${ns}
+
+    ${program} =                API Create Program
+    Set suite variable          ${program}
+    ${contact} =                API Create Contact
+    Set suite variable          ${contact}
+    ${contact2} =               API Create Contact
+    Set suite variable          ${contact2}
+    ${service} =                API Create Service              ${Program}[Id]
+    Set suite variable          ${service}
+    ${program_engagement} =     API Create Program Engagement   ${Program}[Id]      ${contact}[Id]
+    Set suite variable          ${program_engagement}
+    ${program_engagement2} =    API Create Program Engagement   ${Program}[Id]      ${contact2}[Id]
+    Set suite variable          ${program_engagement2}
+    ${service_delivery} =       API Create Service Delivery     ${contact}[Id]      ${program_engagement}[Id]  ${service}[Id]
+    Set suite variable          ${service_delivery}
+    ${today} =                  Get Current Date                result_format=%Y-%m-%d
+    Set suite variable          ${today}
+    ${quantity} =               Generate Random String    2     123456789
+    Set suite variable          ${quantity}
+
+*** Test Cases ***
+Create a new service delivery on service using quick action
+    [Documentation]                This test loads the service delivery record, clicks on the new service delivery quick action
+    ...                            and creates a new service delivery record.
+    [tags]                         W-9057513      perm:admin   perm:manage    perm:deliver    feature:Service Delivery
+    Go To Page                     Details                        ServiceDelivery__c        object_id=${service_delivery}[Id]
+    Verify Details                 Service Delivery Name          contains                  ${service_delivery}[Name]
+    Click Quick Action Button      New Service Delivery
+    Wait For Modal                 New                            Service Delivery
+    Populate Field                 Quantity                       ${quantity}
+    Populate Lookup Field          Client                         ${contact2}[FirstName] ${contact2}[LastName]
+    Populate Lookup Field          Program Engagement             ${program_engagement2}[Name]
+    Populate Lookup Field          Service                        ${service}[Name]
+    Select Button On Modal         Save
+    Wait Until Modal Is Closed 
+    Go To Page                     Listing                        ${ns}ServiceDelivery__c
+    Click Listview Link            ${contact2}[FirstName] ${contact2}[LastName] ${today}: ${service}[Name]
+    Verify Details                 Service Delivery Name          contains                  ${contact2}[FirstName] ${contact2}[LastName] ${today}: ${service}[Name]
+    Verify Details                 Quantity                       contains                  ${quantity}.00
+    Save Current Record ID For Deletion     ${ns}ServiceDelivery__c

--- a/robot/pmm/tests/browser/ServiceDeliveries/sd_quickaction.robot
+++ b/robot/pmm/tests/browser/ServiceDeliveries/sd_quickaction.robot
@@ -37,7 +37,7 @@ Setup Test Data
     Set suite variable          ${quantity}
 
 *** Test Cases ***
-Create a new service delivery on service using quick action
+Create a new service delivery on service delivery using quick action
     [Documentation]                This test loads the service delivery record, clicks on the new service delivery quick action
     ...                            and creates a new service delivery record.
     [tags]                         W-9057513      perm:admin   perm:manage    perm:deliver    feature:Service Delivery


### PR DESCRIPTION
[W-9056626](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH0000009ALyYAM/view) Program - View listview

[W-9057513](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH0000009BPUYA2/view) Service Delivery - Create new SD using quick action

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
- [ ] Any net new LWC work has Sa11y tests & 50% or above lines JEST test coverage  
- [ ] CRUD/FLS is enforced in Apex
- [ ] Permission sets are updated to account for CRUD|FLS|Tab|Classes
- [ ] Field sets are updated to account for new fields
- [ ] UX approval or UX not necessary
- [ ] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: W-0000000: Work Name (https://github.com/SalesforceFoundation/PMM/pull/303)
- [ ] All **acceptance criteria** have been met
    - [ ] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [ ] PR contains draft release notes
- [ ] QE story level testing completed