### PR TITLE
Exposing attendance component to experience cloud

### DIFF
--- a/force-app/main/default/lwc/attendance/attendance.js-meta.xml
+++ b/force-app/main/default/lwc/attendance/attendance.js-meta.xml
@@ -6,12 +6,17 @@
     <targets>
         <target>lightning__RecordPage</target>
         <target>lightning__AppPage</target>
+        <target>lightningCommunity__Page</target>
+        <target>lightningCommunity__Default</target>
     </targets>
     <targetConfigs>
         <targetConfig targets="lightning__RecordPage">
             <objects>
                 <object>ServiceSession__c</object>
             </objects>
+        </targetConfig>
+        <targetConfig targets="lightningCommunity__Default">
+            <property name="recordId" type="String" label="Record ID" default="{!recordId}"/>
         </targetConfig>
     </targetConfigs>
 </LightningComponentBundle>


### PR DESCRIPTION
# Critical Changes

# Changes
Added design properties to expose the attendance component to experience cloud. When the customer goes to the experience cloud builder to build the community they will be able to see the attendance component in the list of components.
# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
~~- [] Any net new LWC work has Sa11y tests & 50% or above lines JEST test coverage ~~
~~- [ ] CRUD/FLS is enforced in Apex~~
~~- [ ] Permission sets are updated to account for CRUD|FLS|Tab|Classes~~
~~- [ ] Field sets are updated to account for new fields~~
~~- [ ] UX approval or UX not necessary~~
- [x] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: W-0000000: Work Name (https://github.com/SalesforceFoundation/PMM/pull/303)
- [ ] All **acceptance criteria** have been met
    - [x] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [x] PR contains draft release notes
- [ ] QE story level testing completed