### PR TITLE
Feature/234  new con poc  cohort picker

### DIFF
--- a/force-app/main/default/classes/ProgramController.cls
+++ b/force-app/main/default/classes/ProgramController.cls
@@ -5,8 +5,7 @@ public with sharing class ProgramController {
     @AuraEnabled(cacheable=true)
     public static List<ProgramCohort__c> getCohortsForProgram(Id programId) {
         try {
-            return [SELECT Id, Name FROM ProgramCohort__c WHERE Program__c = :programId];
-            //return service.generateRoster(sessionId);
+            return service.getCohortsForProgram(programId);
         } catch (Exception ex) {
             throw Util.getAuraHandledException(ex);
         }

--- a/force-app/main/default/classes/ProgramController.cls
+++ b/force-app/main/default/classes/ProgramController.cls
@@ -1,0 +1,14 @@
+public with sharing class ProgramController {
+    @TestVisible
+    private static ProgramService service = new ProgramService();
+
+    @AuraEnabled(cacheable=true)
+    public static List<ProgramCohort__c> getCohortsForProgram(Id programId) {
+        try {
+            return [SELECT Id, Name FROM ProgramCohort__c WHERE Program__c = :programId];
+            //return service.generateRoster(sessionId);
+        } catch (Exception ex) {
+            throw Util.getAuraHandledException(ex);
+        }
+    }
+}

--- a/force-app/main/default/classes/ProgramController.cls-meta.xml
+++ b/force-app/main/default/classes/ProgramController.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>52.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/ProgramController_TEST.cls
+++ b/force-app/main/default/classes/ProgramController_TEST.cls
@@ -1,0 +1,48 @@
+/*
+ *
+ *  * Copyright (c) 2021, salesforce.com, inc.
+ *  * All rights reserved.
+ *  * SPDX-License-Identifier: BSD-3-Clause
+ *  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ *
+ */
+
+@IsTest
+public with sharing class ProgramController_TEST {
+    @IsTest
+    private static void testGetCohortsForProgram() {
+        List<ProgramCohort__c> cohortsToReturn = new List<ProgramCohort__c>();
+        cohortsToReturn.add(
+            new ProgramCohort__c(
+                Id = TestUtil.mockId(ProgramCohort__c.SObjectType),
+                Name = 'Cohort1'
+            )
+        );
+        cohortsToReturn.add(
+            new ProgramCohort__c(
+                Id = TestUtil.mockId(ProgramCohort__c.SObjectType),
+                Name = 'Cohort2'
+            )
+        );
+
+        Id programId = TestUtil.mockId(Program__c.SObjectType);
+
+        TestStub programServiceStub = new StubBuilder(ProgramService.class)
+            .when('getCohortsForProgram', Id.class)
+            .calledWith(programId)
+            .thenReturn(cohortsToReturn)
+            .build();
+
+        ProgramController.service = (ProgramService) programServiceStub.create();
+
+        Test.startTest();
+        System.assertEquals(
+            cohortsToReturn,
+            ProgramController.getCohortsForProgram(programId),
+            'Expected the controller to return list delivered by service.'
+        );
+        Test.stopTest();
+
+        programServiceStub.assertCalledAsExpected();
+    }
+}

--- a/force-app/main/default/classes/ProgramController_TEST.cls
+++ b/force-app/main/default/classes/ProgramController_TEST.cls
@@ -45,4 +45,41 @@ public with sharing class ProgramController_TEST {
 
         programServiceStub.assertCalledAsExpected();
     }
+
+    @IsTest
+    private static void throwsExceptionOnGetCohortsForProgram() {
+        Id programId = TestUtil.mockId(Program__c.SObjectType);
+
+        TestStub programServiceStub = new StubBuilder(ProgramService.class)
+            .when('getCohortsForProgram', Id.class)
+            .calledWith(programId)
+            .thenThrowException()
+            .build();
+
+        Exception actualException;
+
+        ProgramController.service = (ProgramService) programServiceStub.create();
+
+        Test.startTest();
+        try {
+            List<ProgramCohort__c> cohorts = ProgramController.getCohortsForProgram(
+                programId
+            );
+        } catch (AuraHandledException ex) {
+            actualException = ex;
+        } catch (Exception ex) {
+            System.assert(
+                false,
+                'Expecting only AuraHandledException: ' + ex.getMessage()
+            );
+        }
+        Test.stopTest();
+
+        System.assertNotEquals(
+            null,
+            actualException,
+            'Expected an exception to be thrown.'
+        );
+        programServiceStub.assertCalledAsExpected();
+    }
 }

--- a/force-app/main/default/classes/ProgramController_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/ProgramController_TEST.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="ServiceDeliveryController_TEST">
+    <apiVersion>52.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/ProgramSelector.cls
+++ b/force-app/main/default/classes/ProgramSelector.cls
@@ -1,0 +1,22 @@
+public with sharing class ProgramSelector {
+    private QueryBuilder queryBuilder = new QueryBuilder();
+
+    public List<ProgramCohort__c> getCohortsForProgram(Id programId, Set<String> fields) {
+        if (!Schema.SObjectType.ProgramCohort__c.isAccessible()) {
+            return new List<ProgramCohort__c>();
+        }
+
+        queryBuilder
+            .reset()
+            .withSObjectType(ProgramCohort__c.getSObjectType())
+            .withSelectFields(new List<String>(fields))
+            .addCondition(String.valueOf(ProgramCohort__c.Program__c) + ' = :programId');
+
+        List<ProgramCohort__c> programCohorts = Database.query(
+            queryBuilder.buildSoqlQuery()
+        );
+
+        return Security.stripInaccessible(AccessType.READABLE, programCohorts)
+            .getRecords();
+    }
+}

--- a/force-app/main/default/classes/ProgramSelector.cls-meta.xml
+++ b/force-app/main/default/classes/ProgramSelector.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>52.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/ProgramSelector_TEST.cls
+++ b/force-app/main/default/classes/ProgramSelector_TEST.cls
@@ -9,10 +9,10 @@
 
 @IsTest
 public with sharing class ProgramSelector_TEST {
+    private static ProgramSelector programSelector = new ProgramSelector();
+
     @IsTest
     private static void testGetCohortsForProgram() {
-        ProgramSelector programSelector = new ProgramSelector();
-
         Set<String> cohortFields = new Set<String>{
             String.valueOf(ProgramCohort__c.Id),
             String.valueOf(ProgramCohort__c.Name),
@@ -37,5 +37,29 @@ public with sharing class ProgramSelector_TEST {
                 'Should return cohorts only for the requested program'
             );
         }
+    }
+
+    @IsTest
+    private static void returnsEmptyCohortListWithoutReadAccess() {
+        Set<String> cohortFields = new Set<String>{
+            String.valueOf(ProgramCohort__c.Id),
+            String.valueOf(ProgramCohort__c.Name),
+            String.valueOf(ProgramCohort__c.Program__c)
+        };
+
+        TestDataFactory.generateProgramData();
+
+        Id programId = TestDataFactory.programs[0].Id;
+
+        User standardUser = TestUtil.getTestUser();
+        List<ProgramCohort__c> cohorts;
+
+        System.runAs(standardUser) {
+            Test.startTest();
+            cohorts = programSelector.getCohortsForProgram(programId, cohortFields);
+            Test.stopTest();
+        }
+
+        System.assert(cohorts.isEmpty(), 'Expected an empty list to be returned.');
     }
 }

--- a/force-app/main/default/classes/ProgramSelector_TEST.cls
+++ b/force-app/main/default/classes/ProgramSelector_TEST.cls
@@ -34,7 +34,7 @@ public with sharing class ProgramSelector_TEST {
             System.assertEquals(
                 programId,
                 cohort.Program__c,
-                'Should return cohorts only for the request program'
+                'Should return cohorts only for the requested program'
             );
         }
     }

--- a/force-app/main/default/classes/ProgramSelector_TEST.cls
+++ b/force-app/main/default/classes/ProgramSelector_TEST.cls
@@ -1,0 +1,41 @@
+/*
+ *
+ *  * Copyright (c) 2021, salesforce.com, inc.
+ *  * All rights reserved.
+ *  * SPDX-License-Identifier: BSD-3-Clause
+ *  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ *
+ */
+
+@IsTest
+public with sharing class ProgramSelector_TEST {
+    @IsTest
+    private static void testGetCohortsForProgram() {
+        ProgramSelector programSelector = new ProgramSelector();
+
+        Set<String> cohortFields = new Set<String>{
+            String.valueOf(ProgramCohort__c.Id),
+            String.valueOf(ProgramCohort__c.Name),
+            String.valueOf(ProgramCohort__c.Program__c)
+        };
+
+        TestDataFactory.generateProgramData();
+
+        Id programId = TestDataFactory.programs[0].Id;
+
+        List<ProgramCohort__c> cohorts = programSelector.getCohortsForProgram(
+            programId,
+            cohortFields
+        );
+
+        System.assert(cohorts.size() > 0, 'Should return at least one cohort');
+
+        for (ProgramCohort__c cohort : cohorts) {
+            System.assertEquals(
+                programId,
+                cohort.Program__c,
+                'Should return cohorts only for the request program'
+            );
+        }
+    }
+}

--- a/force-app/main/default/classes/ProgramSelector_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/ProgramSelector_TEST.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>52.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/ProgramService.cls
+++ b/force-app/main/default/classes/ProgramService.cls
@@ -11,6 +11,9 @@ public with sharing class ProgramService {
     @TestVisible
     private ProgramEngagementSelector programEngagementSelector = new ProgramEngagementSelector();
 
+    @TestVisible
+    private ProgramSelector programSelector = new ProgramSelector();
+
     public Map<Id, String> getProgramNamesByIdForContact(Id contactId) {
         Map<Id, String> programNamesById = new Map<Id, String>();
         for (
@@ -21,5 +24,13 @@ public with sharing class ProgramService {
             programNamesById.put(engagement.Program__c, engagement.Program__r.Name);
         }
         return programNamesById;
+    }
+
+    public List<ProgramCohort__c> getCohortsForProgram(Id programId) {
+        Set<String> fields = new Set<String>{
+            String.valueOf(ProgramCohort__c.Id),
+            String.valueOf(ProgramCohort__c.Name)
+        };
+        return programSelector.getCohortsForProgram(programId, fields);
     }
 }

--- a/force-app/main/default/classes/ProgramService_TEST.cls
+++ b/force-app/main/default/classes/ProgramService_TEST.cls
@@ -9,6 +9,50 @@
 
 @isTest
 public with sharing class ProgramService_TEST {
+    private static ProgramService programService = new ProgramService();
+
+    @IsTest
+    private static void testGetCohortsForProgram() {
+        List<ProgramCohort__c> cohortsToReturn = new List<ProgramCohort__c>();
+        cohortsToReturn.add(
+            new ProgramCohort__c(
+                Id = TestUtil.mockId(ProgramCohort__c.SObjectType),
+                Name = 'Cohort1'
+            )
+        );
+        cohortsToReturn.add(
+            new ProgramCohort__c(
+                Id = TestUtil.mockId(ProgramCohort__c.SObjectType),
+                Name = 'Cohort2'
+            )
+        );
+
+        Id programId = TestUtil.mockId(Program__c.SObjectType);
+
+        Set<String> programFields = new Set<String>{
+            String.valueOf(ProgramCohort__c.Id),
+            String.valueOf(ProgramCohort__c.Name)
+        };
+
+        TestStub programSelectorStub = new StubBuilder(ProgramSelector.class)
+            .when('getCohortsForProgram', Id.class, Set<String>.class)
+            .calledWith(programId, programFields)
+            .thenReturn(cohortsToReturn)
+            .build();
+
+        programService.programSelector = (ProgramSelector) programSelectorStub.create();
+
+        Test.startTest();
+        System.assertEquals(
+            cohortsToReturn,
+            programService.getCohortsForProgram(programId),
+            'Expected the service to return list delivered by selector.'
+        );
+        Test.stopTest();
+
+        programSelectorStub.assertCalledAsExpected();
+    }
+
     @isTest
     private static void testGetProgramNamesByIdForContact() {
         Id contactId = TestUtil.mockId(Contact.SObjectType);

--- a/force-app/main/default/lwc/newProgramEngagement/newProgramEngagement.html
+++ b/force-app/main/default/lwc/newProgramEngagement/newProgramEngagement.html
@@ -50,7 +50,7 @@
                             </div>
                             <lightning-combobox
                                 options={cohortOptions}
-                                value={field.value}
+                                value={selectedCohortId}
                                 disabled={cohortIsDisabled}
                                 onchange={handleCohortChange}
                                 variant="label-hidden"

--- a/force-app/main/default/lwc/newProgramEngagement/newProgramEngagement.html
+++ b/force-app/main/default/lwc/newProgramEngagement/newProgramEngagement.html
@@ -11,7 +11,9 @@
     <lightning-record-edit-form
         object-api-name={objectApiName}
         record-id={recordId}
+        onsubmit={handleSubmit}
         onsuccess={handleSuccess}
+        onerror={handleFormError}
     >
         <c-modal header={labels.newProgramEngagement} ondialogclose={handleClose}>
             <lightning-messages></lightning-messages>
@@ -36,7 +38,24 @@
                             field-name={field.apiName}
                             value={field.value}
                             disabled={field.disabled}
+                            onchange={handleFieldChange}
+                            if:false={field.isCohortField}
                         ></lightning-input-field>
+                        <template if:true={field.isCohortField}>
+                            <div
+                                class="slds-form-element__label slds-truncate"
+                                title={field.label}
+                            >
+                                {field.label}
+                            </div>
+                            <lightning-combobox
+                                options={cohortOptions}
+                                value={field.value}
+                                disabled={cohortIsDisabled}
+                                onchange={handleCohortChange}
+                                variant="label-hidden"
+                            ></lightning-combobox>
+                        </template>
                     </lightning-layout-item>
                 </template>
             </lightning-layout>
@@ -54,6 +73,7 @@
                     variant="brand"
                     class="slds-p-left_medium"
                     type="submit"
+                    disabled={isSaving}
                 ></lightning-button>
             </div>
         </c-modal>

--- a/force-app/main/default/lwc/newProgramEngagement/newProgramEngagement.js
+++ b/force-app/main/default/lwc/newProgramEngagement/newProgramEngagement.js
@@ -110,6 +110,7 @@ export default class NewProgramEngagement extends LightningElement {
     handleFieldChange(event) {
         if (event.target.fieldName === PROGRAM_FIELD.fieldApiName) {
             this.selectedProgramId = event.detail.value[0];
+            this.selectedCohortId = undefined;
         }
     }
 


### PR DESCRIPTION
# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
- [ ] Any net new LWC work has Sa11y tests & 50% or above lines JEST test coverage  
- [ ] CRUD/FLS is enforced in Apex
- [ ] Permission sets are updated to account for CRUD|FLS|Tab|Classes
- [ ] Field sets are updated to account for new fields
- [ ] UX approval or UX not necessary
- [ ] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: W-0000000: Work Name (https://github.com/SalesforceFoundation/PMM/pull/303)
- [ ] All **acceptance criteria** have been met
    - [ ] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [ ] PR contains draft release notes
- [ ] QE story level testing completed