### PR TITLE
Reset Default Service Quantity in Schedule Wizard

### DIFF
--- a/force-app/main/default/lwc/newServiceSchedule/newServiceSchedule.js
+++ b/force-app/main/default/lwc/newServiceSchedule/newServiceSchedule.js
@@ -183,7 +183,16 @@ export default class NewServiceSchedule extends LightningElement {
     }
 
     connectedCallback() {
+        this.syncDefaultServiceQuantity();
         loadStyle(this, pmmFolder + "/hideHelpIcons.css");
+    }
+
+    syncDefaultServiceQuantity() {
+        this.fieldSet.forEach(field => {
+            if (field.apiName === DEFAULT_SERVICE_QUANTITY.fieldApiName && field.value) {
+                this.defaultServiceQuantity = field.value;
+            }
+        });
     }
 
     processFields() {


### PR DESCRIPTION
# Critical Changes

# Changes
Fixes an issue where the default service quantity wasn't being maintained if the user went back and reset information in step 1 of the Service Schedule Wizard.

# Issues Closed
[W-8939893](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B00000097YfvIAE/view)

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
- [ ] Any net new LWC work has Sa11y tests & 50% or above lines JEST test coverage  
- [ ] CRUD/FLS is enforced in Apex
- [ ] Permission sets are updated to account for CRUD|FLS|Tab|Classes
- [ ] Field sets are updated to account for new fields
- [x] UX approval or UX not necessary
- [x] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: W-0000000: Work Name (https://github.com/SalesforceFoundation/PMM/pull/303)
- [ ] All **acceptance criteria** have been met
    - [x] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [x] PR contains draft release notes
- [ ] QE story level testing completed