### PR TITLE
Fix for count calculation on Recent Sessions

### DIFF
--- a/force-app/main/default/lwc/recentSessions/recentSessions.js
+++ b/force-app/main/default/lwc/recentSessions/recentSessions.js
@@ -195,9 +195,18 @@ export default class RecentSessions extends LightningElement {
             );
 
             if (sessionData.sessions && sessionData.sessions.length) {
+                sessionData.totalSessions = this.calculateTotalSessions(
+                    sessionData.sessions.length
+                );
                 this.sessionsData.push(sessionData);
             }
         });
+    }
+
+    calculateTotalSessions(sessionCount) {
+        return sessionCount === 1
+            ? sessionCount + " " + this.objectLabel
+            : sessionCount + " " + this.objectLabelPlural;
     }
 
     handleGetServiceSessions() {
@@ -232,14 +241,7 @@ export default class RecentSessions extends LightningElement {
                                             SESSION_START_FIELD.fieldApiName
                                         ]
                                     ).getDate() === currentDate.getDate(),
-                                totalSessions:
-                                    sessions[sessionStartDateValue].length === 1
-                                        ? sessions[sessionStartDateValue].length +
-                                          " " +
-                                          this.objectLabel
-                                        : sessions[sessionStartDateValue].length +
-                                          " " +
-                                          this.objectLabelPlural,
+                                totalSessions: "",
                             });
                         });
                         this.filter();


### PR DESCRIPTION
# Critical Changes

# Changes
Fixes the count for the number of recent sessions per day on the Recent Sessions component.

# Issues Closed
[W-9222936
](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000KuQSYA0/view)

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
- [ ] Any net new LWC work has Sa11y tests & 50% or above lines JEST test coverage  
- [ ] CRUD/FLS is enforced in Apex
- [ ] Permission sets are updated to account for CRUD|FLS|Tab|Classes
- [ ] Field sets are updated to account for new fields
- [x] UX approval or UX not necessary
- [x] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: W-0000000: Work Name (https://github.com/SalesforceFoundation/PMM/pull/303)
- [ ] All **acceptance criteria** have been met
    - [x] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [x] PR contains draft release notes
- [ ] QE story level testing completed