### PR TITLE
Telemetry for active services with service schedules

### DIFF
--- a/force-app/main/default/classes/FeatureParameters.cls
+++ b/force-app/main/default/classes/FeatureParameters.cls
@@ -30,7 +30,8 @@ public without sharing class FeatureParameters {
         ATTENDANCE_SERVICE_DELIVERIES_LAST30,
         ACTIVE_PROGRAMS_WITH_COHORTS,
         ACTIVE_PROGRAMS_WITH_ACTIVE_SERVICES,
-        ACTIVE_SERVICES
+        ACTIVE_SERVICES,
+        ACTIVE_SERVICES_WITH_SERVICE_SCHEDULES
     }
 
     private static final String ACTIVE_PROGRAM_CONDITION =
@@ -94,6 +95,9 @@ public without sharing class FeatureParameters {
             }
             when ACTIVE_SERVICES {
                 return new ActiveServices();
+            }
+            when ACTIVE_SERVICES_WITH_SERVICE_SCHEDULES {
+                return new ActiveServicesWithServiceSchedules();
             }
             when else {
                 return null;
@@ -432,6 +436,62 @@ public without sharing class FeatureParameters {
                     }
                 )
                 .addCondition(CREATED_LAST_30_CONDITION)
+                .buildSoqlQuery();
+        }
+    }
+
+    @TestVisible
+    private without sharing class ActiveServicesWithServiceSchedules implements FeatureManagement.FeatureParameter {
+        @TestVisible
+        private QueryBuilder queryBuilder {
+            get {
+                if (queryBuilder == null) {
+                    queryBuilder = new QueryBuilder()
+                        .withSObjectType(Service__c.SObjectType)
+                        .addCondition(ACTIVE_SERVICE_CONDITION)
+                        .addCondition('Id IN (' + buildServiceScheduleQuery() + ')');
+                }
+
+                return queryBuilder;
+            }
+            set;
+        }
+        @TestVisible
+        private Finder finder {
+            get {
+                if (finder == null) {
+                    finder = new Finder(queryBuilder);
+                }
+
+                return finder;
+            }
+            set;
+        }
+
+        public void send() {
+            final Object value = getValue();
+
+            if (value instanceof Integer) {
+                FeatureManagement.getInstance()
+                    .setPackageIntegerValue(getName(), (Integer) value);
+            }
+        }
+
+        private String getName() {
+            return DeveloperName.ACTIVE_SERVICES_WITH_SERVICE_SCHEDULES.name()
+                .remove('_');
+        }
+
+        private Object getValue() {
+            return finder.findCount();
+        }
+
+        private String buildServiceScheduleQuery() {
+            return new QueryBuilder()
+                .withSObjectType(ServiceSchedule__c.SObjectType)
+                .withSelectFields(
+                    new List<String>{ String.valueOf(ServiceSchedule__c.Service__c) }
+                )
                 .buildSoqlQuery();
         }
     }

--- a/force-app/main/default/classes/FeatureParameters_TEST.cls
+++ b/force-app/main/default/classes/FeatureParameters_TEST.cls
@@ -15,7 +15,7 @@ public with sharing class FeatureParameters_TEST {
 
     @TestSetup
     static void generateData() {
-        TestDataFactory.generateServiceData();
+        TestDataFactory.generateAttendanceData('Daily');
     }
 
     @IsTest
@@ -234,6 +234,66 @@ public with sharing class FeatureParameters_TEST {
 
         Test.startTest();
         new FeatureParameters.ActiveProgramsWithCohorts().send();
+        Test.stopTest();
+
+        featureManagementStub.assertCalledWith(
+            'setPackageIntegerValue',
+            new List<Type>{ String.class, Integer.class },
+            new List<Object>{ expectedName, expectedValue }
+        );
+    }
+
+    @IsTest
+    private static void shouldCallSetPackageIntegerByActiveServicesWithServiceSchedules() {
+        final String expectedName = FeatureParameters.DeveloperName.ACTIVE_SERVICES_WITH_SERVICE_SCHEDULES.name()
+            .remove('_');
+        final Integer expectedValue = 10;
+        Integer ordinalValue = FeatureParameters.DeveloperName.ACTIVE_SERVICES_WITH_SERVICE_SCHEDULES.ordinal();
+
+        FeatureManagement.instance = (FeatureManagement) featureManagementStub.createMock();
+
+        List<FeatureManagement.FeatureParameter> allFeatureParameters = new FeatureParameters()
+            .getAll();
+        FeatureParameters.ActiveServicesWithServiceSchedules activeServicesWithServiceSchedulesParameter = (FeatureParameters.ActiveServicesWithServiceSchedules) allFeatureParameters[
+            ordinalValue
+        ];
+        BasicStub finderStub = new BasicStub(Finder.class)
+            .withReturnValue('findCount', expectedValue);
+        activeServicesWithServiceSchedulesParameter.finder = (Finder) finderStub.createMock();
+
+        Test.startTest();
+        activeServicesWithServiceSchedulesParameter.send();
+        Test.stopTest();
+
+        finderStub.assertCalled('findCount');
+        featureManagementStub.assertCalledWith(
+            'setPackageIntegerValue',
+            new List<Type>{ String.class, Integer.class },
+            new List<Object>{ expectedName, expectedValue }
+        );
+    }
+
+    @IsTest
+    private static void shouldPassActualActiveServicesWithServiceSchedules() {
+        List<Service__c> services = [
+            SELECT Id
+            FROM Service__c
+            WHERE
+                Status__c = 'Active'
+                AND Id IN (SELECT Service__c FROM ServiceSchedule__c)
+        ];
+        System.assert(
+            !services.isEmpty(),
+            'Sanity check: Test setup should have generated at least 1 active record with a related service schedule.'
+        );
+
+        final String expectedName = FeatureParameters.DeveloperName.ACTIVE_SERVICES_WITH_SERVICE_SCHEDULES.name()
+            .remove('_');
+        final Integer expectedValue = services.size();
+        FeatureManagement.instance = (FeatureManagement) featureManagementStub.createMock();
+
+        Test.startTest();
+        new FeatureParameters.ActiveServicesWithServiceSchedules().send();
         Test.stopTest();
 
         featureManagementStub.assertCalledWith(

--- a/force-app/main/default/classes/TestDataFactory.cls
+++ b/force-app/main/default/classes/TestDataFactory.cls
@@ -211,7 +211,8 @@ public with sharing class TestDataFactory {
                 FirstSessionStart__c = sessionStart,
                 FirstSessionEnd__c = sessionStart.addHours(24),
                 PrimaryServiceProvider__c = contacts[0].Id,
-                OtherServiceProvider__c = contacts[0].Id
+                OtherServiceProvider__c = contacts[0].Id,
+                Service__c = services[0].Id
             )
         );
         insert serviceSchedules;

--- a/force-app/main/default/featureParameters/ActiveServicesWithServiceSchedules.featureParameterInteger-meta.xml
+++ b/force-app/main/default/featureParameters/ActiveServicesWithServiceSchedules.featureParameterInteger-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FeatureParameterInteger xmlns="http://soap.sforce.com/2006/04/metadata">
+    <dataflowDirection>SubscriberToLmo</dataflowDirection>
+    <masterLabel>The number of Active Services with Service Schedules</masterLabel>
+    <value>-1</value>
+</FeatureParameterInteger>


### PR DESCRIPTION
# Critical Changes

# Changes
We added Feature Telemetry to track the number of active Services with Service Schedules.
# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
~~- [ ] Any net new LWC work has Sa11y tests & 50% or above lines JEST test coverage~~  
~~- [ ] CRUD/FLS is enforced in Apex~~
~~- [ ] Permission sets are updated to account for CRUD|FLS|Tab|Classes~~
~~- [ ] Field sets are updated to account for new fields~~
~~- [ ] UX approval or UX not necessary~~
- [x] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: W-0000000: Work Name (https://github.com/SalesforceFoundation/PMM/pull/303)
- [ ] All **acceptance criteria** have been met
    - [x] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [x] PR contains draft release notes
- [ ] QE story level testing completed