### PR TITLE
Add empty state warning to Attendance tab when no recordId

### DIFF
--- a/force-app/main/default/labels/CustomLabels.labels-meta.xml
+++ b/force-app/main/default/labels/CustomLabels.labels-meta.xml
@@ -179,6 +179,20 @@
         <value>After participants are added to this Service Schedule, track their attendance here.</value>
     </labels>
     <labels>
+        <fullName>Incorrect_Tab</fullName>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>Supporting message for Attendance tab when reached incorrectly</shortDescription>
+        <value>This isn’t the tab you want.</value>
+    </labels>
+    <labels>
+        <fullName>Attendance_Tab_Message</fullName>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>Supporting message for Attendance tab when reached incorrectly</shortDescription>
+        <value>This tab is used only for printing attendance from a Service Session page.</value>
+    </labels>
+    <labels>
         <fullName>Back</fullName>
         <language>en_US</language>
         <protected>false</protected>

--- a/force-app/main/default/lwc/attendance/attendance.html
+++ b/force-app/main/default/lwc/attendance/attendance.html
@@ -8,114 +8,124 @@
   -->
 
 <template>
-    <lightning-card if:true={displayHeader}>
-        <div class="slds-var-m-left_medium">
-            <lightning-record-form
-                record-id={recordId}
-                object-api-name={serviceSession}
-                layout-type="Compact"
-                mode="readonly"
-                columns="7"
-                density="comfy"
-            >
-            </lightning-record-form>
-        </div>
-    </lightning-card>
+    <template if:false={recordId}>
+        <lightning-card>
+            <c-empty-state
+                text={labels.badTabHeader}
+                sub-text={labels.badTabMessage}
+            ></c-empty-state>
+        </lightning-card>
+    </template>
+    <template if:true={recordId}>
+        <lightning-card if:true={displayHeader}>
+            <div class="slds-var-m-left_medium">
+                <lightning-record-form
+                    record-id={recordId}
+                    object-api-name={serviceSession}
+                    layout-type="Compact"
+                    mode="readonly"
+                    columns="7"
+                    density="comfy"
+                >
+                </lightning-record-form>
+            </div>
+        </lightning-card>
 
-    <lightning-card>
-        <div slot="title">
-            <lightning-icon icon-name="custom:custom15" size="small"></lightning-icon>
-            <span class="slds-p-left_x-small">
-                {labels.trackAttendance}
-            </span>
-        </div>
+        <lightning-card>
+            <div slot="title">
+                <lightning-icon icon-name="custom:custom15" size="small"></lightning-icon>
+                <span class="slds-var-p-left_x-small">
+                    {labels.trackAttendance}
+                </span>
+            </div>
 
-        <lightning-button
-            onclick={handleUpdateClick}
-            variant="neutral"
-            label={labels.update}
-            title={labels.update}
-            slot="actions"
-            if:true={showUpdateButton}
-        ></lightning-button>
+            <lightning-button
+                onclick={handleUpdateClick}
+                variant="neutral"
+                label={labels.update}
+                title={labels.update}
+                slot="actions"
+                if:true={showUpdateButton}
+            ></lightning-button>
 
-        <lightning-button
-            onclick={handlePrintClick}
-            variant="neutral"
-            label={printButtonLabel}
-            title={printButtonLabel}
-            slot="actions"
-            if:true={showPrintButton}
-        ></lightning-button>
+            <lightning-button
+                onclick={handlePrintClick}
+                variant="neutral"
+                label={printButtonLabel}
+                title={printButtonLabel}
+                slot="actions"
+                if:true={showPrintButton}
+            ></lightning-button>
 
-        <div class="slds-border_top">
-            <template if:true={showSpinner}>
-                <div class="slds-align_absolute-center">
-                    <lightning-spinner
-                        alternative-text={labels.loading}
-                        size="medium"
-                    ></lightning-spinner>
-                </div>
-            </template>
+            <div class="slds-border_top">
+                <template if:true={showSpinner}>
+                    <div class="slds-align_absolute-center">
+                        <lightning-spinner
+                            alternative-text={labels.loading}
+                            size="medium"
+                        ></lightning-spinner>
+                    </div>
+                </template>
 
-            <template if:true={hasServiceDeliveries}>
-                <template if:true={hasPermissions}>
-                    <template for:each={serviceDeliveries} for:item="delivery">
-                        <c-attendance-row
-                            record={delivery}
-                            field-set={fieldSet}
-                            unit-of-measurement={unitOfMeasurement}
-                            key={delivery.index}
-                            read-only={isReadMode}
-                        ></c-attendance-row>
+                <template if:true={hasServiceDeliveries}>
+                    <template if:true={hasPermissions}>
+                        <template for:each={serviceDeliveries} for:item="delivery">
+                            <c-attendance-row
+                                record={delivery}
+                                field-set={fieldSet}
+                                unit-of-measurement={unitOfMeasurement}
+                                key={delivery.index}
+                                read-only={isReadMode}
+                            ></c-attendance-row>
+                        </template>
+                    </template>
+                    <template if:false={hasPermissions}>
+                        <div class="slds-var-p-horizontal_small slds-var-p-top_small">
+                            <c-scoped-notification
+                                theme="warning"
+                                title={labels.noPermissions}
+                            ></c-scoped-notification>
+                        </div>
                     </template>
                 </template>
-                <template if:false={hasPermissions}>
-                    <div class="slds-var-p-horizontal_small slds-var-p-top_small">
-                        <c-scoped-notification
-                            theme="warning"
-                            title={labels.noPermissions}
-                        ></c-scoped-notification>
-                    </div>
-                </template>
-            </template>
 
-            <template if:false={hasServiceDeliveries}>
-                <template if:false={showSpinner}>
-                    <div class="slds-var-p-top_small">
-                        <c-empty-state
-                            text={labels.noParticipantsHeader}
-                            sub-text={labels.noParticipantsMessage}
-                        ></c-empty-state>
-                    </div>
+                <template if:false={hasServiceDeliveries}>
+                    <template if:false={showSpinner}>
+                        <div class="slds-var-p-top_small">
+                            <c-empty-state
+                                text={labels.noParticipantsHeader}
+                                sub-text={labels.noParticipantsMessage}
+                            ></c-empty-state>
+                        </div>
+                    </template>
                 </template>
-            </template>
-        </div>
+            </div>
 
-        <!-- Footer will only re-render if the if statement is on an element inside it. -->
-        <div slot="footer" class="slds-text-align_center">
-            <lightning-button
-                onclick={handleSave}
-                variant="brand"
-                label={labels.submit}
-                title={labels.submit}
-                if:true={showSubmitButton}
-            ></lightning-button>
-            <lightning-button
-                onclick={handleCancel}
-                variant="neutral"
-                label={labels.cancel}
-                title={labels.cancel}
-                if:true={isUpdateMode}
-                class="slds-var-p-right_xx-small"
-            ></lightning-button>
-            <lightning-button
-                onclick={handleSave}
-                variant="brand"
-                label={labels.save}
-                title={labels.save}
-                if:true={isUpdateMode}
-            ></lightning-button>
-        </div>
-    </lightning-card>
+            <!-- Footer will only re-render if the if statement is on an element inside it. -->
+            <div slot="footer" class="slds-text-align_center">
+                <lightning-button
+                    onclick={handleSave}
+                    variant="brand"
+                    label={labels.submit}
+                    title={labels.submit}
+                    if:true={showSubmitButton}
+                ></lightning-button>
+                <lightning-button
+                    onclick={handleCancel}
+                    variant="neutral"
+                    label={labels.cancel}
+                    title={labels.cancel}
+                    if:true={isUpdateMode}
+                    class="slds-var-p-right_xx-small"
+                ></lightning-button>
+                <lightning-button
+                    onclick={handleSave}
+                    variant="brand"
+                    label={labels.save}
+                    title={labels.save}
+                    if:true={isUpdateMode}
+                ></lightning-button>
+            </div>
+        </lightning-card>
+    </template>
 </template>

--- a/force-app/main/default/lwc/attendance/attendance.js
+++ b/force-app/main/default/lwc/attendance/attendance.js
@@ -46,6 +46,8 @@ import PRINTABLE_VIEW_LABEL from "@salesforce/label/c.Printable_View";
 import NO_PARTICIPANTS_HEADER_LABEL from "@salesforce/label/c.No_Participants_Header";
 import NO_PARTICIPANTS_MESSAGE_LABEL from "@salesforce/label/c.No_Participants_Message";
 import NO_PERMISSIONS_MESSAGE_LABEL from "@salesforce/label/c.No_Permission_Message";
+import BAD_TAB_HEADER from "@salesforce/label/c.Incorrect_Tab";
+import ATTENDANCE_TAB_MESSAGE from "@salesforce/label/c.Attendance_Tab_Message";
 import pmmFolder from "@salesforce/resourceUrl/pmm";
 
 const FIELD_SET_NAME = "Attendance_Service_Deliveries";
@@ -88,6 +90,8 @@ export default class Attendance extends NavigationMixin(LightningElement) {
         noParticipantsHeader: NO_PARTICIPANTS_HEADER_LABEL,
         noParticipantsMessage: NO_PARTICIPANTS_MESSAGE_LABEL,
         noPermissions: NO_PERMISSIONS_MESSAGE_LABEL,
+        badTabHeader: BAD_TAB_HEADER,
+        badTabMessage: ATTENDANCE_TAB_MESSAGE,
     };
 
     fields = {


### PR DESCRIPTION
# Critical Changes

# Changes
Adds a message to the attendance tab to let users know the tab shouldn't be used directly

# Issues Closed
[W-9049173](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH00000091SgYAI/view)

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
- [ ] Any net new LWC work has Sa11y tests & 50% or above lines JEST test coverage  
- [ ] CRUD/FLS is enforced in Apex
- [ ] Permission sets are updated to account for CRUD|FLS|Tab|Classes
- [ ] Field sets are updated to account for new fields
- [ ] UX approval or UX not necessary
- [ ] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: W-0000000: Work Name (https://github.com/SalesforceFoundation/PMM/pull/303)
- [ ] All **acceptance criteria** have been met
    - [ ] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [ ] PR contains draft release notes
- [ ] QE story level testing completed