### PR TITLE
Reduce the number of query rows needed for telemetry

### DIFF
--- a/force-app/main/default/classes/FeatureParameters.cls
+++ b/force-app/main/default/classes/FeatureParameters.cls
@@ -189,14 +189,17 @@ public without sharing class FeatureParameters {
 
     @TestVisible
     private without sharing class ActiveProgramsWithServiceDeliveriesLast30 implements FeatureManagement.FeatureParameter {
-        private string programField =
-            ServiceDelivery__c.ProgramEngagement__c.getDescribe().getRelationshipName() +
-            '.' +
-            String.valueOf(ProgramEngagement__c.Program__c);
+        private String childRelationshipName = Util.getChildRelationshipName(
+            ProgramEngagement__c.SObjectType,
+            ServiceDelivery__c.SObjectType
+        );
+        private string programField = String.valueOf(ProgramEngagement__c.Program__c);
+        private QueryBuilder subQueryBuilder = new QueryBuilder()
+            .withChildRelationshipName(childRelationshipName)
+            .addCondition(CREATED_LAST_30_CONDITION)
+            .withLimit(1);
 
-        private String activeServiceDelivery =
-            ServiceDelivery__c.ProgramEngagement__c.getDescribe().getRelationshipName() +
-            '.' +
+        private String activeProgram =
             ProgramEngagement__c.Program__c.getDescribe().getRelationshipName() +
             '.' +
             String.valueOf(Program__c.Status__c) +
@@ -207,10 +210,10 @@ public without sharing class FeatureParameters {
             get {
                 if (queryBuilder == null) {
                     queryBuilder = new QueryBuilder()
-                        .withSObjectType(ServiceDelivery__c.SObjectType)
+                        .withSObjectType(ProgramEngagement__c.SObjectType)
                         .withSelectFields(new List<String>{ programField })
-                        .addCondition(activeServiceDelivery)
-                        .addCondition(CREATED_LAST_30_CONDITION);
+                        .addCondition(activeProgram)
+                        .addCondition('Id IN (' + buildServiceDeliveryQuery() + ')');
                 }
 
                 return queryBuilder;
@@ -245,12 +248,27 @@ public without sharing class FeatureParameters {
         }
 
         private Object getValue() {
-            List<ServiceDelivery__c> serviceDeliveries = (List<ServiceDelivery__c>) finder.findRecords();
             Set<Id> programIds = new Set<Id>();
-            for (ServiceDelivery__c serviceDelivery : serviceDeliveries) {
-                programIds.add(serviceDelivery.programengagement__r.Program__c);
+
+            for (
+                ProgramEngagement__c programEngagement : (List<ProgramEngagement__c>) finder.findRecords()
+            ) {
+                programIds.add(programEngagement.Program__c);
             }
+
             return programIds.size();
+        }
+
+        private String buildServiceDeliveryQuery() {
+            return new QueryBuilder()
+                .withSObjectType(ServiceDelivery__c.SObjectType)
+                .withSelectFields(
+                    new List<String>{
+                        String.valueOf(ServiceDelivery__c.ProgramEngagement__c)
+                    }
+                )
+                .addCondition(CREATED_LAST_30_CONDITION)
+                .buildSoqlQuery();
         }
     }
 

--- a/force-app/main/default/classes/FeatureParameters.cls
+++ b/force-app/main/default/classes/FeatureParameters.cls
@@ -189,15 +189,7 @@ public without sharing class FeatureParameters {
 
     @TestVisible
     private without sharing class ActiveProgramsWithServiceDeliveriesLast30 implements FeatureManagement.FeatureParameter {
-        private String childRelationshipName = Util.getChildRelationshipName(
-            ProgramEngagement__c.SObjectType,
-            ServiceDelivery__c.SObjectType
-        );
         private string programField = String.valueOf(ProgramEngagement__c.Program__c);
-        private QueryBuilder subQueryBuilder = new QueryBuilder()
-            .withChildRelationshipName(childRelationshipName)
-            .addCondition(CREATED_LAST_30_CONDITION)
-            .withLimit(1);
 
         private String activeProgram =
             ProgramEngagement__c.Program__c.getDescribe().getRelationshipName() +

--- a/force-app/main/default/classes/FeatureParameters_TEST.cls
+++ b/force-app/main/default/classes/FeatureParameters_TEST.cls
@@ -197,21 +197,82 @@ public with sharing class FeatureParameters_TEST {
     private static void shouldPassActualActiveProgramsWithServiceDeliveriesLast30() {
         Set<Id> programIds = new Set<Id>();
 
-        List<ServiceDelivery__c> serviceDeliveries = [
-            SELECT ProgramEngagement__r.Program__c
-            FROM ServiceDelivery__c
+        List<ProgramEngagement__c> programEngagements = [
+            SELECT Program__c
+            FROM ProgramEngagement__c
             WHERE
-                ProgramEngagement__r.Program__r.Status__c = 'Active'
-                AND CreatedDate = LAST_N_DAYS:30
+                ProgramEngagement__c.Program__r.Status__c = 'Active'
+                AND Id IN (
+                    SELECT ProgramEngagement__c
+                    FROM ServiceDelivery__c
+                    WHERE CreatedDate = LAST_N_DAYS:30
+                )
         ];
 
-        for (ServiceDelivery__c serviceDelivery : serviceDeliveries) {
-            programIds.add(serviceDelivery.ProgramEngagement__r.Program__c);
+        for (ProgramEngagement__c programEngagement : programEngagements) {
+            programIds.add(programEngagement.Program__c);
         }
 
         System.assert(
             !programIds.isEmpty(),
             'Sanity check: Test setup should have generated at least 1 active record with a related program engagement.'
+        );
+
+        final String expectedName = FeatureParameters.DeveloperName.ACTIVE_PROGRAMS_WITH_SERVICE_DELIVERIES_LAST30.name()
+            .remove('_');
+        final Integer expectedValue = programIds.size();
+        FeatureManagement.instance = (FeatureManagement) featureManagementStub.createMock();
+
+        Test.startTest();
+        new FeatureParameters.ActiveProgramsWithServiceDeliveriesLast30().send();
+        Test.stopTest();
+
+        featureManagementStub.assertCalledWith(
+            'setPackageIntegerValue',
+            new List<Type>{ String.class, Integer.class },
+            new List<Object>{ expectedName, expectedValue }
+        );
+    }
+
+    @IsTest
+    private static void shouldNotPassActiveProgramsWithoutServiceDeliveriesLast30() {
+        Set<Id> programIds = new Set<Id>();
+
+        List<ProgramEngagement__c> programEngagements = [
+            SELECT Program__c
+            FROM ProgramEngagement__c
+            WHERE
+                Program__r.Status__c = 'Active'
+                AND Id IN (
+                    SELECT ProgramEngagement__c
+                    FROM ServiceDelivery__c
+                    WHERE CreatedDate = LAST_N_DAYS:30
+                )
+        ];
+
+        Id programEngagementId = programEngagements[0].Id;
+        delete [
+            SELECT Id
+            FROM ServiceDelivery__c
+            WHERE ProgramEngagement__c = :programEngagementId
+        ];
+
+        for (ProgramEngagement__c programEngagement : programEngagements) {
+            if (programEngagement.Id == programEngagementId) {
+                continue;
+            }
+
+            programIds.add(programEngagement.Program__c);
+        }
+
+        System.assert(
+            !programIds.isEmpty(),
+            'Sanity check: Test setup should have generated at least 1 active record with a related program engagement.'
+        );
+
+        System.assert(
+            !programIds.contains(programEngagements[0].Program__c),
+            'The program related to the first program engagement should not be included.'
         );
 
         final String expectedName = FeatureParameters.DeveloperName.ACTIVE_PROGRAMS_WITH_SERVICE_DELIVERIES_LAST30.name()

--- a/force-app/main/default/classes/ServiceDeliveryRollupsService.cls
+++ b/force-app/main/default/classes/ServiceDeliveryRollupsService.cls
@@ -286,20 +286,6 @@ public with sharing class ServiceDeliveryRollupsService {
         return fields;
     }
 
-    private String getChildRelationshipName(SObjectType sObjectType) {
-        String childRelationshipName;
-        for (
-            ChildRelationship relation : sObjectType.getDescribe().getChildRelationships()
-        ) {
-            if (relation.getChildSObject() == ServiceDelivery__c.SObjectType) {
-                childRelationshipName = relation.getRelationshipName();
-                break;
-            }
-        }
-
-        return childRelationshipName;
-    }
-
     private void process(List<ServiceDelivery__c> deliveries, Boolean isNew) {
         Set<SObjectField> activeRollupFields = getActiveRollupFields();
         if (activeRollupFields.isEmpty()) {
@@ -362,7 +348,10 @@ public with sharing class ServiceDeliveryRollupsService {
             }
 
             List<SObject> parentRecords = new List<SObject>();
-            String childRelationshipName = getChildRelationshipName(parentObject);
+            String childRelationshipName = Util.getChildRelationshipName(
+                parentObject,
+                ServiceDelivery__c.SObjectType
+            );
             Boolean shouldIncludeDeliveries =
                 LAST_SERVICE_DATE_FIELD_BY_SOBJECT_TYPE.containsKey(parentObject) ||
                 CONSECUTIVE_ABSENCES_FIELD_BY_SOBJECT_TYPE.containsKey(parentObject);

--- a/force-app/main/default/classes/Util.cls
+++ b/force-app/main/default/classes/Util.cls
@@ -36,6 +36,23 @@ public with sharing class Util {
         };
     }
 
+    public static String getChildRelationshipName(
+        SObjectType sObjectType,
+        SObjectType childSObjectType
+    ) {
+        String childRelationshipName;
+        for (
+            ChildRelationship relation : sObjectType.getDescribe().getChildRelationships()
+        ) {
+            if (relation.getChildSObject() == childSObjectType) {
+                childRelationshipName = relation.getRelationshipName();
+                break;
+            }
+        }
+
+        return childRelationshipName;
+    }
+
     public static Date getToday() {
         return System.today();
     }


### PR DESCRIPTION
# Critical Changes

# Changes
- Fixes an issue where a customer could hit too many query row limit if they have more than 50000 Service Deliveries created in the last 30 days.

# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
~~Any net new LWC work has Sa11y tests & 50% or above lines JEST test coverage~~
~~CRUD/FLS is enforced in Apex~~
~~Permission sets are updated to account for CRUD|FLS|Tab|Classes~~
~~Field sets are updated to account for new fields~~
~~UX approval or UX not necessary~~
- [x] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: W-0000000: Work Name (https://github.com/SalesforceFoundation/PMM/pull/303)
- [ ] All **acceptance criteria** have been met
    - [x] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [x] PR contains draft release notes
- [ ] QE story level testing completed