### PR TITLE
Fix error on Service Schedule Wizard when in Lightning Debug Mode and Fix error when attempting to load more than 50000 related Program Engagements

### DIFF
--- a/force-app/main/default/classes/ProgramEngagementSelector.cls
+++ b/force-app/main/default/classes/ProgramEngagementSelector.cls
@@ -54,12 +54,18 @@ public with sharing class ProgramEngagementSelector {
             return new List<ProgramEngagement__c>();
         }
 
-        queryBuilder.withSObjectType(ProgramEngagement__c.getSObjectType())
+        Integer limitTo =
+            System.Limits.getLimitQueryRows() - System.Limits.getQueryRows();
+
+        queryBuilder
+            .reset()
+            .withSObjectType(ProgramEngagement__c.getSObjectType())
             .withSelectFields(new List<String>(fields))
             .addCondition(
                 String.valueOf(ProgramEngagement__c.Program__c) + ' = :programId'
             )
-            .addCondition(String.valueOf(ProgramEngagement__c.Stage__c) + ' IN :stages');
+            .addCondition(String.valueOf(ProgramEngagement__c.Stage__c) + ' IN :stages')
+            .withLimit(limitTo);
 
         List<ProgramEngagement__c> programEngagements = Database.query(
             queryBuilder.buildSoqlQuery()

--- a/force-app/main/default/classes/ServiceScheduleService.cls
+++ b/force-app/main/default/classes/ServiceScheduleService.cls
@@ -230,13 +230,14 @@ public with sharing class ServiceScheduleService {
             return;
         }
 
+        model.programCohorts = programEngagementSelector.getProgramCohortsByProgramId(
+            model.program.Id
+        );
+
         model.programEngagements = programEngagementSelector.getProgramEngagementsByProgramId(
             model.program.Id,
             getSelectFieldsWithToLabel(model),
             ACTIVE_ENGAGEMENT_STAGES
-        );
-        model.programCohorts = programEngagementSelector.getProgramCohortsByProgramId(
-            model.program.Id
         );
     }
 

--- a/force-app/main/default/lwc/loadingStencil/__tests__/loadingStencil.test.js
+++ b/force-app/main/default/lwc/loadingStencil/__tests__/loadingStencil.test.js
@@ -12,12 +12,13 @@ describe("c-loading-stencil", () => {
         });
     });
 
-    it("displays the stencils with default levels", () => {
+    it("displays the stencils with default levels", async () => {
         document.body.appendChild(element);
 
         let stencils = element.shadowRoot.querySelectorAll(".stencil");
         expect(stencils.length).toBe(element.levels.length);
         expect(element.levels.length).toBeGreaterThan(0);
+        await expect(element).toBeAccessible();
     });
 
     it("displays the stencils with provided levels", () => {
@@ -26,6 +27,14 @@ describe("c-loading-stencil", () => {
 
         let stencils = element.shadowRoot.querySelectorAll(".stencil");
         expect(stencils.length).toBe(3);
+    });
+
+    it("displays nothing without levels", () => {
+        element.levels = [];
+        document.body.appendChild(element);
+
+        let stencils = element.shadowRoot.querySelectorAll(".stencil");
+        expect(stencils.length).toBe(0);
     });
 
     it("displays a spinner", () => {

--- a/force-app/main/default/lwc/loadingStencil/__tests__/loadingStencil.test.js
+++ b/force-app/main/default/lwc/loadingStencil/__tests__/loadingStencil.test.js
@@ -1,0 +1,38 @@
+import { createElement } from "lwc";
+import LoadingStencil from "c/loadingStencil";
+
+describe("c-loading-stencil", () => {
+    let element;
+
+    afterEach(global.clearDOM);
+
+    beforeEach(() => {
+        element = createElement("c-loading-stencil", {
+            is: LoadingStencil,
+        });
+    });
+
+    it("displays the stencils with default levels", () => {
+        document.body.appendChild(element);
+
+        let stencils = element.shadowRoot.querySelectorAll(".stencil");
+        expect(stencils.length).toBe(element.levels.length);
+        expect(element.levels.length).toBeGreaterThan(0);
+    });
+
+    it("displays the stencils with provided levels", () => {
+        element.levels = [1, 0.5, 0.25];
+        document.body.appendChild(element);
+
+        let stencils = element.shadowRoot.querySelectorAll(".stencil");
+        expect(stencils.length).toBe(3);
+    });
+
+    it("displays a spinner", () => {
+        element.levels = [1, 0.5, 0.25];
+        document.body.appendChild(element);
+
+        let spinner = element.shadowRoot.querySelector("lightning-spinner");
+        expect(spinner).toBeDefined();
+    });
+});

--- a/force-app/main/default/lwc/loadingStencil/loadingStencil.css
+++ b/force-app/main/default/lwc/loadingStencil/loadingStencil.css
@@ -1,0 +1,7 @@
+.stencil {
+    height: 6px;
+    margin: 13px auto;
+    border-radius: 1rem;
+    background: rgb(224, 229, 238);
+    width: 85%;
+}

--- a/force-app/main/default/lwc/loadingStencil/loadingStencil.html
+++ b/force-app/main/default/lwc/loadingStencil/loadingStencil.html
@@ -1,0 +1,22 @@
+<template>
+    <lightning-card>
+        <lightning-layout multiple-rows="true">
+            <template for:each={levels} for:item="level">
+                <lightning-layout-item size="12" key={level}>
+                    <div class="opacity-target">
+                        <div class="stencil"></div>
+                    </div>
+                </lightning-layout-item>
+            </template>
+            <lightning-layout-item flexibility="auto" padding="around-large">
+                <div class="slds-is-relative">
+                    <lightning-spinner
+                        alternative-text={labels.loading}
+                        size="small"
+                        variant="brand"
+                    ></lightning-spinner>
+                </div>
+            </lightning-layout-item>
+        </lightning-layout>
+    </lightning-card>
+</template>

--- a/force-app/main/default/lwc/loadingStencil/loadingStencil.js
+++ b/force-app/main/default/lwc/loadingStencil/loadingStencil.js
@@ -1,0 +1,36 @@
+import { LightningElement, api } from "lwc";
+import LOADING from "@salesforce/label/c.Loading";
+
+const OPACITY = "opacity:";
+
+export default class LoadingStencil extends LightningElement {
+    @api levels = [1, 0.95, 0.9, 0.85, 0.8, 0.75, 0.7, 0.65, 0.6, 0.55, 0.5];
+    labels = {
+        loading: LOADING,
+    };
+
+    renderedCallback() {
+        if (this.hasRendered) {
+            return;
+        }
+        this.hasRendered = true;
+
+        this.setOpacity();
+    }
+
+    setOpacity() {
+        if (!this.levels) {
+            return;
+        }
+
+        let elements = this.template.querySelectorAll(".opacity-target");
+
+        if (!elements || elements.length !== this.levels.length) {
+            return;
+        }
+
+        this.levels.forEach((level, index) => {
+            elements[index].style = `${OPACITY} ${level}`;
+        });
+    }
+}

--- a/force-app/main/default/lwc/loadingStencil/loadingStencil.js
+++ b/force-app/main/default/lwc/loadingStencil/loadingStencil.js
@@ -1,33 +1,20 @@
 import { LightningElement, api } from "lwc";
-import LOADING from "@salesforce/label/c.Loading";
+import loading from "@salesforce/label/c.Loading";
 
 const OPACITY = "opacity:";
 
 export default class LoadingStencil extends LightningElement {
     @api levels = [1, 0.95, 0.9, 0.85, 0.8, 0.75, 0.7, 0.65, 0.6, 0.55, 0.5];
     labels = {
-        loading: LOADING,
+        loading,
     };
 
     renderedCallback() {
-        if (this.hasRendered) {
-            return;
-        }
-        this.hasRendered = true;
-
         this.setOpacity();
     }
 
     setOpacity() {
-        if (!this.levels) {
-            return;
-        }
-
         let elements = this.template.querySelectorAll(".opacity-target");
-
-        if (!elements || elements.length !== this.levels.length) {
-            return;
-        }
 
         this.levels.forEach((level, index) => {
             elements[index].style = `${OPACITY} ${level}`;

--- a/force-app/main/default/lwc/loadingStencil/loadingStencil.js-meta.xml
+++ b/force-app/main/default/lwc/loadingStencil/loadingStencil.js-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>48.0</apiVersion>
+    <isExposed>false</isExposed>
+</LightningComponentBundle>

--- a/force-app/main/default/lwc/participantSelector/participantSelector.html
+++ b/force-app/main/default/lwc/participantSelector/participantSelector.html
@@ -146,4 +146,12 @@
             </lightning-layout>
         </lightning-layout-item>
     </lightning-layout>
+    <template if:false={isLoaded}>
+        <div class="slds-align_absolute-center">
+            <lightning-spinner
+                alternative-text={labels.loading}
+                size="medium"
+            ></lightning-spinner>
+        </div>
+    </template>
 </template>

--- a/force-app/main/default/lwc/participantSelector/participantSelector.html
+++ b/force-app/main/default/lwc/participantSelector/participantSelector.html
@@ -84,7 +84,7 @@
                                             class="slds-border_top slds-var-m-top_xx-small"
                                         >
                                             <lightning-datatable
-                                                data={filteredEngagements}
+                                                data={data}
                                                 key-field="Id"
                                                 columns={selectorColumns}
                                                 column-widths-mode="auto"
@@ -92,6 +92,8 @@
                                                 resize-column-disabled
                                                 hide-checkbox-column
                                                 onrowaction={handleSelectParticipant}
+                                                enable-infinite-loading={enableInfiniteLoading}
+                                                onloadmore={handleLoadMore}
                                             ></lightning-datatable>
                                         </div>
                                     </lightning-layout-item>

--- a/force-app/main/default/lwc/participantSelector/participantSelector.html
+++ b/force-app/main/default/lwc/participantSelector/participantSelector.html
@@ -146,12 +146,16 @@
             </lightning-layout>
         </lightning-layout-item>
     </lightning-layout>
-    <template if:false={isLoaded}>
-        <div class="slds-align_absolute-center">
-            <lightning-spinner
-                alternative-text={labels.loading}
-                size="medium"
-            ></lightning-spinner>
-        </div>
-    </template>
+    <lightning-layout if:false={isLoaded}>
+        <lightning-layout-item size="10">
+            <lightning-layout>
+                <lightning-layout-item size="8" class="slds-var-p-top_small">
+                    <c-loading-stencil></c-loading-stencil>
+                </lightning-layout-item>
+                <lightning-layout-item size="4" class="slds-var-p-top_small">
+                    <c-loading-stencil></c-loading-stencil>
+                </lightning-layout-item>
+            </lightning-layout>
+        </lightning-layout-item>
+    </lightning-layout>
 </template>

--- a/force-app/main/default/lwc/participantSelector/participantSelector.js
+++ b/force-app/main/default/lwc/participantSelector/participantSelector.js
@@ -40,6 +40,7 @@ export default class ParticipantSelector extends LightningElement {
     @track filteredEngagements;
     @track engagements;
     @track cohorts;
+    @track data = [];
 
     searchValue;
     noRecordsFound = false;
@@ -52,6 +53,8 @@ export default class ParticipantSelector extends LightningElement {
     objectLabels;
     isLoaded = false;
     rendered = false;
+    offsetRows = 50;
+    offset = this.offsetRows;
 
     labels = {
         selectContacts,
@@ -182,9 +185,21 @@ export default class ParticipantSelector extends LightningElement {
         });
 
         this.sortData(this.availableEngagements);
-        this.filteredEngagements = [...this.availableEngagements];
+        this.applyFilters();
         this.noRecordsFound =
             this.filteredEngagements && this.filteredEngagements.length === 0;
+    }
+
+    get enableInfiniteLoading() {
+        return this.offset < this.filteredEngagements.length;
+    }
+
+    handleLoadMore() {
+        this.offset += this.offsetRows;
+        this.data = this.filteredEngagements.slice(
+            0,
+            Math.min(this.offset, this.filteredEngagements.length)
+        );
     }
 
     sortData(engagements) {
@@ -349,6 +364,10 @@ export default class ParticipantSelector extends LightningElement {
 
         this.noRecordsFound =
             this.filteredEngagements && this.filteredEngagements.length === 0;
+        this.data = this.filteredEngagements.slice(
+            0,
+            Math.min(this.filteredEngagements.length, this.offset)
+        );
     }
 
     dispatchSelectEvent() {

--- a/force-app/main/default/lwc/participantSelector/participantSelector.js
+++ b/force-app/main/default/lwc/participantSelector/participantSelector.js
@@ -27,7 +27,6 @@ import filterByRecord from "@salesforce/label/c.Filter_By_Record";
 import noContactsSelected from "@salesforce/label/c.No_Service_Participants_Created_Warning";
 import add from "@salesforce/label/c.Add";
 import addAll from "@salesforce/label/c.Add_All";
-import loading from "@salesforce/label/c.Loading";
 export default class ParticipantSelector extends LightningElement {
     @api serviceId;
     @api serviceSchedule;
@@ -58,7 +57,6 @@ export default class ParticipantSelector extends LightningElement {
     offset = this.offsetRows;
 
     labels = {
-        loading,
         selectContacts,
         selectedContacts,
         capacityWarning,

--- a/force-app/main/default/lwc/participantSelector/participantSelector.js
+++ b/force-app/main/default/lwc/participantSelector/participantSelector.js
@@ -27,6 +27,7 @@ import filterByRecord from "@salesforce/label/c.Filter_By_Record";
 import noContactsSelected from "@salesforce/label/c.No_Service_Participants_Created_Warning";
 import add from "@salesforce/label/c.Add";
 import addAll from "@salesforce/label/c.Add_All";
+import loading from "@salesforce/label/c.Loading";
 export default class ParticipantSelector extends LightningElement {
     @api serviceId;
     @api serviceSchedule;
@@ -57,6 +58,7 @@ export default class ParticipantSelector extends LightningElement {
     offset = this.offsetRows;
 
     labels = {
+        loading,
         selectContacts,
         selectedContacts,
         capacityWarning,

--- a/force-app/main/default/lwc/picklist/picklist.js
+++ b/force-app/main/default/lwc/picklist/picklist.js
@@ -14,19 +14,33 @@ const SELECTED_VARIANT = "brand";
 
 export default class Picklist extends LightningElement {
     // Expects an object with a label and the salesforce picklistValue object
-    @api picklist;
     @api value;
     @api type = "radio";
     @api multiSelect = false;
 
-    @track _options;
+    @track options;
+    _picklist;
 
-    get options() {
-        if (!this.picklist) {
-            return undefined;
-        }
+    @api
+    get picklist() {
+        return this._picklist;
+    }
 
-        this._options = this.picklist.picklistValues.map(picklistValue => {
+    set picklist(value) {
+        this._picklist = value;
+        this.setOptions();
+    }
+
+    get label() {
+        return this.picklist && this.picklist.label ? this.picklist.label : undefined;
+    }
+
+    get selection() {
+        return this.options.filter(option => option.isSelected);
+    }
+
+    setOptions() {
+        this.options = this.picklist.picklistValues.map(picklistValue => {
             let isSelected = !this.value
                 ? picklistValue.defaultValue
                 : this.value.includes(picklistValue.value);
@@ -42,20 +56,10 @@ export default class Picklist extends LightningElement {
                 variant: isSelected ? SELECTED_VARIANT : UNSELECTED_VARIANT,
             };
         });
-
-        return this._options;
-    }
-
-    get label() {
-        return this.picklist && this.picklist.label ? this.picklist.label : undefined;
-    }
-
-    get selection() {
-        return this._options.filter(option => option.isSelected);
     }
 
     handleChange(event) {
-        this._options.forEach(option => {
+        this.options.forEach(option => {
             option.isSelected = option.value === event.detail.value;
         });
 
@@ -63,7 +67,7 @@ export default class Picklist extends LightningElement {
     }
 
     handleMultiSelectClick(event) {
-        this._options.forEach(option => {
+        this.options.forEach(option => {
             if (option.value === event.target.name) {
                 option.isSelected = !option.isSelected;
                 option.variant = option.isSelected


### PR DESCRIPTION
# Critical Changes

# Changes
- On Bulk Service Delivery Wizard and the Service Schedule Wizard, the participant/contact selector screen will now present a larger amount of data up to the maximum number rows allowed by SOQL.
- On Service Schedule Wizard when in Lightning Debug Mode there is no longer a console error and the Frequency options load.

# Issues Closed
- Fixes #433 

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
- [x] Any net new LWC work has Sa11y tests & 50% or above lines JEST test coverage
~~CRUD/FLS is enforced in Apex~~
~~Permission sets are updated to account for CRUD|FLS|Tab|Classes~~
~~Field sets are updated to account for new fields~~
~~UX approval or UX not necessary~~
- [x] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: W-0000000: Work Name (https://github.com/SalesforceFoundation/PMM/pull/303)
- [ ] All **acceptance criteria** have been met
    - [x] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [x] PR contains draft release notes
- [ ] QE story level testing completed