### PR TITLE
BSDT fieldset changes

### DIFF
--- a/force-app/main/default/classes/ServiceDeliveryController.cls
+++ b/force-app/main/default/classes/ServiceDeliveryController.cls
@@ -33,10 +33,9 @@ public with sharing class ServiceDeliveryController {
     @AuraEnabled(cacheable=true)
     public static Map<String, Object> getServiceDeliveryFieldSets() {
         try {
-            Map<String, Object> fieldSets = service.getServiceDeliveryFieldSets();
+            return service.getServiceDeliveryFieldSets();
         } catch (Exception e) {
             throw Util.getAuraHandledException(e);
         }
-        return service.getServiceDeliveryFieldSets();
     }
 }

--- a/force-app/main/default/classes/ServiceDeliveryController.cls
+++ b/force-app/main/default/classes/ServiceDeliveryController.cls
@@ -29,4 +29,14 @@ public with sharing class ServiceDeliveryController {
             throw Util.getAuraHandledException(e);
         }
     }
+
+    @AuraEnabled(cacheable=true)
+    public static Map<String, Object> getFieldSetsByName(String objectName) {
+        try {
+            Map<String, Object> fieldSets = service.getFieldSetsByName(objectName);
+        } catch (Exception e) {
+            throw Util.getAuraHandledException(e);
+        }
+        return service.getFieldSetsByName(objectName);
+    }
 }

--- a/force-app/main/default/classes/ServiceDeliveryController.cls
+++ b/force-app/main/default/classes/ServiceDeliveryController.cls
@@ -31,12 +31,12 @@ public with sharing class ServiceDeliveryController {
     }
 
     @AuraEnabled(cacheable=true)
-    public static Map<String, Object> getFieldSetsByName(String objectName) {
+    public static Map<String, Object> getServiceDeliveryFieldSets() {
         try {
-            Map<String, Object> fieldSets = service.getFieldSetsByName(objectName);
+            Map<String, Object> fieldSets = service.getServiceDeliveryFieldSets();
         } catch (Exception e) {
             throw Util.getAuraHandledException(e);
         }
-        return service.getFieldSetsByName(objectName);
+        return service.getServiceDeliveryFieldSets();
     }
 }

--- a/force-app/main/default/classes/ServiceDeliveryController_TEST.cls
+++ b/force-app/main/default/classes/ServiceDeliveryController_TEST.cls
@@ -151,6 +151,7 @@ public with sharing class ServiceDeliveryController_TEST {
 
     @IsTest
     private static void testGetServiceDeliveryFieldSets() {
+        String methodName = 'getServiceDeliveryFieldSets';
         Test.startTest();
 
         ServiceDeliveryController.service = (ServiceService) serviceStub.createMock();
@@ -158,12 +159,14 @@ public with sharing class ServiceDeliveryController_TEST {
 
         Test.stopTest();
 
-        serviceStub.assertCalled('getServiceDeliveryFieldSets');
+        serviceStub.assertCalled(methodName);
     }
 
     @IsTest
     private static void whenGetServiceDeliveryFieldSetsThrowsException() {
-        serviceStub.withThrowException('getServiceDeliveryFieldSets');
+        String methodName = 'getServiceDeliveryFieldSets';
+
+        serviceStub.withThrowException(methodName);
 
         Test.startTest();
 
@@ -189,6 +192,6 @@ public with sharing class ServiceDeliveryController_TEST {
             actualException.getMessage()
         );
 
-        serviceStub.assertCalled('getServiceDeliveryFieldSets');
+        serviceStub.assertCalled(methodName);
     }
 }

--- a/force-app/main/default/classes/ServiceDeliveryController_TEST.cls
+++ b/force-app/main/default/classes/ServiceDeliveryController_TEST.cls
@@ -148,4 +148,51 @@ public with sharing class ServiceDeliveryController_TEST {
             programEngagementId
         );
     }
+
+    @IsTest
+    private static void testGetFieldSetsByName() {
+        String objectName = 'ServiceDelivery__c';
+
+        Test.startTest();
+
+        ServiceDeliveryController.service = (ServiceService) serviceStub.createMock();
+        ServiceDeliveryController.getFieldSetsByName(objectName);
+
+        Test.stopTest();
+
+        serviceStub.assertCalledWith('getFieldSetsByName', String.class, objectName);
+    }
+
+    @IsTest
+    private static void whenGetFieldSetsByNameThrowsException() {
+        String objectName = 'ServiceDelivery__c';
+
+        serviceStub.withThrowException('getFieldSetsByName', String.class);
+
+        Test.startTest();
+
+        ServiceDeliveryController.service = (serviceService) serviceStub.createMock();
+
+        Exception actualException;
+
+        try {
+            ServiceDeliveryController.getFieldSetsByName(objectName);
+        } catch (Exception e) {
+            actualException = e;
+        }
+
+        Test.stopTest();
+
+        System.assertEquals(
+            true,
+            actualException instanceof AuraHandledException,
+            actualException
+        );
+        System.assertEquals(
+            serviceStub.testExceptionMessage,
+            actualException.getMessage()
+        );
+
+        serviceStub.assertCalledWith('getFieldSetsByName', String.class, objectName);
+    }
 }

--- a/force-app/main/default/classes/ServiceDeliveryController_TEST.cls
+++ b/force-app/main/default/classes/ServiceDeliveryController_TEST.cls
@@ -150,24 +150,20 @@ public with sharing class ServiceDeliveryController_TEST {
     }
 
     @IsTest
-    private static void testGetFieldSetsByName() {
-        String objectName = 'ServiceDelivery__c';
-
+    private static void testGetServiceDeliveryFieldSets() {
         Test.startTest();
 
         ServiceDeliveryController.service = (ServiceService) serviceStub.createMock();
-        ServiceDeliveryController.getFieldSetsByName(objectName);
+        ServiceDeliveryController.getServiceDeliveryFieldSets();
 
         Test.stopTest();
 
-        serviceStub.assertCalledWith('getFieldSetsByName', String.class, objectName);
+        serviceStub.assertCalled('getServiceDeliveryFieldSets');
     }
 
     @IsTest
-    private static void whenGetFieldSetsByNameThrowsException() {
-        String objectName = 'ServiceDelivery__c';
-
-        serviceStub.withThrowException('getFieldSetsByName', String.class);
+    private static void whenGetServiceDeliveryFieldSetsThrowsException() {
+        serviceStub.withThrowException('getServiceDeliveryFieldSets');
 
         Test.startTest();
 
@@ -176,7 +172,7 @@ public with sharing class ServiceDeliveryController_TEST {
         Exception actualException;
 
         try {
-            ServiceDeliveryController.getFieldSetsByName(objectName);
+            ServiceDeliveryController.getServiceDeliveryFieldSets();
         } catch (Exception e) {
             actualException = e;
         }
@@ -193,6 +189,6 @@ public with sharing class ServiceDeliveryController_TEST {
             actualException.getMessage()
         );
 
-        serviceStub.assertCalledWith('getFieldSetsByName', String.class, objectName);
+        serviceStub.assertCalled('getServiceDeliveryFieldSets');
     }
 }

--- a/force-app/main/default/classes/ServiceService.cls
+++ b/force-app/main/default/classes/ServiceService.cls
@@ -12,7 +12,7 @@ public with sharing class ServiceService {
     }
 
     @TestVisible
-    private static FieldSetService fieldSetService = new FieldSetService();
+    private FieldSetService fieldSetService = new FieldSetService();
 
     @TestVisible
     private ServiceSelector serviceSelector = new ServiceSelector();

--- a/force-app/main/default/classes/ServiceService.cls
+++ b/force-app/main/default/classes/ServiceService.cls
@@ -69,48 +69,34 @@ public with sharing class ServiceService {
     }
 
     public Map<String, Object> getServiceDeliveryFieldSets() {
-        String objectName = Schema.SObjectType.ServiceDelivery__c.getName();
         Integer indexToInsertServiceField;
-        Boolean fieldSetContainsServiceField = true;
-        Map<String, Object> serviceField = new Map<String, Object>();
-
+        String objectName = Schema.SObjectType.ServiceDelivery__c.getName();
         Map<String, Object> fieldSets = fieldSetService.getFieldSetsByName(objectName);
+        Map<String, Object> serviceField = fieldSetService.getFieldForLWC(
+            ServiceDelivery__c.Service__c.getDescribe()
+        );
+        Map<String, Object> contactField = fieldSetService.getFieldForLWC(
+            ServiceDelivery__c.Contact__c.getDescribe()
+        );
+        Map<String, Object> peField = fieldSetService.getFieldForLWC(
+            ServiceDelivery__c.ProgramEngagement__c.getDescribe()
+        );
 
         for (String key : fieldSets.keySet()) {
-            indexToInsertServiceField = 0;
             List<Map<String, Object>> fieldSetValues = (List<Map<String, Object>>) fieldSets.get(
                 key
             );
 
-            for (Map<String, Object> field : fieldSetValues) {
-                String fieldApiName = (String) field.get('apiName');
-
-                if (
-                    fieldApiName ==
-                    Schema.SObjectType.ServiceDelivery__c.Fields.Contact__c.getName()
-                ) {
-                    indexToInsertServiceField = fieldSetValues.indexOf(field) + 1;
-                }
-                if (
-                    fieldApiName ==
-                    Schema.SObjectType.ServiceDelivery__c.Fields.ProgramEngagement__c.getName()
-                ) {
-                    indexToInsertServiceField = fieldSetValues.indexOf(field) + 1;
-                }
-
-                if (
-                    fieldApiName !=
-                    Schema.SObjectType.ServiceDelivery__c.Fields.Service__c.getName()
-                ) {
-                    fieldSetContainsServiceField = false;
-                }
+            Boolean fieldSetContainsServiceField = fieldSetValues.contains(serviceField);
+            if (fieldSetContainsServiceField) {
+                continue;
             }
 
-            if (!fieldSetContainsServiceField) {
-                DescribeFieldResult serviceFieldDescribe = ServiceDelivery__c.Service__c.getDescribe();
-                serviceField = fieldSetService.getFieldForLWC(serviceFieldDescribe);
-                fieldSetValues.add(indexToInsertServiceField, serviceField);
-            }
+            indexToInsertServiceField = fieldSetValues.indexOf(peField) + 1;
+            indexToInsertServiceField = indexToInsertServiceField > 0
+                ? indexToInsertServiceField
+                : fieldSetValues.indexOf(contactField) + 1;
+            fieldSetValues.add(indexToInsertServiceField, serviceField);
         }
 
         return fieldSets;

--- a/force-app/main/default/classes/ServiceService.cls
+++ b/force-app/main/default/classes/ServiceService.cls
@@ -69,16 +69,16 @@ public with sharing class ServiceService {
     }
 
     public Map<String, Object> getServiceDeliveryFieldSets() {
-        Integer indexToInsertServiceField;
-        String objectName = Schema.SObjectType.ServiceDelivery__c.getName();
-        Map<String, Object> fieldSets = fieldSetService.getFieldSetsByName(objectName);
+        Map<String, Object> fieldSets = fieldSetService.getFieldSetsByName(
+            Schema.SObjectType.ServiceDelivery__c.getName()
+        );
         Map<String, Object> serviceField = fieldSetService.getFieldForLWC(
             ServiceDelivery__c.Service__c.getDescribe()
         );
         Map<String, Object> contactField = fieldSetService.getFieldForLWC(
             ServiceDelivery__c.Contact__c.getDescribe()
         );
-        Map<String, Object> peField = fieldSetService.getFieldForLWC(
+        Map<String, Object> engagementField = fieldSetService.getFieldForLWC(
             ServiceDelivery__c.ProgramEngagement__c.getDescribe()
         );
 
@@ -92,7 +92,8 @@ public with sharing class ServiceService {
                 continue;
             }
 
-            indexToInsertServiceField = fieldSetValues.indexOf(peField) + 1;
+            Integer indexToInsertServiceField =
+                fieldSetValues.indexOf(engagementField) + 1;
             indexToInsertServiceField = indexToInsertServiceField > 0
                 ? indexToInsertServiceField
                 : fieldSetValues.indexOf(contactField) + 1;

--- a/force-app/main/default/classes/ServiceService.cls
+++ b/force-app/main/default/classes/ServiceService.cls
@@ -97,7 +97,12 @@ public with sharing class ServiceService {
             indexToInsertServiceField = indexToInsertServiceField > 0
                 ? indexToInsertServiceField
                 : fieldSetValues.indexOf(contactField) + 1;
-            fieldSetValues.add(indexToInsertServiceField, serviceField);
+
+            if (fieldSetValues.size() <= indexToInsertServiceField) {
+                fieldSetValues.add(serviceField);
+            } else {
+                fieldSetValues.add(indexToInsertServiceField, serviceField);
+            }
         }
 
         return fieldSets;

--- a/force-app/main/default/classes/ServiceService.cls
+++ b/force-app/main/default/classes/ServiceService.cls
@@ -12,6 +12,9 @@ public with sharing class ServiceService {
     }
 
     @TestVisible
+    private static FieldSetService fieldSetService = new FieldSetService();
+
+    @TestVisible
     private ServiceSelector serviceSelector = new ServiceSelector();
 
     @TestVisible
@@ -63,5 +66,43 @@ public with sharing class ServiceService {
             allServices.add(convertObjectToOption(service, serviceProgram));
         }
         return allServices;
+    }
+
+    public Map<String, Object> getFieldSetsByName(String objectName) {
+        Integer indexToInsertServiceField;
+        Boolean fieldSetContainsServiceField = true;
+        Map<String, Object> serviceField = new Map<String, Object>();
+
+        Map<String, Object> fieldSets = fieldSetService.getFieldSetsByName(objectName);
+
+        for (String key : fieldSets.keySet()) {
+            indexToInsertServiceField = 0;
+            List<Map<String, Object>> fieldSetValues = (List<Map<String, Object>>) fieldSets.get(
+                key
+            );
+
+            for (Map<String, Object> field : fieldSetValues) {
+                String fieldApiName = (String) field.get('apiName');
+
+                if (fieldApiName == 'Contact__c') {
+                    indexToInsertServiceField = fieldSetValues.indexOf(field) + 1;
+                }
+                if (fieldApiName == 'ProgramEngagement__c') {
+                    indexToInsertServiceField = fieldSetValues.indexOf(field) + 1;
+                }
+
+                if (fieldApiName != 'Service__c') {
+                    fieldSetContainsServiceField = false;
+                }
+            }
+
+            if (!fieldSetContainsServiceField) {
+                DescribeFieldResult serviceFieldDescribe = ServiceDelivery__c.Service__c.getDescribe();
+                serviceField = fieldSetService.getFieldForLWC(serviceFieldDescribe);
+                fieldSetValues.add(indexToInsertServiceField, serviceField);
+            }
+        }
+
+        return fieldSets;
     }
 }

--- a/force-app/main/default/classes/ServiceService.cls
+++ b/force-app/main/default/classes/ServiceService.cls
@@ -68,7 +68,8 @@ public with sharing class ServiceService {
         return allServices;
     }
 
-    public Map<String, Object> getFieldSetsByName(String objectName) {
+    public Map<String, Object> getServiceDeliveryFieldSets() {
+        String objectName = Schema.SObjectType.ServiceDelivery__c.getName();
         Integer indexToInsertServiceField;
         Boolean fieldSetContainsServiceField = true;
         Map<String, Object> serviceField = new Map<String, Object>();
@@ -84,14 +85,23 @@ public with sharing class ServiceService {
             for (Map<String, Object> field : fieldSetValues) {
                 String fieldApiName = (String) field.get('apiName');
 
-                if (fieldApiName == 'Contact__c') {
+                if (
+                    fieldApiName ==
+                    Schema.SObjectType.ServiceDelivery__c.Fields.Contact__c.getName()
+                ) {
                     indexToInsertServiceField = fieldSetValues.indexOf(field) + 1;
                 }
-                if (fieldApiName == 'ProgramEngagement__c') {
+                if (
+                    fieldApiName ==
+                    Schema.SObjectType.ServiceDelivery__c.Fields.ProgramEngagement__c.getName()
+                ) {
                     indexToInsertServiceField = fieldSetValues.indexOf(field) + 1;
                 }
 
-                if (fieldApiName != 'Service__c') {
+                if (
+                    fieldApiName !=
+                    Schema.SObjectType.ServiceDelivery__c.Fields.Service__c.getName()
+                ) {
                     fieldSetContainsServiceField = false;
                 }
             }

--- a/force-app/main/default/classes/ServiceService_TEST.cls
+++ b/force-app/main/default/classes/ServiceService_TEST.cls
@@ -153,4 +153,111 @@ public with sharing class ServiceService_TEST {
             programEngagementId
         );
     }
+
+    //Removing the service field from the fieldset
+    @IsTest
+    private static void testGetServiceDeliveryFieldSetsWithoutService() {
+        String methodName = 'getFieldSetsByName';
+        String getLWCMethodName = 'getFieldForLWC';
+        Map<String, Object> removedServiceField;
+        FieldSetService fieldSetService = new FieldSetService();
+        Integer serviceFieldIndex;
+
+        Map<String, Object> expectedFieldSets = fieldSetService.getFieldSetsByName(
+            Schema.SObjectType.ServiceDelivery__c.getName()
+        );
+
+        Map<String, Object> serviceField = fieldSetService.getFieldForLWC(
+            ServiceDelivery__c.Service__c.getDescribe()
+        );
+
+        Map<String, Object> contactField = fieldSetService.getFieldForLWC(
+            ServiceDelivery__c.Contact__c.getDescribe()
+        );
+
+        Map<String, Object> engagementField = fieldSetService.getFieldForLWC(
+            ServiceDelivery__c.ProgramEngagement__c.getDescribe()
+        );
+
+        //Remove the service field from the fieldset that we got back
+        for (String key : expectedFieldSets.keySet()) {
+            List<Map<String, Object>> fieldSetValues = (List<Map<String, Object>>) expectedFieldSets.get(
+                key
+            );
+
+            if (fieldSetValues.indexOf(serviceField) > 0) {
+                removedServiceField = fieldSetValues.remove(
+                    fieldSetValues.indexOf(serviceField)
+                );
+
+                System.assertEquals(
+                    removedServiceField,
+                    serviceField,
+                    'Service field was not removed from the fieldset'
+                );
+                System.assertEquals(
+                    false,
+                    fieldSetValues.contains(serviceField),
+                    'Service field was not removed from the fieldset'
+                );
+            }
+        }
+
+        fieldSetServiceStub.withReturnValue(methodName, String.class, expectedFieldSets);
+        fieldSetServiceStub.withReturnValue(
+            getLWCMethodName,
+            DescribeFieldResult.class,
+            serviceField
+        );
+        fieldSetServiceStub.withReturnValue(
+            getLWCMethodName,
+            DescribeFieldResult.class,
+            contactField
+        );
+        fieldSetServiceStub.withReturnValue(
+            getLWCMethodName,
+            DescribeFieldResult.class,
+            engagementField
+        );
+
+        Test.startTest();
+
+        final ServiceService service = new ServiceService();
+        service.fieldSetService = (fieldSetService) fieldSetServiceStub.createMock();
+        Map<String, Object> actualFieldSets = service.getServiceDeliveryFieldSets();
+
+        Test.stopTest();
+
+        for (String key : actualFieldSets.keySet()) {
+            List<Map<String, Object>> fieldSetValues = (List<Map<String, Object>>) actualFieldSets.get(
+                key
+            );
+
+            for (Map<String, Object> obj : fieldSetValues) {
+                System.debug('obj : ' + obj);
+            }
+
+            //serviceFieldIndex = fieldSetValues.indexOf(serviceField);
+
+            //System.assertEquals(2, serviceFieldIndex);
+        }
+
+        System.assertEquals(
+            expectedFieldSets.keySet(),
+            actualFieldSets.keySet(),
+            'Expected that both expected and actual have the same values'
+        );
+
+        fieldSetServiceStub.assertCalledWith(
+            methodName,
+            String.class,
+            Schema.SObjectType.ServiceDelivery__c.getName()
+        );
+
+        fieldSetServiceStub.assertCalledWith(
+            getLWCMethodName,
+            DescribeFieldResult.class,
+            ServiceDelivery__c.Service__c.getDescribe()
+        );
+    }
 }

--- a/force-app/main/default/classes/ServiceService_TEST.cls
+++ b/force-app/main/default/classes/ServiceService_TEST.cls
@@ -9,106 +9,100 @@
 
 @isTest
 public with sharing class ServiceService_TEST {
-    private static BasicStub engagementSelectorStub = new BasicStub(
-        ProgramEngagementSelector.class
-    );
-    private static BasicStub serviceSelectorStub = new BasicStub(ServiceSelector.class);
-
     @IsTest
     private static void testGetServicesEngagementsByContactId() {
         Id contactId = TestUtil.mockId(Contact.SObjectType);
 
-        Program__c program1 = new Program__c();
-        program1.Id = TestUtil.mockId(Program__c.SObjectType);
-        program1.Name = 'Program 1';
-        program1.Status__c = 'Active';
-        program1.StartDate__c = Date.today();
-        program1.EndDate__c = Date.today().addDays(30);
+        Program__c program1 = new Program__c(
+            Id = TestUtil.mockId(Program__c.SObjectType),
+            Name = 'Program 1',
+            Status__c = 'Active',
+            StartDate__c = Date.today(),
+            EndDate__c = Date.today().addDays(30)
+        );
 
-        ProgramEngagement__c engagement1 = new ProgramEngagement__c();
-        engagement1.Name = 'Engagement 1';
-        engagement1.Stage__c = 'Enrolled';
-        engagement1.Contact__c = contactId;
-        engagement1.Program__c = program1.Id;
-        engagement1.Role__c = 'Client';
+        ProgramEngagement__c engagement1 = new ProgramEngagement__c(
+            Name = 'Engagement 1',
+            Stage__c = 'Enrolled',
+            Contact__c = contactId,
+            Program__c = program1.Id,
+            Role__c = 'Client'
+        );
 
-        Service__c service1 = new Service__c();
-        service1.Id = TestUtil.mockId(Service__c.SObjectType);
-        service1.Name = 'Service 1';
-        service1.Program__c = program1.Id;
-        service1.Status__c = 'Active';
-        service1.UnitOfMeasurement__c = 'Hours';
+        Service__c service1 = new Service__c(
+            Id = TestUtil.mockId(Service__c.SObjectType),
+            Name = 'Service 1',
+            Program__c = program1.Id,
+            Status__c = 'Active',
+            UnitOfMeasurement__c = 'Hours'
+        );
 
         List<ProgramEngagement__c> engagements = new List<ProgramEngagement__c>{
             engagement1
         };
         List<Service__c> services = new List<Service__c>{ service1 };
-        engagementSelectorStub.withReturnValue(
-            'getProgramEngagementsByContactId',
-            Id.class,
-            engagements
-        );
-        serviceSelectorStub.withReturnValue(
-            'getServicesByProgramIds',
-            Set<Id>.class,
-            services
-        );
+        Stub engagementSelectorStub = new StubBuilder(ProgramEngagementSelector.class)
+            .when('getProgramEngagementsByContactId', Id.class)
+            .calledWith(contactId)
+            .thenReturn(engagements)
+            .build();
+        Stub serviceSelectorStub = new StubBuilder(ServiceSelector.class)
+            .when('getServicesByProgramIds', Set<Id>.class)
+            .calledWith(new Set<Id>{ program1.Id })
+            .thenReturn(services)
+            .build();
+
+        ServiceService service = new ServiceService();
+        service.serviceSelector = (ServiceSelector) serviceSelectorStub.create();
+        service.engagementSelector = (ProgramEngagementSelector) engagementSelectorStub.create();
 
         Test.startTest();
-
-        final ServiceService service = new ServiceService();
-        service.serviceSelector = (ServiceSelector) serviceSelectorStub.createMock();
-        service.engagementSelector = (ProgramEngagementSelector) engagementSelectorStub.createMock();
-
-        final Map<String, List<Object>> actual = service.getServicesEngagementsByContactId(
+        Map<String, List<Object>> actual = service.getServicesEngagementsByContactId(
             contactId
         );
-
         Test.stopTest();
 
         Set<String> expectedKeySet = new Set<String>{ 'engagements', 'services' };
-
-        System.assertEquals(expectedKeySet, actual.keySet());
+        System.assertEquals(
+            expectedKeySet,
+            actual.keySet(),
+            'Expected both keys to be returned.'
+        );
 
         for (List<Object> objList : actual.values()) {
             System.assert(!objList.isEmpty());
         }
 
-        serviceSelectorStub.assertCalledWith(
-            'getServicesByProgramIds',
-            Set<Id>.class,
-            new Set<Id>{ program1.Id }
-        );
-        engagementSelectorStub.assertCalledWith(
-            'getProgramEngagementsByContactId',
-            Id.class,
-            contactId
-        );
+        engagementSelectorStub.assertMethodsCalled();
+        serviceSelectorStub.assertMethodsCalled();
     }
 
     @IsTest
     private static void testGetServicesByProgramEngagementId() {
         Id programEngagementId = TestUtil.mockId(ProgramEngagement__c.SObjectType);
 
-        Program__c program1 = new Program__c();
-        program1.Id = TestUtil.mockId(Program__c.SObjectType);
-        program1.Name = 'Program 1';
-        program1.Status__c = 'Active';
-        program1.StartDate__c = Date.today();
-        program1.EndDate__c = Date.today().addDays(30);
+        Program__c program1 = new Program__c(
+            Id = TestUtil.mockId(Program__c.SObjectType),
+            Name = 'Program 1',
+            Status__c = 'Active',
+            StartDate__c = Date.today(),
+            EndDate__c = Date.today().addDays(30)
+        );
 
-        ProgramEngagement__c engagement1 = new ProgramEngagement__c();
-        engagement1.Name = 'Engagement 1';
-        engagement1.Stage__c = 'Enrolled';
-        engagement1.Program__c = program1.Id;
-        engagement1.Role__c = 'Client';
+        ProgramEngagement__c engagement1 = new ProgramEngagement__c(
+            Name = 'Engagement 1',
+            Stage__c = 'Enrolled',
+            Program__c = program1.Id,
+            Role__c = 'Client'
+        );
 
-        Service__c service1 = new Service__c();
-        service1.Id = TestUtil.mockId(Service__c.SObjectType);
-        service1.Name = 'Service 1';
-        service1.Program__c = program1.Id;
-        service1.Status__c = 'Active';
-        service1.UnitOfMeasurement__c = 'Hours';
+        Service__c service1 = new Service__c(
+            Id = TestUtil.mockId(Service__c.SObjectType),
+            Name = 'Service 1',
+            Program__c = program1.Id,
+            Status__c = 'Active',
+            UnitOfMeasurement__c = 'Hours'
+        );
 
         List<Service__c> services = new List<Service__c>{ service1 };
         Map<String, String> expectedValues = new Map<String, String>();
@@ -118,16 +112,16 @@ public with sharing class ServiceService_TEST {
 
         final List<object> expected = new List<Object>{ expectedValues };
 
-        serviceSelectorStub.withReturnValue(
-            'getServicesByProgramEngagementId',
-            Id.class,
-            services
-        );
+        Stub serviceSelectorStub = new StubBuilder(ServiceSelector.class)
+            .when('getServicesByProgramEngagementId', Id.class)
+            .calledWith(programEngagementId)
+            .thenReturn(services)
+            .build();
 
         Test.startTest();
 
         final ServiceService service = new ServiceService();
-        service.serviceSelector = (ServiceSelector) serviceSelectorStub.createMock();
+        service.serviceSelector = (ServiceSelector) serviceSelectorStub.create();
 
         final List<Object> actual = service.getServicesByProgramEngagementId(
             programEngagementId
@@ -146,11 +140,7 @@ public with sharing class ServiceService_TEST {
             'Expected the size of both expected and actual are the same'
         );
 
-        serviceSelectorStub.assertCalledWith(
-            'getServicesByProgramEngagementId',
-            Id.class,
-            programEngagementId
-        );
+        serviceSelectorStub.assertMethodsCalled();
     }
 
     //Removing the service field from the fieldset
@@ -232,6 +222,6 @@ public with sharing class ServiceService_TEST {
             );
         }
 
-        fieldSetServiceStub.expectedMethodsCalled();
+        fieldSetServiceStub.assertMethodsCalled();
     }
 }

--- a/force-app/main/default/classes/ServiceService_TEST.cls
+++ b/force-app/main/default/classes/ServiceService_TEST.cls
@@ -13,6 +13,7 @@ public with sharing class ServiceService_TEST {
         ProgramEngagementSelector.class
     );
     private static BasicStub serviceSelectorStub = new BasicStub(ServiceSelector.class);
+    private static BasicStub fieldSetServiceStub = new BasicStub(FieldSetService.class);
 
     @IsTest
     private static void testGetServicesEngagementsByContactId() {

--- a/force-app/main/default/classes/ServiceService_TEST.cls
+++ b/force-app/main/default/classes/ServiceService_TEST.cls
@@ -282,4 +282,111 @@ public with sharing class ServiceService_TEST {
 
         fieldSetServiceStub.assertMethodsCalled();
     }
+
+    //Removing the contact and service field from the fieldset
+    @IsTest
+    private static void testGetServiceDeliveryFieldSetsWithoutContactAndService() {
+        Map<String, Object> removedServiceField;
+        Map<String, Object> removedContactField;
+        FieldSetService fieldSetService = new FieldSetService();
+        Integer serviceFieldIndex;
+
+        Map<String, Object> fieldSetsToReturn = fieldSetService.getFieldSetsByName(
+            Schema.SObjectType.ServiceDelivery__c.getName()
+        );
+        Map<String, Object> serviceField = fieldSetService.getFieldForLWC(
+            ServiceDelivery__c.Service__c.getDescribe()
+        );
+        Map<String, Object> contactField = fieldSetService.getFieldForLWC(
+            ServiceDelivery__c.Contact__c.getDescribe()
+        );
+        Map<String, Object> engagementField = fieldSetService.getFieldForLWC(
+            ServiceDelivery__c.ProgramEngagement__c.getDescribe()
+        );
+
+        //Remove the contact and service field from the fieldset that we got back
+        for (String key : fieldSetsToReturn.keySet()) {
+            List<Map<String, Object>> fieldSetValues = (List<Map<String, Object>>) fieldSetsToReturn.get(
+                key
+            );
+
+            if (fieldSetValues.indexOf(serviceField) > 0) {
+                removedServiceField = fieldSetValues.remove(
+                    fieldSetValues.indexOf(serviceField)
+                );
+
+                System.assertEquals(
+                    removedServiceField,
+                    serviceField,
+                    'Service field was not removed from the fieldset as expected'
+                );
+
+                System.assertEquals(
+                    false,
+                    fieldSetValues.contains(serviceField),
+                    'Service field was not removed from the fieldset'
+                );
+            }
+
+            if (fieldSetValues.indexOf(contactField) > 0) {
+                removedContactField = fieldSetValues.remove(
+                    fieldSetValues.indexOf(contactField)
+                );
+
+                System.assertEquals(
+                    removedContactField,
+                    contactField,
+                    'Contact field was not removed from the fieldset as expected'
+                );
+
+                System.assertEquals(
+                    false,
+                    fieldSetValues.contains(contactField),
+                    'Contact field was not removed from the fieldset'
+                );
+            }
+        }
+
+        Stub fieldSetServiceStub = new StubBuilder(fieldSetService.class)
+            .when('getFieldSetsByName', String.class)
+            .calledWith(Schema.SObjectType.ServiceDelivery__c.getName())
+            .thenReturn(fieldSetsToReturn)
+            .when('getFieldForLWC', DescribeFieldResult.class)
+            .calledWith(ServiceDelivery__c.Service__c.getDescribe())
+            .thenReturn(serviceField)
+            .when('getFieldForLWC', DescribeFieldResult.class)
+            .calledWith(ServiceDelivery__c.Contact__c.getDescribe())
+            .thenReturn(contactField)
+            .when('getFieldForLWC', DescribeFieldResult.class)
+            .calledWith(ServiceDelivery__c.ProgramEngagement__c.getDescribe())
+            .thenReturn(engagementField)
+            .build();
+
+        ServiceService service = new ServiceService();
+        service.fieldSetService = (FieldSetService) fieldSetServiceStub.create();
+
+        Test.startTest();
+        Map<String, Object> actualFieldSets = service.getServiceDeliveryFieldSets();
+        Test.stopTest();
+
+        for (String key : actualFieldSets.keySet()) {
+            List<Map<String, Object>> fieldSetValues = (List<Map<String, Object>>) actualFieldSets.get(
+                key
+            );
+
+            serviceFieldIndex = fieldSetValues.indexOf(serviceField);
+
+            System.assert(
+                serviceFieldIndex > 0,
+                'Expected the service field to be after the program engagement field.'
+            );
+        }
+
+        fieldSetServiceStub.assertMethodsCalled();
+    }
+
+    // TODO: Write more tests for the following scenarios :
+    // 1. Remove the program engagement and contact field the fieldset
+    // 2. Remove the program engagement field from the fieldset
+    // 3. Test List index scenario when fieldset size is less than the index of where the service field needs to be added
 }

--- a/force-app/main/default/classes/ServiceService_TEST.cls
+++ b/force-app/main/default/classes/ServiceService_TEST.cls
@@ -224,4 +224,62 @@ public with sharing class ServiceService_TEST {
 
         fieldSetServiceStub.assertMethodsCalled();
     }
+
+    //Do not remove any fields from the fieldset
+    @IsTest
+    private static void testGetServiceDeliveryFieldSetsWithAllFields() {
+        Map<String, Object> removedServiceField;
+        FieldSetService fieldSetService = new FieldSetService();
+        Integer serviceFieldIndex;
+
+        Map<String, Object> fieldSetsToReturn = fieldSetService.getFieldSetsByName(
+            Schema.SObjectType.ServiceDelivery__c.getName()
+        );
+        Map<String, Object> serviceField = fieldSetService.getFieldForLWC(
+            ServiceDelivery__c.Service__c.getDescribe()
+        );
+        Map<String, Object> contactField = fieldSetService.getFieldForLWC(
+            ServiceDelivery__c.Contact__c.getDescribe()
+        );
+        Map<String, Object> engagementField = fieldSetService.getFieldForLWC(
+            ServiceDelivery__c.ProgramEngagement__c.getDescribe()
+        );
+
+        Stub fieldSetServiceStub = new StubBuilder(fieldSetService.class)
+            .when('getFieldSetsByName', String.class)
+            .calledWith(Schema.SObjectType.ServiceDelivery__c.getName())
+            .thenReturn(fieldSetsToReturn)
+            .when('getFieldForLWC', DescribeFieldResult.class)
+            .calledWith(ServiceDelivery__c.Service__c.getDescribe())
+            .thenReturn(serviceField)
+            .when('getFieldForLWC', DescribeFieldResult.class)
+            .calledWith(ServiceDelivery__c.Contact__c.getDescribe())
+            .thenReturn(contactField)
+            .when('getFieldForLWC', DescribeFieldResult.class)
+            .calledWith(ServiceDelivery__c.ProgramEngagement__c.getDescribe())
+            .thenReturn(engagementField)
+            .build();
+
+        ServiceService service = new ServiceService();
+        service.fieldSetService = (FieldSetService) fieldSetServiceStub.create();
+
+        Test.startTest();
+        Map<String, Object> actualFieldSets = service.getServiceDeliveryFieldSets();
+        Test.stopTest();
+
+        for (String key : actualFieldSets.keySet()) {
+            List<Map<String, Object>> fieldSetValues = (List<Map<String, Object>>) actualFieldSets.get(
+                key
+            );
+
+            serviceFieldIndex = fieldSetValues.indexOf(serviceField);
+
+            System.assert(
+                serviceFieldIndex > 0,
+                'Expected the service field to be after the contact or the program engagement field.'
+            );
+        }
+
+        fieldSetServiceStub.assertMethodsCalled();
+    }
 }

--- a/force-app/main/default/classes/ServiceService_TEST.cls
+++ b/force-app/main/default/classes/ServiceService_TEST.cls
@@ -13,7 +13,6 @@ public with sharing class ServiceService_TEST {
         ProgramEngagementSelector.class
     );
     private static BasicStub serviceSelectorStub = new BasicStub(ServiceSelector.class);
-    private static BasicStub fieldSetServiceStub = new BasicStub(FieldSetService.class);
 
     @IsTest
     private static void testGetServicesEngagementsByContactId() {
@@ -157,31 +156,26 @@ public with sharing class ServiceService_TEST {
     //Removing the service field from the fieldset
     @IsTest
     private static void testGetServiceDeliveryFieldSetsWithoutService() {
-        String methodName = 'getFieldSetsByName';
-        String getLWCMethodName = 'getFieldForLWC';
         Map<String, Object> removedServiceField;
         FieldSetService fieldSetService = new FieldSetService();
         Integer serviceFieldIndex;
 
-        Map<String, Object> expectedFieldSets = fieldSetService.getFieldSetsByName(
+        Map<String, Object> fieldSetsToReturn = fieldSetService.getFieldSetsByName(
             Schema.SObjectType.ServiceDelivery__c.getName()
         );
-
         Map<String, Object> serviceField = fieldSetService.getFieldForLWC(
             ServiceDelivery__c.Service__c.getDescribe()
         );
-
         Map<String, Object> contactField = fieldSetService.getFieldForLWC(
             ServiceDelivery__c.Contact__c.getDescribe()
         );
-
         Map<String, Object> engagementField = fieldSetService.getFieldForLWC(
             ServiceDelivery__c.ProgramEngagement__c.getDescribe()
         );
 
         //Remove the service field from the fieldset that we got back
-        for (String key : expectedFieldSets.keySet()) {
-            List<Map<String, Object>> fieldSetValues = (List<Map<String, Object>>) expectedFieldSets.get(
+        for (String key : fieldSetsToReturn.keySet()) {
+            List<Map<String, Object>> fieldSetValues = (List<Map<String, Object>>) fieldSetsToReturn.get(
                 key
             );
 
@@ -193,7 +187,7 @@ public with sharing class ServiceService_TEST {
                 System.assertEquals(
                     removedServiceField,
                     serviceField,
-                    'Service field was not removed from the fieldset'
+                    'Service field was not removed from the fieldset as expected'
                 );
                 System.assertEquals(
                     false,
@@ -203,29 +197,26 @@ public with sharing class ServiceService_TEST {
             }
         }
 
-        fieldSetServiceStub.withReturnValue(methodName, String.class, expectedFieldSets);
-        fieldSetServiceStub.withReturnValue(
-            getLWCMethodName,
-            DescribeFieldResult.class,
-            serviceField
-        );
-        fieldSetServiceStub.withReturnValue(
-            getLWCMethodName,
-            DescribeFieldResult.class,
-            contactField
-        );
-        fieldSetServiceStub.withReturnValue(
-            getLWCMethodName,
-            DescribeFieldResult.class,
-            engagementField
-        );
+        Stub fieldSetServiceStub = new StubBuilder(fieldSetService.class)
+            .when('getFieldSetsByName', String.class)
+            .calledWith(Schema.SObjectType.ServiceDelivery__c.getName())
+            .thenReturn(fieldSetsToReturn)
+            .when('getFieldForLWC', DescribeFieldResult.class)
+            .calledWith(ServiceDelivery__c.Service__c.getDescribe())
+            .thenReturn(serviceField)
+            .when('getFieldForLWC', DescribeFieldResult.class)
+            .calledWith(ServiceDelivery__c.Contact__c.getDescribe())
+            .thenReturn(contactField)
+            .when('getFieldForLWC', DescribeFieldResult.class)
+            .calledWith(ServiceDelivery__c.ProgramEngagement__c.getDescribe())
+            .thenReturn(engagementField)
+            .build();
+
+        ServiceService service = new ServiceService();
+        service.fieldSetService = (FieldSetService) fieldSetServiceStub.create();
 
         Test.startTest();
-
-        final ServiceService service = new ServiceService();
-        service.fieldSetService = (fieldSetService) fieldSetServiceStub.createMock();
         Map<String, Object> actualFieldSets = service.getServiceDeliveryFieldSets();
-
         Test.stopTest();
 
         for (String key : actualFieldSets.keySet()) {
@@ -233,31 +224,14 @@ public with sharing class ServiceService_TEST {
                 key
             );
 
-            for (Map<String, Object> obj : fieldSetValues) {
-                System.debug('obj : ' + obj);
-            }
+            serviceFieldIndex = fieldSetValues.indexOf(serviceField);
 
-            //serviceFieldIndex = fieldSetValues.indexOf(serviceField);
-
-            //System.assertEquals(2, serviceFieldIndex);
+            System.assert(
+                serviceFieldIndex > 0,
+                'Expected the service field to be after the contact or the program engagement field.'
+            );
         }
 
-        System.assertEquals(
-            expectedFieldSets.keySet(),
-            actualFieldSets.keySet(),
-            'Expected that both expected and actual have the same values'
-        );
-
-        fieldSetServiceStub.assertCalledWith(
-            methodName,
-            String.class,
-            Schema.SObjectType.ServiceDelivery__c.getName()
-        );
-
-        fieldSetServiceStub.assertCalledWith(
-            getLWCMethodName,
-            DescribeFieldResult.class,
-            ServiceDelivery__c.Service__c.getDescribe()
-        );
+        fieldSetServiceStub.expectedMethodsCalled();
     }
 }

--- a/force-app/main/default/classes/Stub.cls
+++ b/force-app/main/default/classes/Stub.cls
@@ -31,7 +31,7 @@ public with sharing class Stub implements System.StubProvider {
         return null;
     }
 
-    public void expectedMethodsCalled() {
+    public void assertMethodsCalled() {
         for (MethodCall methodCall : methodCalls) {
             methodCall.expectedToHaveBeenCalled();
         }

--- a/force-app/main/default/classes/Stub.cls
+++ b/force-app/main/default/classes/Stub.cls
@@ -1,0 +1,145 @@
+@IsTest
+public with sharing class Stub implements System.StubProvider {
+    private Type objType;
+    List<MethodCall> methodCalls = new List<MethodCall>();
+
+    public Stub(Type objType) {
+        this.objType = objType;
+    }
+
+    public Stub(Type objType, List<MethodCall> methodCalls) {
+        this(objType);
+        this.methodCalls = methodCalls;
+    }
+
+    public Object handleMethodCall(
+        Object obj,
+        String methodName,
+        Type returnType,
+        List<Type> paramTypes,
+        List<String> paramNames,
+        List<Object> args
+    ) {
+        Signature signature = new Signature(methodName, paramTypes);
+
+        for (MethodCall methodCall : methodCalls) {
+            if (methodCall.matches(signature, args)) {
+                return methodCall.handleCall();
+            }
+        }
+
+        return null;
+    }
+
+    public void expectedMethodsCalled() {
+        for (MethodCall methodCall : methodCalls) {
+            methodCall.expectedToHaveBeenCalled();
+        }
+    }
+
+    public Object create() {
+        return Test.createStub(objType, this);
+    }
+
+    public class MethodCall {
+        private Signature signature;
+        private List<Object> args;
+        private Object returnValue;
+        private Boolean throwException = false;
+        private List<Id> ids;
+        private Integer callCount = 0;
+        private String testExceptionMessage = 'Exception thrown by Stub.';
+
+        public MethodCall(Signature signature) {
+            this.signature = signature;
+        }
+
+        public Object handleCall() {
+            callCount++;
+
+            if (ids != null) {
+                List<SObject> sObjects = (List<SObject>) args[0];
+                for (Integer i = 0; i < sObjects.size(); i++) {
+                    sObjects[i].Id = ids[i];
+                }
+            }
+
+            if (throwException) {
+                throw new StubException(testExceptionMessage);
+            }
+
+            return returnValue;
+        }
+
+        public void expectedToHaveBeenCalled() {
+            if (callCount < 1) {
+                System.assert(
+                    false,
+                    'This bound method was not called as expected: ' + this.toString()
+                );
+            }
+        }
+
+        public MethodCall calledWith(List<Object> args) {
+            this.args = args;
+            return this;
+        }
+
+        public MethodCall thenReturn(Object returnValue) {
+            this.returnValue = returnValue;
+            return this;
+        }
+
+        public MethodCall setIds(List<Id> ids) {
+            this.ids = ids;
+            return this;
+        }
+
+        // TODO: Allow exceptions to be passed in.
+        public MethodCall thenThrowException() {
+            throwException = true;
+            return this;
+        }
+
+        // TODO: Explore equals or making this better
+        public Boolean matches(Signature signature, List<Object> args) {
+            return this.signature.equals(signature) && argsMatch(args);
+        }
+
+        private Boolean argsMatch(List<Object> compareTo) {
+            Boolean matchesSoFar = args.size() == compareTo.size();
+
+            for (Integer i = 0; i < compareTo.size(); i++) {
+                if (!matchesSoFar) {
+                    break;
+                }
+
+                matchesSoFar &= String.valueOf(args[i]) == String.valueOf(compareTo[i]);
+            }
+
+            return matchesSoFar;
+        }
+    }
+
+    public class Signature {
+        private String methodName;
+        private List<Type> paramTypes;
+
+        public Signature(String methodName, List<Type> paramTypes) {
+            this.methodName = methodName;
+            this.paramTypes = paramTypes;
+        }
+
+        public Boolean equals(Object otherInstance) {
+            if (otherInstance instanceof Signature) {
+                Signature otherSignature = (Signature) otherInstance;
+                return ((methodName == otherSignature.methodName) &&
+                paramTypes.equals(otherSignature.paramTypes));
+            }
+            return false;
+        }
+    }
+
+    private class StubException extends Exception {
+    }
+}

--- a/force-app/main/default/classes/Stub.cls-meta.xml
+++ b/force-app/main/default/classes/Stub.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>51.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/StubBuilder.cls
+++ b/force-app/main/default/classes/StubBuilder.cls
@@ -1,0 +1,165 @@
+public with sharing class StubBuilder {
+    private Type objType;
+    List<SignatureBuilder> signatureBuilders = new List<SignatureBuilder>();
+
+    public StubBuilder(Type objType) {
+        this.objType = objType;
+    }
+
+    public SignatureBuilder when(String methodName, List<Type> paramTypes) {
+        SignatureBuilder sb = new SignatureBuilder(this, methodName, paramTypes);
+        signatureBuilders.add(sb);
+        return sb;
+    }
+
+    public SignatureBuilder when(String methodName) {
+        return when(methodName, new List<Type>());
+    }
+
+    public SignatureBuilder when(String methodName, Type paramType) {
+        return when(methodName, new List<Type>{ paramType });
+    }
+
+    public SignatureBuilder when(String methodName, Type paramType, Type paramType2) {
+        return when(methodName, new List<Type>{ paramType, paramType2 });
+    }
+
+    public SignatureBuilder when(
+        String methodName,
+        Type paramType,
+        Type paramType2,
+        Type paramType3
+    ) {
+        return when(methodName, new List<Type>{ paramType, paramType2, paramType3 });
+    }
+
+    public SignatureBuilder when(
+        String methodName,
+        Type paramType,
+        Type paramType2,
+        Type paramType3,
+        Type paramType4
+    ) {
+        return when(
+            methodName,
+            new List<Type>{ paramType, paramType2, paramType3, paramType4 }
+        );
+    }
+
+    public Stub build() {
+        List<Stub.MethodCall> methodCalls = new List<Stub.MethodCall>();
+        for (SignatureBuilder sb : signatureBuilders) {
+            methodCalls.addAll(sb.build());
+        }
+        return new Stub(objType, methodCalls);
+    }
+
+    public class SignatureBuilder {
+        private StubBuilder builder;
+        private String methodName;
+        private List<Type> paramTypes;
+
+        List<MethodBuilder> methodBuilders = new List<MethodBuilder>();
+
+        public SignatureBuilder(
+            StubBuilder builder,
+            String methodName,
+            List<Type> paramTypes
+        ) {
+            this.builder = builder;
+            this.methodName = methodName;
+            this.paramTypes = paramTypes;
+        }
+
+        public MethodBuilder called() {
+            return calledWith(new List<Object>());
+        }
+
+        public MethodBuilder calledWith(List<Object> args) {
+            MethodBuilder mb = new MethodBuilder(this, args);
+            methodBuilders.add(mb);
+            return mb;
+        }
+
+        public MethodBuilder calledWith(Object arg) {
+            return calledWith(new List<Object>{ arg });
+        }
+
+        public MethodBuilder calledWith(Object arg, Object arg2) {
+            return calledWith(new List<Object>{ arg, arg2 });
+        }
+
+        public MethodBuilder calledWith(Object arg, Object arg2, Object arg3) {
+            return calledWith(new List<Object>{ arg, arg2, arg3 });
+        }
+
+        public MethodBuilder calledWith(
+            Object arg,
+            Object arg2,
+            Object arg3,
+            Object arg4
+        ) {
+            return calledWith(new List<Object>{ arg, arg2, arg3, arg4 });
+        }
+
+        private StubBuilder endSignature() {
+            return builder;
+        }
+
+        private List<Stub.MethodCall> build() {
+            Stub.Signature signature = new Stub.Signature(methodName, paramTypes);
+            List<Stub.MethodCall> methodCalls = new List<Stub.MethodCall>();
+            for (MethodBuilder mb : methodBuilders) {
+                methodCalls.add(mb.build(signature));
+            }
+
+            return methodCalls;
+        }
+    }
+
+    public class MethodBuilder {
+        private SignatureBuilder signatureBuilder;
+        private List<Object> args;
+        private List<Id> ids;
+        private Boolean throwException = false;
+        private Object returnValue;
+
+        public MethodBuilder(SignatureBuilder signatureBuilder, List<Object> args) {
+            this.args = args;
+            this.signatureBuilder = signatureBuilder;
+        }
+
+        public MethodBuilder setIds(List<Id> ids) {
+            this.ids = ids;
+            return this;
+        }
+
+        public StubBuilder thenReturn(Object returnValue) {
+            this.returnValue = returnValue;
+            return signatureBuilder.endSignature();
+        }
+
+        public StubBuilder thenReturn() {
+            return signatureBuilder.endSignature();
+        }
+
+        public StubBuilder thenThrowException() {
+            throwException = true;
+            return signatureBuilder.endSignature();
+        }
+
+        private Stub.MethodCall build(Stub.Signature signature) {
+            Stub.MethodCall methodCall = new Stub.MethodCall(signature).calledWith(args);
+            if (ids != null) {
+                methodCall.setIds(ids);
+            }
+            if (throwException) {
+                methodCall.thenThrowException();
+            } else {
+                methodCall.thenReturn(returnValue);
+            }
+
+            return methodCall;
+        }
+    }
+}

--- a/force-app/main/default/classes/StubBuilder.cls-meta.xml
+++ b/force-app/main/default/classes/StubBuilder.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>51.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/lwc/bulkServiceDeliveryUI/bulkServiceDeliveryUI.js
+++ b/force-app/main/default/lwc/bulkServiceDeliveryUI/bulkServiceDeliveryUI.js
@@ -33,7 +33,7 @@ import SERVICE_DELIVERY_FIELD_SET_FIELD from "@salesforce/schema/Service__c.Serv
 import SERVICE_FIELD from "@salesforce/schema/ServiceDelivery__c.Service__c";
 import SERVICEDELIVERY_OBJECT from "@salesforce/schema/ServiceDelivery__c";
 
-import getFieldSets from "@salesforce/apex/ServiceDeliveryController.getFieldSetsByName";
+import getFieldSets from "@salesforce/apex/ServiceDeliveryController.getServiceDeliveryFieldSets";
 
 import pmmFolder from "@salesforce/resourceUrl/pmm";
 export default class BulkServiceDeliveryUI extends NavigationMixin(LightningElement) {

--- a/force-app/main/default/lwc/bulkServiceDeliveryUI/bulkServiceDeliveryUI.js
+++ b/force-app/main/default/lwc/bulkServiceDeliveryUI/bulkServiceDeliveryUI.js
@@ -33,7 +33,7 @@ import SERVICE_DELIVERY_FIELD_SET_FIELD from "@salesforce/schema/Service__c.Serv
 import SERVICE_FIELD from "@salesforce/schema/ServiceDelivery__c.Service__c";
 import SERVICEDELIVERY_OBJECT from "@salesforce/schema/ServiceDelivery__c";
 
-import getFieldSets from "@salesforce/apex/FieldSetController.getFieldSetsByName";
+import getFieldSets from "@salesforce/apex/ServiceDeliveryController.getFieldSetsByName";
 
 import pmmFolder from "@salesforce/resourceUrl/pmm";
 export default class BulkServiceDeliveryUI extends NavigationMixin(LightningElement) {


### PR DESCRIPTION

# Critical Changes

# Changes
If the service field does not exist on the BSDT fieldsets then we will be automatically adding the field to the UI.
# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
~~- [ ] Any net new LWC work has Sa11y tests & 50% or above lines JEST test coverage ~~
~~- [ ] CRUD/FLS is enforced in Apex~~
~~- [ ] Permission sets are updated to account for CRUD|FLS|Tab|Classes~~
~~- [ ] Field sets are updated to account for new fields~~
- [x] UX approval or UX not necessary
- [x] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: W-0000000: Work Name (https://github.com/SalesforceFoundation/PMM/pull/303)
- [ ] All **acceptance criteria** have been met
    - [x] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [x] PR contains draft release notes
- [ ] QE story level testing completed