### PR TITLE
Add active services telemetry

### DIFF
--- a/force-app/main/default/classes/FeatureParameters.cls
+++ b/force-app/main/default/classes/FeatureParameters.cls
@@ -27,11 +27,16 @@ public without sharing class FeatureParameters {
         ACTIVE_PROGRAMS_WITH_SERVICE_DELIVERIES_LAST30,
         PERM_SET_DELIVER_USERS,
         PERM_SET_MANAGE_USERS,
-        ATTENDANCE_SERVICE_DELIVERIES_LAST30
+        ATTENDANCE_SERVICE_DELIVERIES_LAST30,
+        ACTIVE_SERVICES
     }
 
     private static final String ACTIVE_PROGRAM_CONDITION =
         String.valueOf(Program__c.Status__c) +
+        ' = ' +
+        '\'Active\'';
+    private static final String ACTIVE_SERVICE_CONDITION =
+        String.valueOf(Service__c.Status__c) +
         ' = ' +
         '\'Active\'';
     private static final String CREATED_LAST_30_CONDITION = 'CreatedDate = LAST_N_DAYS:30';
@@ -79,6 +84,9 @@ public without sharing class FeatureParameters {
             when ATTENDANCE_SERVICE_DELIVERIES_LAST30 {
                 return new AttendanceServiceDeliveriesLast30();
             }
+            when ACTIVE_SERVICES {
+                return new ActiveServices();
+            }
             when else {
                 return null;
             }
@@ -123,6 +131,51 @@ public without sharing class FeatureParameters {
 
         private String getName() {
             return DeveloperName.ACTIVE_PROGRAMS.name().remove('_');
+        }
+
+        private Object getValue() {
+            return finder.findCount();
+        }
+    }
+
+    @TestVisible
+    private without sharing class ActiveServices implements FeatureManagement.FeatureParameter {
+        @TestVisible
+        private QueryBuilder queryBuilder {
+            get {
+                if (queryBuilder == null) {
+                    queryBuilder = new QueryBuilder()
+                        .withSObjectType(Service__c.SObjectType)
+                        .addCondition(ACTIVE_SERVICE_CONDITION);
+                }
+
+                return queryBuilder;
+            }
+            set;
+        }
+        @TestVisible
+        private Finder finder {
+            get {
+                if (finder == null) {
+                    finder = new Finder(queryBuilder);
+                }
+
+                return finder;
+            }
+            set;
+        }
+
+        public void send() {
+            final Object value = getValue();
+
+            if (value instanceof Integer) {
+                FeatureManagement.getInstance()
+                    .setPackageIntegerValue(getName(), (Integer) value);
+            }
+        }
+
+        private String getName() {
+            return DeveloperName.ACTIVE_SERVICES.name().remove('_');
         }
 
         private Object getValue() {

--- a/force-app/main/default/classes/FeatureParameters_TEST.cls
+++ b/force-app/main/default/classes/FeatureParameters_TEST.cls
@@ -96,6 +96,36 @@ public with sharing class FeatureParameters_TEST {
     }
 
     @IsTest
+    private static void shouldCallSetPackageIntegerByActiveServices() {
+        final String expectedName = FeatureParameters.DeveloperName.ACTIVE_SERVICES.name()
+            .remove('_');
+        final Integer expectedValue = 10;
+        Integer ordinalValue = FeatureParameters.DeveloperName.ACTIVE_SERVICES.ordinal();
+
+        FeatureManagement.instance = (FeatureManagement) featureManagementStub.createMock();
+
+        List<FeatureManagement.FeatureParameter> allFeatureParameters = new FeatureParameters()
+            .getAll();
+        FeatureParameters.ActiveServices activeServicesParameter = (FeatureParameters.ActiveServices) allFeatureParameters[
+            ordinalValue
+        ];
+        BasicStub finderStub = new BasicStub(Finder.class)
+            .withReturnValue('findCount', expectedValue);
+        activeServicesParameter.finder = (Finder) finderStub.createMock();
+
+        Test.startTest();
+        activeServicesParameter.send();
+        Test.stopTest();
+
+        finderStub.assertCalled('findCount');
+        featureManagementStub.assertCalledWith(
+            'setPackageIntegerValue',
+            new List<Type>{ String.class, Integer.class },
+            new List<Object>{ expectedName, expectedValue }
+        );
+    }
+
+    @IsTest
     private static void shouldCallSetPackageIntegerByActiveProgramsWithEngagementsLast30() {
         final String expectedName = FeatureParameters.DeveloperName.ACTIVE_PROGRAMS_WITH_ENGAGEMENTS_LAST30.name()
             .remove('_');
@@ -166,6 +196,34 @@ public with sharing class FeatureParameters_TEST {
 
         Test.startTest();
         new FeatureParameters.ActivePrograms().send();
+        Test.stopTest();
+
+        featureManagementStub.assertCalledWith(
+            'setPackageIntegerValue',
+            new List<Type>{ String.class, Integer.class },
+            new List<Object>{ expectedName, expectedValue }
+        );
+    }
+
+    @IsTest
+    private static void shouldPassActualActiveServices() {
+        List<Service__c> services = [
+            SELECT Id
+            FROM Service__c
+            WHERE Status__c = 'Active'
+        ];
+        System.assert(
+            !services.isEmpty(),
+            'Sanity check: Test setup should have generated at least 1 active record.'
+        );
+
+        final String expectedName = FeatureParameters.DeveloperName.ACTIVE_SERVICES.name()
+            .remove('_');
+        final Integer expectedValue = services.size();
+        FeatureManagement.instance = (FeatureManagement) featureManagementStub.createMock();
+
+        Test.startTest();
+        new FeatureParameters.ActiveServices().send();
         Test.stopTest();
 
         featureManagementStub.assertCalledWith(

--- a/force-app/main/default/featureParameters/ActiveServices.featureParameterInteger-meta.xml
+++ b/force-app/main/default/featureParameters/ActiveServices.featureParameterInteger-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FeatureParameterInteger xmlns="http://soap.sforce.com/2006/04/metadata">
+    <dataflowDirection>SubscriberToLmo</dataflowDirection>
+    <masterLabel>The number of Active Services</masterLabel>
+    <value>-1</value>
+</FeatureParameterInteger>


### PR DESCRIPTION
# Critical Changes

# Changes
- New telemetry query to send us how many active services an org has.

# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
~~Any net new LWC work has Sa11y tests & 50% or above lines JEST test coverage~~
~~CRUD/FLS is enforced in Apex~~
~~Permission sets are updated to account for CRUD|FLS|Tab|Classes~~
~~Field sets are updated to account for new fields~~
~~UX approval or UX not necessary~~
- [x] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: W-0000000: Work Name (https://github.com/SalesforceFoundation/PMM/pull/303)
- [ ] All **acceptance criteria** have been met
    - [x] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [x] PR contains draft release notes
- [ ] QE story level testing completed