### PR TITLE
Add service schedules with sessions feature count.

### DIFF
--- a/force-app/main/default/classes/FeatureParameters.cls
+++ b/force-app/main/default/classes/FeatureParameters.cls
@@ -31,7 +31,8 @@ public without sharing class FeatureParameters {
         ACTIVE_PROGRAMS_WITH_COHORTS,
         ACTIVE_PROGRAMS_WITH_ACTIVE_SERVICES,
         ACTIVE_SERVICES,
-        ACTIVE_SERVICES_WITH_SERVICE_SCHEDULES
+        ACTIVE_SERVICES_WITH_SERVICE_SCHEDULES,
+        SERVICE_SCHEDULES_WITH_SESSIONS
     }
 
     private static final String ACTIVE_PROGRAM_CONDITION =
@@ -98,6 +99,9 @@ public without sharing class FeatureParameters {
             }
             when ACTIVE_SERVICES_WITH_SERVICE_SCHEDULES {
                 return new ActiveServicesWithServiceSchedules();
+            }
+            when SERVICE_SCHEDULES_WITH_SESSIONS {
+                return new ServiceSchedulesWithSessions();
             }
             when else {
                 return null;
@@ -491,6 +495,65 @@ public without sharing class FeatureParameters {
                 .withSObjectType(ServiceSchedule__c.SObjectType)
                 .withSelectFields(
                     new List<String>{ String.valueOf(ServiceSchedule__c.Service__c) }
+                )
+                .buildSoqlQuery();
+        }
+    }
+
+    @TestVisible
+    private without sharing class ServiceSchedulesWithSessions implements FeatureManagement.FeatureParameter {
+        @TestVisible
+        private QueryBuilder queryBuilder {
+            get {
+                if (queryBuilder == null) {
+                    queryBuilder = new QueryBuilder()
+                        .withSObjectType(ServiceSchedule__c.SObjectType)
+                        .addCondition('Id IN (' + buildSessionsQuery() + ')');
+                }
+
+                return queryBuilder;
+            }
+            set;
+        }
+        @TestVisible
+        private Finder finder {
+            get {
+                if (finder == null) {
+                    finder = new Finder(queryBuilder);
+                }
+
+                return finder;
+            }
+            set;
+        }
+
+        public void send() {
+            final Object value = getValue();
+
+            if (value instanceof Integer) {
+                FeatureManagement.getInstance()
+                    .setPackageIntegerValue(getName(), (Integer) value);
+            }
+        }
+
+        private String getName() {
+            return DeveloperName.SERVICE_SCHEDULES_WITH_SESSIONS.name().remove('_');
+        }
+
+        private Object getValue() {
+            return finder.findCount();
+        }
+
+        private String buildSessionsQuery() {
+            return new QueryBuilder()
+                .withSObjectType(ServiceSession__c.SObjectType)
+                .withSelectFields(
+                    new List<String>{
+                        String.valueOf(ServiceSession__c.ServiceSchedule__c)
+                    }
+                )
+                .addCondition(
+                    String.valueOf(ServiceSession__c.SessionStart__c) + ' > TODAY'
                 )
                 .buildSoqlQuery();
         }

--- a/force-app/main/default/classes/FeatureParameters_TEST.cls
+++ b/force-app/main/default/classes/FeatureParameters_TEST.cls
@@ -304,6 +304,69 @@ public with sharing class FeatureParameters_TEST {
     }
 
     @IsTest
+    private static void shouldCallSetPackageIntegerByServiceSchedulesWithSessions() {
+        final String expectedName = FeatureParameters.DeveloperName.SERVICE_SCHEDULES_WITH_SESSIONS.name()
+            .remove('_');
+        final Integer expectedValue = 10;
+        Integer ordinalValue = FeatureParameters.DeveloperName.SERVICE_SCHEDULES_WITH_SESSIONS.ordinal();
+
+        FeatureManagement.instance = (FeatureManagement) featureManagementStub.createMock();
+
+        List<FeatureManagement.FeatureParameter> allFeatureParameters = new FeatureParameters()
+            .getAll();
+        FeatureParameters.ServiceSchedulesWithSessions serviceSchedulesWithSessionsParameter = (FeatureParameters.ServiceSchedulesWithSessions) allFeatureParameters[
+            ordinalValue
+        ];
+        BasicStub finderStub = new BasicStub(Finder.class)
+            .withReturnValue('findCount', expectedValue);
+        serviceSchedulesWithSessionsParameter.finder = (Finder) finderStub.createMock();
+
+        Test.startTest();
+        serviceSchedulesWithSessionsParameter.send();
+        Test.stopTest();
+
+        finderStub.assertCalled('findCount');
+        featureManagementStub.assertCalledWith(
+            'setPackageIntegerValue',
+            new List<Type>{ String.class, Integer.class },
+            new List<Object>{ expectedName, expectedValue }
+        );
+    }
+
+    @IsTest
+    private static void shouldPassActualServiceSchedulesWithSessions() {
+        List<ServiceSchedule__c> schedules = [
+            SELECT Id
+            FROM ServiceSchedule__c
+            WHERE
+                Id IN (
+                    SELECT ServiceSchedule__c
+                    FROM ServiceSession__c
+                    WHERE SessionStart__c > TODAY
+                )
+        ];
+        System.assert(
+            !schedules.isEmpty(),
+            'Sanity check: Test setup should have generated at least 1 service schedule with a session in the future.'
+        );
+
+        final String expectedName = FeatureParameters.DeveloperName.SERVICE_SCHEDULES_WITH_SESSIONS.name()
+            .remove('_');
+        final Integer expectedValue = schedules.size();
+        FeatureManagement.instance = (FeatureManagement) featureManagementStub.createMock();
+
+        Test.startTest();
+        new FeatureParameters.ServiceSchedulesWithSessions().send();
+        Test.stopTest();
+
+        featureManagementStub.assertCalledWith(
+            'setPackageIntegerValue',
+            new List<Type>{ String.class, Integer.class },
+            new List<Object>{ expectedName, expectedValue }
+        );
+    }
+
+    @IsTest
     private static void shouldCreateTheQueryBuilderOnDemand() {
         QueryBuilder queryBuilder = new FeatureParameters.ActivePrograms().queryBuilder;
 

--- a/force-app/main/default/featureParameters/ServiceSchedulesWithSessions.featureParameterInteger-meta.xml
+++ b/force-app/main/default/featureParameters/ServiceSchedulesWithSessions.featureParameterInteger-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FeatureParameterInteger xmlns="http://soap.sforce.com/2006/04/metadata">
+    <dataflowDirection>SubscriberToLmo</dataflowDirection>
+    <masterLabel>The number of Service Schedules with at least one Session in the future.</masterLabel>
+    <value>-1</value>
+</FeatureParameterInteger>


### PR DESCRIPTION
# Critical Changes

# Changes
- Add new telemetry capture of the number of service schedules with at least one service session in the future.

# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
~~Any net new LWC work has Sa11y tests & 50% or above lines JEST test coverage~~
~~CRUD/FLS is enforced in Apex~~
~~Permission sets are updated to account for CRUD|FLS|Tab|Classes~~
~~Field sets are updated to account for new fields~~
~~UX approval or UX not necessary~~
- [x] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: W-0000000: Work Name (https://github.com/SalesforceFoundation/PMM/pull/303)
- [ ] All **acceptance criteria** have been met
    - [x] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [x] PR contains draft release notes
- [ ] QE story level testing completed