### PR TITLE
Removing duplicate entries in participant selector

### DIFF
--- a/force-app/main/default/lwc/participantSelector/participantSelector.js
+++ b/force-app/main/default/lwc/participantSelector/participantSelector.js
@@ -371,6 +371,11 @@ export default class ParticipantSelector extends LightningElement {
 
     handleDeselectParticipant(event) {
         if (event) {
+            //filter availableEngagementRows to remove program engagement that we deselected so there are no duplicates
+            this.availableEngagementRows = this.availableEngagementRows.filter(
+                row => row.Id !== event.detail.row.Id
+            );
+
             let tempSelectedEngagements = [...this.selectedEngagements];
 
             let index = tempSelectedEngagements.findIndex(


### PR DESCRIPTION
# Critical Changes

# Changes
Filtering out the availableRows array before adding the deselected value to avoid duplicate values
# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
~~- [ ] Any net new LWC work has Sa11y tests & 50% or above lines JEST test coverage~~  
~~- [ ] CRUD/FLS is enforced in Apex~~
~~- [ ] Permission sets are updated to account for CRUD|FLS|Tab|Classes~~
~~- [ ] Field sets are updated to account for new fields~~
~~- [ ] UX approval or UX not necessary~~
- [x] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: W-0000000: Work Name (https://github.com/SalesforceFoundation/PMM/pull/303)
- [ ] All **acceptance criteria** have been met
    - [x] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [x] PR contains draft release notes
- [ ] QE story level testing completed