### PR TITLE
[PMM] Upgrade metadeploy install plan

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -348,3 +348,20 @@ plans:
                     path: unpackaged/config/fix_deleted_reports
                 ui_options:
                     name: "Recover Deleted Report"
+    upgrade:
+        slug: upgrade
+        title: Product Upgrade
+        tier: additional
+        is_listed: False
+        preflight_message: "This installer upgrades this package and any required dependencies to the latest version in your org. This installer isn't supported and has risks. Please don't run this installer unless you're aware of its specific use cases and considerations."
+        post_install_message: "Installation complete and package is on the latest version."
+        steps:
+            1:
+                task: update_dependencies
+                options:
+                    security_type: PUSH
+                    packages_only: True
+            2:
+                task: install_managed
+                options:
+                    security_type: PUSH


### PR DESCRIPTION
# Critical Changes

# Changes
Create hidden plan in metadeploy for upgrade installation.
# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
- [ ] Any net new LWC work has Sa11y tests & 50% or above lines JEST test coverage  
- [ ] CRUD/FLS is enforced in Apex
- [ ] Permission sets are updated to account for CRUD|FLS|Tab|Classes
- [ ] Field sets are updated to account for new fields
- [ ] UX approval or UX not necessary
- [ ] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: W-0000000: Work Name (https://github.com/SalesforceFoundation/PMM/pull/303)
- [ ] All **acceptance criteria** have been met
    - [ ] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [ ] PR contains draft release notes
- [ ] QE story level testing completed