### PR TITLE
Fix name of attendance feature parameter.

### DIFF
--- a/force-app/main/default/classes/FeatureParameters.cls
+++ b/force-app/main/default/classes/FeatureParameters.cls
@@ -27,7 +27,7 @@ public without sharing class FeatureParameters {
         ACTIVE_PROGRAMS_WITH_SERVICE_DELIVERIES_LAST30,
         PERM_SET_DELIVER_USERS,
         PERM_SET_MANAGE_USERS,
-        ATTENDANCE_WITH_SERVICE_DELIVERIES_LAST30
+        ATTENDANCE_SERVICE_DELIVERIES_LAST30
     }
 
     private static final String ACTIVE_PROGRAM_CONDITION =
@@ -76,8 +76,8 @@ public without sharing class FeatureParameters {
             when PERM_SET_MANAGE_USERS {
                 return new PermSetManageUsers();
             }
-            when ATTENDANCE_WITH_SERVICE_DELIVERIES_LAST30 {
-                return new AttendanceWithServiceDeliveriesLast30();
+            when ATTENDANCE_SERVICE_DELIVERIES_LAST30 {
+                return new AttendanceServiceDeliveriesLast30();
             }
             when else {
                 return null;
@@ -383,7 +383,7 @@ public without sharing class FeatureParameters {
     }
 
     @TestVisible
-    private without sharing class AttendanceWithServiceDeliveriesLast30 implements FeatureManagement.FeatureParameter {
+    private without sharing class AttendanceServiceDeliveriesLast30 implements FeatureManagement.FeatureParameter {
         private String attendanceStatusField = String.valueOf(
             ServiceDelivery__c.AttendanceStatus__c
         );
@@ -437,17 +437,11 @@ public without sharing class FeatureParameters {
         }
 
         private String getName() {
-            return DeveloperName.ATTENDANCE_WITH_SERVICE_DELIVERIES_LAST30.name()
-                .remove('_');
+            return DeveloperName.ATTENDANCE_SERVICE_DELIVERIES_LAST30.name().remove('_');
         }
 
         private Object getValue() {
-            List<ServiceDelivery__c> serviceDeliveries = (List<ServiceDelivery__c>) finder.findRecords();
-            Set<Id> serviceDeliveryIds = new Set<Id>();
-            for (ServiceDelivery__c serviceDelivery : serviceDeliveries) {
-                serviceDeliveryIds.add(serviceDelivery.Id);
-            }
-            return serviceDeliveryIds.size();
+            return finder.findCount();
         }
 
         public List<String> getAttendanceStatusPicklistValues() {

--- a/force-app/main/default/classes/FeatureParameters_TEST.cls
+++ b/force-app/main/default/classes/FeatureParameters_TEST.cls
@@ -38,6 +38,22 @@ public with sharing class FeatureParameters_TEST {
     }
 
     @IsTest
+    private static void integrationTestSendAllParameters() {
+        List<FeatureManagement.FeatureParameter> allFeatureParameters = new FeatureParameters()
+            .getAll();
+        FeatureManagement.FeatureParameter currentParam;
+
+        try {
+            for (FeatureManagement.FeatureParameter param : allFeatureParameters) {
+                currentParam = param;
+                param.send();
+            }
+        } catch (Exception ex) {
+            System.assert(false, 'Error occurred when sending: ' + currentParam);
+        }
+    }
+
+    @IsTest
     private static void shouldReturnNullForUndefinedParameters() {
         FeatureManagement.FeatureParameter featureParameter = new FeatureParameters()
             .makeFeatureParameter(null);
@@ -306,34 +322,8 @@ public with sharing class FeatureParameters_TEST {
         );
     }
 
-    ////////// Helper Methods //////////
-    private static void deleteExistingPermissionAssignments() {
-        delete [
-            SELECT Id
-            FROM PermissionSetAssignment
-            WHERE
-                AssigneeId = :System.UserInfo.getUserId()
-                AND (PermissionSet.Name = :FeatureParameters.MANAGE_PERMISSION
-                OR PermissionSet.Name = :FeatureParameters.DELIVER_PERMISSION)
-        ];
-    }
-
-    private static void assignPermissionSet(String permissionSetName) {
-        PermissionSet permission = [
-            SELECT Id
-            FROM PermissionSet
-            WHERE Name = :permissionSetName
-            LIMIT 1
-        ];
-
-        insert new PermissionSetAssignment(
-            AssigneeId = System.UserInfo.getUserId(),
-            PermissionSetId = permission.Id
-        );
-    }
-
     @IsTest
-    private static void shouldPassActualAttendanceWithServiceDeliveriesLast30() {
+    private static void shouldPassActualAttendanceServiceDeliveriesLast30() {
         Set<Id> serviceDeliveryIds = new Set<Id>();
         List<String> attendanceStatusOptions = new List<String>{
             'Present',
@@ -358,19 +348,45 @@ public with sharing class FeatureParameters_TEST {
             'Sanity check: Test setup should have generated at least 1 service delivery record with an attendance status.'
         );
 
-        final String expectedName = FeatureParameters.DeveloperName.ATTENDANCE_WITH_SERVICE_DELIVERIES_LAST30.name()
+        final String expectedName = FeatureParameters.DeveloperName.ATTENDANCE_SERVICE_DELIVERIES_LAST30.name()
             .remove('_');
         final Integer expectedValue = serviceDeliveryIds.size();
         FeatureManagement.instance = (FeatureManagement) featureManagementStub.createMock();
 
         Test.startTest();
-        new FeatureParameters.AttendanceWithServiceDeliveriesLast30().send();
+        new FeatureParameters.AttendanceServiceDeliveriesLast30().send();
         Test.stopTest();
 
         featureManagementStub.assertCalledWith(
             'setPackageIntegerValue',
             new List<Type>{ String.class, Integer.class },
             new List<Object>{ expectedName, expectedValue }
+        );
+    }
+
+    ////////// Helper Methods //////////
+    private static void deleteExistingPermissionAssignments() {
+        delete [
+            SELECT Id
+            FROM PermissionSetAssignment
+            WHERE
+                AssigneeId = :System.UserInfo.getUserId()
+                AND (PermissionSet.Name = :FeatureParameters.MANAGE_PERMISSION
+                OR PermissionSet.Name = :FeatureParameters.DELIVER_PERMISSION)
+        ];
+    }
+
+    private static void assignPermissionSet(String permissionSetName) {
+        PermissionSet permission = [
+            SELECT Id
+            FROM PermissionSet
+            WHERE Name = :permissionSetName
+            LIMIT 1
+        ];
+
+        insert new PermissionSetAssignment(
+            AssigneeId = System.UserInfo.getUserId(),
+            PermissionSetId = permission.Id
         );
     }
 }


### PR DESCRIPTION
# Critical Changes

# Changes

# Issues Closed
- Fixes an issue where the name of a telemetry feature parameter was incorrect and could not be sent.

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
~~Any net new LWC work has Sa11y tests & 50% or above lines JEST test coverage~~
~~CRUD/FLS is enforced in Apex~~
~~Permission sets are updated to account for CRUD|FLS|Tab|Classes~~
~~Field sets are updated to account for new fields~~
~~UX approval or UX not necessary~~
- [x] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: W-0000000: Work Name (https://github.com/SalesforceFoundation/PMM/pull/303)
- [ ] All **acceptance criteria** have been met
    - [x] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [x] PR contains draft release notes
- [ ] QE story level testing completed