### PR TITLE
Displaying unique contact count on caseman dashboard

### DIFF
--- a/force-app/main/default/reports/ProgramManagementReports/Contacts_Absent_for_Last_Svc_Delivery_qwd.report-meta.xml
+++ b/force-app/main/default/reports/ProgramManagementReports/Contacts_Absent_for_Last_Svc_Delivery_qwd.report-meta.xml
@@ -1,5 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Report xmlns="http://soap.sforce.com/2006/04/metadata">
+    <aggregates>
+        <calculatedFormula>Contact.Name:UNIQUE</calculatedFormula>
+        <datatype>number</datatype>
+        <description>This shows the unique count of contacts</description>
+        <developerName>FORMULA1</developerName>
+        <isActive>true</isActive>
+        <isCrossBlock>false</isCrossBlock>
+        <masterLabel>Unique Contact Count</masterLabel>
+        <scale>0</scale>
+    </aggregates>
     <columns>
         <field>Contact.Program_Engagements__r$Name</field>
     </columns>

--- a/force-app/main/default/reports/ProgramManagementReports/Contacts_with_3_Consecutive_Absences_p3K.report-meta.xml
+++ b/force-app/main/default/reports/ProgramManagementReports/Contacts_with_3_Consecutive_Absences_p3K.report-meta.xml
@@ -1,5 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Report xmlns="http://soap.sforce.com/2006/04/metadata">
+    <aggregates>
+        <calculatedFormula>Contact.Name:UNIQUE</calculatedFormula>
+        <datatype>number</datatype>
+        <description>This shows the unique count of contacts</description>
+        <developerName>FORMULA1</developerName>
+        <isActive>true</isActive>
+        <isCrossBlock>false</isCrossBlock>
+        <masterLabel>Unique Contact Count</masterLabel>
+        <scale>0</scale>
+    </aggregates>
     <columns>
         <field>Contact.Program_Engagements__r$Name</field>
     </columns>


### PR DESCRIPTION
# Critical Changes

# Changes
Added a new summary level field to Contacts with 3 Consecutive Absences and Contacts Absent for Last Svc Delivery
on PMM so it displays this unique count on the caseman dashboard.

# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
~~- [ ] Any net new LWC work has Sa11y tests & 50% or above lines JEST test coverage~~  
~~- [ ] CRUD/FLS is enforced in Apex~~
~~- [ ] Permission sets are updated to account for CRUD|FLS|Tab|Classes~~
~~- [ ] Field sets are updated to account for new fields~~
~~- [ ] UX approval or UX not necessary~~
- [x] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: W-0000000: Work Name (https://github.com/SalesforceFoundation/PMM/pull/303)
- [ ] All **acceptance criteria** have been met
    - [x] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [ ] PR contains draft release notes
- [ ] QE story level testing completed