### PR TITLE
PE fields no longer required

### DIFF
--- a/force-app/main/default/layouts/ProgramEngagement__c-Program Engagement Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/ProgramEngagement__c-Program Engagement Layout.layout-meta.xml
@@ -19,7 +19,7 @@
                 <field>AutoName_Override__c</field>
             </layoutItems>
             <layoutItems>
-                <behavior>Required</behavior>
+                <behavior>Edit</behavior>
                 <field>Stage__c</field>
             </layoutItems>
             <layoutItems>
@@ -51,7 +51,7 @@
         <label>Additional Details</label>
         <layoutColumns>
             <layoutItems>
-                <behavior>Required</behavior>
+                <behavior>Edit</behavior>
                 <field>Role__c</field>
             </layoutItems>
             <layoutItems>

--- a/force-app/main/default/objects/ProgramEngagement__c/fields/Role__c.field-meta.xml
+++ b/force-app/main/default/objects/ProgramEngagement__c/fields/Role__c.field-meta.xml
@@ -5,7 +5,7 @@
     <externalId>false</externalId>
     <inlineHelpText>A Contact&#39;s relationship with the Program Engagement. Values are determined by your Admin.</inlineHelpText>
     <label>Role</label>
-    <required>true</required>
+    <required>false</required>
     <trackTrending>false</trackTrending>
     <type>Picklist</type>
     <valueSet>

--- a/force-app/main/default/objects/ProgramEngagement__c/fields/Stage__c.field-meta.xml
+++ b/force-app/main/default/objects/ProgramEngagement__c/fields/Stage__c.field-meta.xml
@@ -5,7 +5,7 @@
     <externalId>false</externalId>
     <inlineHelpText>These Picklist values describe a Contact&#39;s stage of engagement in a Program and are displayed in a Path. Values are determined by your Admin.</inlineHelpText>
     <label>Stage</label>
-    <required>true</required>
+    <required>false</required>
     <trackTrending>false</trackTrending>
     <type>Picklist</type>
     <valueSet>

--- a/force-app/main/default/quickActions/Contact.AddContactToProgram.quickAction-meta.xml
+++ b/force-app/main/default/quickActions/Contact.AddContactToProgram.quickAction-meta.xml
@@ -17,7 +17,7 @@
             <quickActionLayoutItems>
                 <emptySpace>false</emptySpace>
                 <field>Role__c</field>
-                <uiBehavior>Required</uiBehavior>
+                <uiBehavior>Edit</uiBehavior>
             </quickActionLayoutItems>
             <quickActionLayoutItems>
                 <emptySpace>false</emptySpace>
@@ -39,7 +39,7 @@
             <quickActionLayoutItems>
                 <emptySpace>false</emptySpace>
                 <field>Stage__c</field>
-                <uiBehavior>Required</uiBehavior>
+                <uiBehavior>Edit</uiBehavior>
             </quickActionLayoutItems>
         </quickActionLayoutColumns>
     </quickActionLayout>

--- a/force-app/main/default/quickActions/Program__c.AddContactToProgram.quickAction-meta.xml
+++ b/force-app/main/default/quickActions/Program__c.AddContactToProgram.quickAction-meta.xml
@@ -17,7 +17,7 @@
             <quickActionLayoutItems>
                 <emptySpace>false</emptySpace>
                 <field>Role__c</field>
-                <uiBehavior>Required</uiBehavior>
+                <uiBehavior>Edit</uiBehavior>
             </quickActionLayoutItems>
             <quickActionLayoutItems>
                 <emptySpace>false</emptySpace>
@@ -39,7 +39,7 @@
             <quickActionLayoutItems>
                 <emptySpace>false</emptySpace>
                 <field>Stage__c</field>
-                <uiBehavior>Required</uiBehavior>
+                <uiBehavior>Edit</uiBehavior>
             </quickActionLayoutItems>
         </quickActionLayoutColumns>
     </quickActionLayout>


### PR DESCRIPTION
# Critical Changes

# Changes
- The Stage and Role fields are no longer required on Program Engagement. Existing customers who want these fields to behave as not-required will need to make that adjustment to the Program Engagement page layout and the "Add Contact to Program" quick actions on Contact and Program.

# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
- [x] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: W-0000000: Work Name (https://github.com/SalesforceFoundation/PMM/pull/303)
- [ ] All **acceptance criteria** have been met
    - [x] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [x] PR contains draft release notes
- [ ] QE story level testing completed