### PR TITLE
Fix bucket namespace, separate field not part of devName

### DIFF
--- a/force-app/main/default/classes/ServiceDeliverySelector.cls
+++ b/force-app/main/default/classes/ServiceDeliverySelector.cls
@@ -101,9 +101,7 @@ public with sharing class ServiceDeliverySelector {
                 QualifiedApiName,
                 (SELECT Id, Value__c FROM BucketedValues__r)
             FROM Bucket__mdt
-            WHERE
-                QualifiedApiName IN :bucketNames
-                AND NamespacePrefix = :Util.getNamespace()
+            WHERE DeveloperName IN :bucketNames AND NamespacePrefix = :Util.getNamespace()
             ORDER BY QualifiedApiName
         ];
     }

--- a/force-app/main/default/classes/ServiceDeliverySelector.cls
+++ b/force-app/main/default/classes/ServiceDeliverySelector.cls
@@ -101,7 +101,9 @@ public with sharing class ServiceDeliverySelector {
                 QualifiedApiName,
                 (SELECT Id, Value__c FROM BucketedValues__r)
             FROM Bucket__mdt
-            WHERE QualifiedApiName IN :bucketNames
+            WHERE
+                QualifiedApiName IN :bucketNames
+                AND NamespacePrefix = :Util.getNamespace()
             ORDER BY QualifiedApiName
         ];
     }

--- a/force-app/main/default/classes/ServiceDeliveryService.cls
+++ b/force-app/main/default/classes/ServiceDeliveryService.cls
@@ -203,10 +203,7 @@ public with sharing class ServiceDeliveryService {
     }
 
     private Map<String, List<String>> getStatusBuckets() {
-        List<String> bucketNames = new List<String>{
-            Util.prefixNamespace(ABSENT),
-            Util.prefixNamespace(PRESENT)
-        };
+        List<String> bucketNames = new List<String>{ ABSENT, PRESENT };
         Map<String, List<String>> buckets = new Map<String, List<String>>();
 
         for (Bucket__mdt bucket : deliverySelector.getBuckets(bucketNames)) {

--- a/force-app/main/default/classes/ServiceDeliveryService_TEST.cls
+++ b/force-app/main/default/classes/ServiceDeliveryService_TEST.cls
@@ -27,7 +27,7 @@ public with sharing class ServiceDeliveryService_TEST {
                 QualifiedApiName,
                 (SELECT Id, Value__c FROM BucketedValues__r)
             FROM Bucket__mdt
-            WHERE QualifiedApiName IN :bucketNames
+            WHERE DeveloperName IN :bucketNames AND NamespacePrefix = :Util.getNamespace()
             ORDER BY QualifiedApiName
         ];
         deliverySelectorStub = new StubBuilder(ServiceDeliverySelector.class)


### PR DESCRIPTION
No work item / pr notes: quick fix for 2gp orgs and namespace issue.

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
- [ ] Any net new LWC work has Sa11y tests & 50% or above lines JEST test coverage  
- [ ] CRUD/FLS is enforced in Apex
- [ ] Permission sets are updated to account for CRUD|FLS|Tab|Classes
- [ ] Field sets are updated to account for new fields
- [ ] UX approval or UX not necessary
- [ ] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: W-0000000: Work Name (https://github.com/SalesforceFoundation/PMM/pull/303)
- [ ] All **acceptance criteria** have been met
    - [ ] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [ ] PR contains draft release notes
- [ ] QE story level testing completed