### PR TITLE
Make New Service Schedule work in Experience Cloud

### DIFF
--- a/force-app/main/default/aura/createServiceSchedule/createServiceSchedule.cmp
+++ b/force-app/main/default/aura/createServiceSchedule/createServiceSchedule.cmp
@@ -21,7 +21,11 @@
     <aura:html tag="style">
         lightning-timepicker, lightning-datepicker { width: 100% }
         .slds-accordion__list-item { border-top: none; }
-        .slds-table_header-fixed_container { overflow-x: hidden; }
+        .slds-table_header-fixed_container { overflow-x: hidden; } .cuf-content { padding:
+        0 0rem !important; } .slds-p-around--medium { padding: 0rem !important; }
+        .slds-modal__content{ overflow-y:hidden !important; height:unset !important;
+        max-height:unset !important; } .slds-modal__container{ width: 80% !important;
+        max-width: 80% !important; }
     </aura:html>
     <c:serviceScheduleCreatorWrapper
         serviceId="{!v.serviceId}"

--- a/force-app/main/default/aura/createServiceSchedule/createServiceSchedule.cmp
+++ b/force-app/main/default/aura/createServiceSchedule/createServiceSchedule.cmp
@@ -23,9 +23,8 @@
         .slds-accordion__list-item { border-top: none; }
         .slds-table_header-fixed_container { overflow-x: hidden; } .cuf-content { padding:
         0 0rem !important; } .slds-p-around--medium { padding: 0rem !important; }
-        .slds-modal__content{ overflow-y:hidden !important; height:unset !important;
-        max-height:unset !important; } .slds-modal__container{ width: 80% !important;
-        max-width: 80% !important; }
+        .slds-modal__content{ height:unset !important; max-height:unset !important; }
+        .slds-modal__container{ width: 80% !important; max-width: 80% !important; }
     </aura:html>
     <c:serviceScheduleCreatorWrapper
         serviceId="{!v.serviceId}"

--- a/force-app/main/default/aura/createServiceSchedule/createServiceSchedule.cmp
+++ b/force-app/main/default/aura/createServiceSchedule/createServiceSchedule.cmp
@@ -13,6 +13,7 @@
 >
     <aura:attribute name="serviceId" type="String" access="private" />
     <aura:attribute name="recordTypeId" type="String" access="private" />
+    <aura:attribute name="isCommunity" type="Boolean" access="private" />
 
     <aura:handler name="init" value="{!this}" action="{!c.doInit}" />
     <aura:handler name="change" value="{!v.pageReference}" action="{!c.refresh}" />
@@ -22,9 +23,10 @@
         .slds-accordion__list-item { border-top: none; }
         .slds-table_header-fixed_container { overflow-x: hidden; }
     </aura:html>
-    <c:serviceScheduleCreator
+    <c:serviceScheduleCreatorWrapper
         serviceId="{!v.serviceId}"
         recordTypeId="{!v.recordTypeId}"
+        isCommunity="{!v.isCommunity}"
         onclose="{!c.refresh}"
     />
 </aura:component>

--- a/force-app/main/default/aura/createServiceSchedule/createServiceScheduleController.js
+++ b/force-app/main/default/aura/createServiceSchedule/createServiceScheduleController.js
@@ -9,6 +9,11 @@
 
 ({
     doInit: function(component, event, helper) {
+        if ($A.get("$Site")) {
+            component.set("v.isCommunity", true);
+        } else {
+            component.set("v.isCommunity", false);
+        }
         helper.extractUrlParams(component, event, helper);
     },
 

--- a/force-app/main/default/aura/createServiceSchedule/createServiceScheduleController.js
+++ b/force-app/main/default/aura/createServiceSchedule/createServiceScheduleController.js
@@ -15,12 +15,5 @@
 
     refresh: function(component, event, helper) {
         helper.refresh();
-    },
-
-    handleClose: function(component, event, helper) {
-        component
-            .find("wizard")
-            .getElement()
-            .handleClose();
     }
 });

--- a/force-app/main/default/aura/createServiceSchedule/createServiceScheduleController.js
+++ b/force-app/main/default/aura/createServiceSchedule/createServiceScheduleController.js
@@ -9,15 +9,18 @@
 
 ({
     doInit: function(component, event, helper) {
-        if ($A.get("$Site")) {
-            component.set("v.isCommunity", true);
-        } else {
-            component.set("v.isCommunity", false);
-        }
+        component.set("v.isCommunity", $A.get("$Site") ? true : false);
         helper.extractUrlParams(component, event, helper);
     },
 
     refresh: function(component, event, helper) {
         helper.refresh();
+    },
+
+    handleClose: function(component, event, helper) {
+        component
+            .find("wizard")
+            .getElement()
+            .handleClose();
     }
 });

--- a/force-app/main/default/classes/FieldSetService.cls
+++ b/force-app/main/default/classes/FieldSetService.cls
@@ -151,7 +151,9 @@ public with sharing class FieldSetService {
             'apiName' => field.getName(),
             'label' => getLabel(field),
             'type' => field.getType().name(),
-            'isRequired' => !field.isNillable(),
+            'isRequired' => field.getType() == Schema.DisplayType.BOOLEAN
+                ? false
+                : !field.isNillable(),
             'helpText' => field.getInlineHelpText(),
             'isAccessible' => field.isAccessible(),
             'relationshipName' => field.getRelationshipName(),

--- a/force-app/main/default/lwc/newServiceSchedule/newServiceSchedule.html
+++ b/force-app/main/default/lwc/newServiceSchedule/newServiceSchedule.html
@@ -131,7 +131,7 @@
                                         {labels.every}
                                     </lightning-layout-item>
                                     <lightning-layout-item
-                                        size="4"
+                                        size="3"
                                         class="slds-var-p-horizontal_x-small"
                                     >
                                         <lightning-input-field

--- a/force-app/main/default/lwc/newServiceSchedule/newServiceSchedule.html
+++ b/force-app/main/default/lwc/newServiceSchedule/newServiceSchedule.html
@@ -131,7 +131,7 @@
                                         {labels.every}
                                     </lightning-layout-item>
                                     <lightning-layout-item
-                                        size="3"
+                                        size="4"
                                         class="slds-var-p-horizontal_x-small"
                                     >
                                         <lightning-input-field

--- a/force-app/main/default/lwc/serviceScheduleCreator/__tests__/serviceScheduleCreator.test.js
+++ b/force-app/main/default/lwc/serviceScheduleCreator/__tests__/serviceScheduleCreator.test.js
@@ -21,19 +21,16 @@ describe("c-service-schedule-creator", () => {
         });
     });
 
-    it("modal is displayed and element is accessible", () => {
+    it("element is accessible", () => {
         document.body.appendChild(element);
 
         return global.flushPromises().then(async () => {
-            const modal = element.shadowRoot.querySelector("c-modal");
             const spinner = element.shadowRoot.querySelector("lightning-spinner");
 
-            // Modal will only display with a spinner loaded
-            expect(modal).not.toBeNull();
             expect(spinner).not.toBeNull();
 
             // TODO: Validate accessibility when each step is loads.
-            // await expect(element).toBeAccessible();
+            await expect(element).toBeAccessible();
         });
     });
 });

--- a/force-app/main/default/lwc/serviceScheduleCreator/serviceScheduleCreator.html
+++ b/force-app/main/default/lwc/serviceScheduleCreator/serviceScheduleCreator.html
@@ -8,139 +8,140 @@
   -->
 
 <template>
-    <c-modal
-        header={labels.newServiceSchedule}
-        ondialogclose={handleClose}
-        default-visible="true"
-        size="large"
-    >
-        <template if:false={hideSpinner}>
-            <div
-                class="slds-var-p-around_medium slds-align_absolute-center slds-is-relative"
-            >
-                <lightning-spinner
-                    alternative-text={labels.loading}
-                    size="medium"
-                ></lightning-spinner>
-            </div>
-        </template>
-        <template if:true={isLoaded}>
-            <template if:true={isStep1}>
-                <c-new-service-schedule
-                    service-id={serviceId}
-                    service-schedule-model={serviceScheduleModel}
-                    onloaded={handleLoaded}
-                ></c-new-service-schedule>
-            </template>
-            <template if:true={isStep2}>
-                <c-review-sessions
-                    service-schedule-model={serviceScheduleModel}
-                    onloaded={handleLoaded}
-                ></c-review-sessions>
-            </template>
-            <template if:true={isStep3}>
-                <c-participant-selector
-                    service-id={serviceId}
-                    service-schedule-model={serviceScheduleModel}
-                    onloaded={handleLoaded}
-                ></c-participant-selector>
-            </template>
-            <template if:true={isStep4}>
-                <c-service-schedule-review
-                    service-schedule-model={serviceScheduleModel}
-                    onloaded={handleLoaded}
-                    participant-columns={participantColumns}
-                ></c-service-schedule-review>
-            </template>
-            <c-modal header={labels.goBack} is-nested="true">
-                {labels.backWarning}
+    <!-- fake header for Experience Cloud where the component brings its own modal -->
+    <template if:true={isCommunity}>
+        <header class="slds-modal__header">
+            <h2 class="slds-text-heading_medium slds-hyphenate header-string">
+                {labels.newServiceSchedule}
+            </h2>
+        </header>
+    </template>
 
-                <div slot="footer">
-                    <lightning-layout>
-                        <lightning-layout-item alignment-bump="left">
-                            <lightning-button
-                                label={labels.cancel}
-                                variant="neutral"
-                                onclick={closeBackWarningModal}
-                            ></lightning-button>
-                            <lightning-button
-                                label={labels.back}
-                                variant="brand"
-                                onclick={handleContinueBack}
-                                class="slds-var-p-left_medium"
-                            ></lightning-button>
-                        </lightning-layout-item>
-                    </lightning-layout>
-                </div>
-            </c-modal>
+    <template if:false={hideSpinner}>
+        <div class="slds-var-p-around_medium slds-align_absolute-center slds-is-relative">
+            <lightning-spinner
+                alternative-text={labels.loading}
+                size="medium"
+            ></lightning-spinner>
+        </div>
+    </template>
+
+    <template if:true={isLoaded}>
+        <template if:true={isStep1}>
+            <c-new-service-schedule
+                service-id={serviceId}
+                service-schedule-model={serviceScheduleModel}
+                onloaded={handleLoaded}
+            ></c-new-service-schedule>
+        </template>
+        <template if:true={isStep2}>
+            <c-review-sessions
+                service-schedule-model={serviceScheduleModel}
+                onloaded={handleLoaded}
+            ></c-review-sessions>
+        </template>
+        <template if:true={isStep3}>
+            <c-participant-selector
+                service-id={serviceId}
+                service-schedule-model={serviceScheduleModel}
+                onloaded={handleLoaded}
+            ></c-participant-selector>
+        </template>
+        <template if:true={isStep4}>
+            <c-service-schedule-review
+                service-schedule-model={serviceScheduleModel}
+                onloaded={handleLoaded}
+                participant-columns={participantColumns}
+            ></c-service-schedule-review>
+        </template>
+        <c-modal header={labels.goBack} is-nested="true">
+            {labels.backWarning}
 
             <div slot="footer">
-                <lightning-layout horizontal-align="spread">
-                    <lightning-layout-item
-                        padding="around-small"
-                        class="slds-text-align_left"
-                    >
+                <lightning-layout>
+                    <lightning-layout-item alignment-bump="left">
                         <lightning-button
-                            if:true={currentStep.back}
-                            name="back"
-                            variant={currentStep.back.variant}
-                            label={currentStep.back.label}
-                            title={currentStep.back.label}
-                            onclick={handleBack}
+                            label={labels.cancel}
+                            variant="neutral"
+                            onclick={closeBackWarningModal}
                         ></lightning-button>
-                    </lightning-layout-item>
-
-                    <lightning-layout-item
-                        padding="around-small"
-                        class="slds-text-align_center"
-                        size="4"
-                    >
-                        <lightning-progress-indicator
-                            current-step={currentStep.value}
-                            type="base"
-                            variant="base"
-                        >
-                            <template for:each={steps} for:item="step">
-                                <lightning-progress-step
-                                    key={step.value}
-                                    label={step.label}
-                                    value={step.value}
-                                ></lightning-progress-step>
-                            </template>
-                        </lightning-progress-indicator>
-                    </lightning-layout-item>
-
-                    <lightning-layout-item padding="around-small">
-                        <lightning-layout>
-                            <lightning-layout-item
-                                flexibility="no-flex"
-                                alignment-bump="left"
-                                if:true={currentStep.next}
-                            >
-                                <lightning-button
-                                    name="next"
-                                    variant={currentStep.next.variant}
-                                    label={currentStep.next.label}
-                                    title={currentStep.next.label}
-                                    onclick={handleNext}
-                                    class="slds-var-p-right_small"
-                                    if:true={currentStep.next}
-                                ></lightning-button>
-                            </lightning-layout-item>
-                            <lightning-layout-item if:true={currentStep.finish}>
-                                <lightning-button
-                                    name="finish"
-                                    variant={currentStep.finish.variant}
-                                    label={currentStep.finish.label}
-                                    title={currentStep.finish.label}
-                                    onclick={handleFinish}
-                                    class="slds-var-p-right_small"
-                                ></lightning-button>
-                            </lightning-layout-item>
-                        </lightning-layout>
+                        <lightning-button
+                            label={labels.back}
+                            variant="brand"
+                            onclick={handleContinueBack}
+                            class="slds-var-p-left_medium"
+                        ></lightning-button>
                     </lightning-layout-item>
                 </lightning-layout>
             </div>
-        </template>
-    </c-modal>
+        </c-modal>
+
+        <div slot="footer">
+            <lightning-layout horizontal-align="spread">
+                <lightning-layout-item
+                    padding="around-small"
+                    class="slds-text-align_left"
+                >
+                    <lightning-button
+                        if:true={currentStep.back}
+                        name="back"
+                        variant={currentStep.back.variant}
+                        label={currentStep.back.label}
+                        title={currentStep.back.label}
+                        onclick={handleBack}
+                    ></lightning-button>
+                </lightning-layout-item>
+
+                <lightning-layout-item
+                    padding="around-small"
+                    class="slds-text-align_center"
+                    size="4"
+                >
+                    <lightning-progress-indicator
+                        current-step={currentStep.value}
+                        type="base"
+                        variant="base"
+                    >
+                        <template for:each={steps} for:item="step">
+                            <lightning-progress-step
+                                key={step.value}
+                                label={step.label}
+                                value={step.value}
+                            ></lightning-progress-step>
+                        </template>
+                    </lightning-progress-indicator>
+                </lightning-layout-item>
+
+                <lightning-layout-item padding="around-small">
+                    <lightning-layout>
+                        <lightning-layout-item
+                            flexibility="no-flex"
+                            alignment-bump="left"
+                            if:true={currentStep.next}
+                        >
+                            <lightning-button
+                                name="next"
+                                variant={currentStep.next.variant}
+                                label={currentStep.next.label}
+                                title={currentStep.next.label}
+                                onclick={handleNext}
+                                class="slds-var-p-right_small"
+                                if:true={currentStep.next}
+                            ></lightning-button>
+                        </lightning-layout-item>
+                        <lightning-layout-item if:true={currentStep.finish}>
+                            <lightning-button
+                                name="finish"
+                                variant={currentStep.finish.variant}
+                                label={currentStep.finish.label}
+                                title={currentStep.finish.label}
+                                onclick={handleFinish}
+                                class="slds-var-p-right_small"
+                            ></lightning-button>
+                        </lightning-layout-item>
+                    </lightning-layout>
+                </lightning-layout-item>
+            </lightning-layout>
+        </div>
+    </template>
 </template>

--- a/force-app/main/default/lwc/serviceScheduleCreator/serviceScheduleCreator.js
+++ b/force-app/main/default/lwc/serviceScheduleCreator/serviceScheduleCreator.js
@@ -29,6 +29,7 @@ import SERVICE_FIELD from "@salesforce/schema/ServiceSchedule__c.Service__c";
 export default class ServiceScheduleCreator extends NavigationMixin(LightningElement) {
     @track hideSpinner = false;
     @api recordTypeId;
+    @api isCommunity;
     isSaving = false;
     isLoaded = false;
     serviceScheduleModel;
@@ -159,6 +160,12 @@ export default class ServiceScheduleCreator extends NavigationMixin(LightningEle
         return this.currentStep.value === 3;
     }
 
+    get warningModal() {
+        return this.isCommunity
+            ? this.template.querySelector("c-modal")
+            : this.template.querySelector("c-modal c-modal");
+    }
+
     handleNext() {
         if (this.isStep1) {
             this.processNewServiceSchedule();
@@ -284,19 +291,18 @@ export default class ServiceScheduleCreator extends NavigationMixin(LightningEle
     }
 
     showBackWarning() {
-        const modal = this.template.querySelector("c-modal c-modal");
-        modal.show();
+        this.warningModal.show();
     }
 
     closeBackWarningModal() {
-        const modal = this.template.querySelector("c-modal c-modal");
-        modal.hide();
+        this.warningModal.hide();
     }
 
     handleFinish() {
         this.save(false);
     }
 
+    @api
     handleClose() {
         this.hideModal();
         this.navigate();

--- a/force-app/main/default/lwc/serviceScheduleCreator/serviceScheduleCreator.js
+++ b/force-app/main/default/lwc/serviceScheduleCreator/serviceScheduleCreator.js
@@ -304,7 +304,6 @@ export default class ServiceScheduleCreator extends NavigationMixin(LightningEle
 
     @api
     handleClose() {
-        this.hideModal();
         this.navigate();
         this.dispatchEvent(new CustomEvent("close", { bubbles: true }));
     }

--- a/force-app/main/default/lwc/serviceScheduleCreator/serviceScheduleCreator.js
+++ b/force-app/main/default/lwc/serviceScheduleCreator/serviceScheduleCreator.js
@@ -306,7 +306,7 @@ export default class ServiceScheduleCreator extends NavigationMixin(LightningEle
     handleClose() {
         this.hideModal();
         this.navigate();
-        this.dispatchEvent(new CustomEvent("close"));
+        this.dispatchEvent(new CustomEvent("close", { bubbles: true }));
     }
 
     init() {

--- a/force-app/main/default/lwc/serviceScheduleCreatorWrapper/__tests__/serviceScheduleCreatorWrapper.test.js
+++ b/force-app/main/default/lwc/serviceScheduleCreatorWrapper/__tests__/serviceScheduleCreatorWrapper.test.js
@@ -1,6 +1,6 @@
 /*
  *
- *  * Copyright (c) 2020, salesforce.com, inc.
+ *  * Copyright (c) 2021, salesforce.com, inc.
  *  * All rights reserved.
  *  * SPDX-License-Identifier: BSD-3-Clause
  *  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
@@ -30,6 +30,7 @@ describe("c-service-schedule-creator", () => {
 
             // Modal will only display with a spinner loaded
             expect(modal).not.toBeNull();
+            modal.dispatchEvent(new CustomEvent("dialogclose"));
 
             // TODO: Validate accessibility when each step is loads.
             await expect(element).toBeAccessible();
@@ -37,27 +38,23 @@ describe("c-service-schedule-creator", () => {
     });
 
     it("modal does not appear in experience-cloud context and element is accessible", () => {
-        let label = "fake label";
         element.isCommunity = true;
         document.body.appendChild(element);
+        return global.flushPromises().then(async () => {
+            const modal = element.shadowRoot.querySelector("c-modal");
+            expect(modal).toBeNull();
 
-        return global
-            .flushPromises()
-            .then(() => {
-                const modal = element.shadowRoot.querySelector("c-modal");
+            const creator = element.shadowRoot.querySelector(
+                "c-service-schedule-creator"
+            );
+            expect(creator).not.toBeNull();
 
-                expect(modal).toBeNull();
-                const creator = element.shadowRoot.querySelector(
-                    "c-service-schedule-creator"
-                );
-                creator.labels = {};
-                creator.labels.newServiceSchedule = label;
-            })
-            .then(async () => {
-                const h2 = element.shadowRoot.querySelectorAll("h2");
-                expect(h2.length).toBe(1);
-                // expect(h2[0].textContent).toBe(label);
-                await expect(element).toBeAccessible();
-            });
+            const h2Container = creator.shadowRoot.querySelector("h2");
+            let slot = document.createElement("span");
+            slot.textContent = "Test Accessibility";
+            h2Container.attachShadow({ mode: "open" }).appendChild(slot.cloneNode(true));
+            // assert that DOM is accessible (using extended preset-rule)
+            await expect(element).toBeAccessible();
+        });
     });
 });

--- a/force-app/main/default/lwc/serviceScheduleCreatorWrapper/__tests__/serviceScheduleCreatorWrapper.test.js
+++ b/force-app/main/default/lwc/serviceScheduleCreatorWrapper/__tests__/serviceScheduleCreatorWrapper.test.js
@@ -1,0 +1,63 @@
+/*
+ *
+ *  * Copyright (c) 2020, salesforce.com, inc.
+ *  * All rights reserved.
+ *  * SPDX-License-Identifier: BSD-3-Clause
+ *  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ *
+ */
+
+import { createElement } from "lwc";
+import ServiceScheduleCreatorWrapper from "c/serviceScheduleCreatorWrapper";
+
+describe("c-service-schedule-creator", () => {
+    let element;
+
+    afterEach(global.clearDOM);
+
+    beforeEach(() => {
+        element = createElement("c-service-schedule-creator-wrapper", {
+            is: ServiceScheduleCreatorWrapper,
+        });
+    });
+
+    it("modal appears in non-experience-cloud context and element is accessible", () => {
+        element.isCommunity = false;
+        document.body.appendChild(element);
+
+        return global.flushPromises().then(async () => {
+            const modal = element.shadowRoot.querySelector("c-modal");
+
+            // Modal will only display with a spinner loaded
+            expect(modal).not.toBeNull();
+
+            // TODO: Validate accessibility when each step is loads.
+            await expect(element).toBeAccessible();
+        });
+    });
+
+    it("modal does not appear in experience-cloud context and element is accessible", () => {
+        let label = "fake label";
+        element.isCommunity = true;
+        document.body.appendChild(element);
+
+        return global
+            .flushPromises()
+            .then(() => {
+                const modal = element.shadowRoot.querySelector("c-modal");
+
+                expect(modal).toBeNull();
+                const creator = element.shadowRoot.querySelector(
+                    "c-service-schedule-creator"
+                );
+                creator.labels = {};
+                creator.labels.newServiceSchedule = label;
+            })
+            .then(async () => {
+                const h2 = element.shadowRoot.querySelectorAll("h2");
+                expect(h2.length).toBe(1);
+                // expect(h2[0].textContent).toBe(label);
+                await expect(element).toBeAccessible();
+            });
+    });
+});

--- a/force-app/main/default/lwc/serviceScheduleCreatorWrapper/serviceScheduleCreatorWrapper.html
+++ b/force-app/main/default/lwc/serviceScheduleCreatorWrapper/serviceScheduleCreatorWrapper.html
@@ -1,3 +1,12 @@
+<!--
+  - /*
+  -  * Copyright (c) 2020, salesforce.com, inc.
+  -  * All rights reserved.
+  -  * SPDX-License-Identifier: BSD-3-Clause
+  -  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+  -  */
+  -->
+
 <template>
     <c-modal
         header={labels.newServiceSchedule}

--- a/force-app/main/default/lwc/serviceScheduleCreatorWrapper/serviceScheduleCreatorWrapper.html
+++ b/force-app/main/default/lwc/serviceScheduleCreatorWrapper/serviceScheduleCreatorWrapper.html
@@ -1,6 +1,6 @@
 <!--
   - /*
-  -  * Copyright (c) 2020, salesforce.com, inc.
+  -  * Copyright (c) 2021, salesforce.com, inc.
   -  * All rights reserved.
   -  * SPDX-License-Identifier: BSD-3-Clause
   -  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/force-app/main/default/lwc/serviceScheduleCreatorWrapper/serviceScheduleCreatorWrapper.html
+++ b/force-app/main/default/lwc/serviceScheduleCreatorWrapper/serviceScheduleCreatorWrapper.html
@@ -1,0 +1,23 @@
+<template>
+    <c-modal
+        header={labels.newServiceSchedule}
+        default-visible="true"
+        size="large"
+        if:false={isCommunity}
+        ondialogclose={handleClose}
+    >
+        <c-service-schedule-creator
+            service-id={serviceId}
+            record-type-id={recordTypeId}
+            is-community={isCommunity}
+        ></c-service-schedule-creator>
+    </c-modal>
+
+    <c-service-schedule-creator
+        service-id={serviceId}
+        record-type-id={recordTypeId}
+        is-community={isCommunity}
+        if:true={isCommunity}
+    >
+    </c-service-schedule-creator>
+</template>

--- a/force-app/main/default/lwc/serviceScheduleCreatorWrapper/serviceScheduleCreatorWrapper.js
+++ b/force-app/main/default/lwc/serviceScheduleCreatorWrapper/serviceScheduleCreatorWrapper.js
@@ -1,6 +1,6 @@
 /*
  *
- *  * Copyright (c) 2020, salesforce.com, inc.
+ *  * Copyright (c) 2021, salesforce.com, inc.
  *  * All rights reserved.
  *  * SPDX-License-Identifier: BSD-3-Clause
  *  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/force-app/main/default/lwc/serviceScheduleCreatorWrapper/serviceScheduleCreatorWrapper.js
+++ b/force-app/main/default/lwc/serviceScheduleCreatorWrapper/serviceScheduleCreatorWrapper.js
@@ -1,3 +1,12 @@
+/*
+ *
+ *  * Copyright (c) 2020, salesforce.com, inc.
+ *  * All rights reserved.
+ *  * SPDX-License-Identifier: BSD-3-Clause
+ *  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ *
+ */
+
 import { LightningElement, api } from "lwc";
 import newServiceSchedule from "@salesforce/label/c.New_Service_Schedule";
 

--- a/force-app/main/default/lwc/serviceScheduleCreatorWrapper/serviceScheduleCreatorWrapper.js
+++ b/force-app/main/default/lwc/serviceScheduleCreatorWrapper/serviceScheduleCreatorWrapper.js
@@ -1,0 +1,14 @@
+import { LightningElement, api } from "lwc";
+import newServiceSchedule from "@salesforce/label/c.New_Service_Schedule";
+
+export default class ServiceScheduleCreatorWrapper extends LightningElement {
+    @api recordTypeId;
+    @api isCommunity;
+    @api serviceId;
+
+    labels = { newServiceSchedule };
+
+    handleClose() {
+        this.template.querySelector("c-service-schedule-creator").handleClose();
+    }
+}

--- a/force-app/main/default/lwc/serviceScheduleCreatorWrapper/serviceScheduleCreatorWrapper.js-meta.xml
+++ b/force-app/main/default/lwc/serviceScheduleCreatorWrapper/serviceScheduleCreatorWrapper.js-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>51.0</apiVersion>
+    <isExposed>false</isExposed>
+</LightningComponentBundle>


### PR DESCRIPTION
# Critical Changes

# Changes
- The custom wizard override for creating a new Service Schedule now works in Experience Cloud.

# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
- [ ] Any net new LWC work has Sa11y tests & 50% or above lines JEST test coverage  
- ~~CRUD/FLS is enforced in Apex~~
- ~~Permission sets are updated to account for CRUD|FLS|Tab|Classes~~
- ~~Field sets are updated to account for new fields~~
- [x] UX approval or UX not necessary
- [x] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: W-0000000: Work Name (https://github.com/SalesforceFoundation/PMM/pull/303)
- [ ] All **acceptance criteria** have been met
    - [x] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [x] PR contains draft release notes
- [ ] QE story level testing completed