### PR TITLE
PMM Localized UI labels - Winter '22

### DIFF
--- a/force-app/main/default/objectTranslations/Bucket__mdt-fr_CA/Bucket__mdt-fr_CA.objectTranslation-meta.xml
+++ b/force-app/main/default/objectTranslations/Bucket__mdt-fr_CA/Bucket__mdt-fr_CA.objectTranslation-meta.xml
@@ -2,12 +2,12 @@
 <CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
     <caseValues>
         <plural>false</plural>
-        <value><!-- Bucket --></value>
+        <value/>
     </caseValues>
     <caseValues>
         <plural>true</plural>
-        <value><!-- Bucket --></value>
+        <value/>
     </caseValues>
-    <gender><!-- Masculine --></gender>
-    <startsWith><!-- Consonant --></startsWith>
+    <gender/>
+    <startsWith/>
 </CustomObjectTranslation>

--- a/force-app/main/default/objectTranslations/BucketedField__mdt-fr_CA/BucketedField__mdt-fr_CA.objectTranslation-meta.xml
+++ b/force-app/main/default/objectTranslations/BucketedField__mdt-fr_CA/BucketedField__mdt-fr_CA.objectTranslation-meta.xml
@@ -2,12 +2,12 @@
 <CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
     <caseValues>
         <plural>false</plural>
-        <value><!-- Bucketed Field --></value>
+        <value/>
     </caseValues>
     <caseValues>
         <plural>true</plural>
-        <value><!-- Bucketed Field --></value>
+        <value/>
     </caseValues>
-    <gender><!-- Masculine --></gender>
-    <startsWith><!-- Consonant --></startsWith>
+    <gender/>
+    <startsWith/>
 </CustomObjectTranslation>

--- a/force-app/main/default/objectTranslations/BucketedValue__mdt-fr_CA/BucketedValue__mdt-fr_CA.objectTranslation-meta.xml
+++ b/force-app/main/default/objectTranslations/BucketedValue__mdt-fr_CA/BucketedValue__mdt-fr_CA.objectTranslation-meta.xml
@@ -2,12 +2,12 @@
 <CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
     <caseValues>
         <plural>false</plural>
-        <value><!-- Bucketed Value --></value>
+        <value/>
     </caseValues>
     <caseValues>
         <plural>true</plural>
-        <value><!-- Bucketed Value --></value>
+        <value/>
     </caseValues>
-    <gender><!-- Masculine --></gender>
-    <startsWith><!-- Consonant --></startsWith>
+    <gender/>
+    <startsWith/>
 </CustomObjectTranslation>

--- a/force-app/main/default/objectTranslations/FeatureGate__mdt-fr_CA/FeatureGate__mdt-fr_CA.objectTranslation-meta.xml
+++ b/force-app/main/default/objectTranslations/FeatureGate__mdt-fr_CA/FeatureGate__mdt-fr_CA.objectTranslation-meta.xml
@@ -2,12 +2,12 @@
 <CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
     <caseValues>
         <plural>false</plural>
-        <value><!-- Feature Gate --></value>
+        <value/>
     </caseValues>
     <caseValues>
         <plural>true</plural>
-        <value><!-- Feature Gate --></value>
+        <value/>
     </caseValues>
-    <gender><!-- Masculine --></gender>
-    <startsWith><!-- Consonant --></startsWith>
+    <gender/>
+    <startsWith/>
 </CustomObjectTranslation>

--- a/force-app/main/default/objectTranslations/ProgramEngagement__c-de/ProgramCohort__c.fieldTranslation-meta.xml
+++ b/force-app/main/default/objectTranslations/ProgramEngagement__c-de/ProgramCohort__c.fieldTranslation-meta.xml
@@ -2,5 +2,5 @@
 <CustomFieldTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
     <name>ProgramCohort__c</name>
     <relationshipLabel>Programmteilnahme</relationshipLabel>
-    <label>Programmgruppe</label>
+    <label>Programmuntergruppe</label>
 </CustomFieldTranslation>

--- a/force-app/main/default/objectTranslations/ProgramEngagement__c-de/StartDate__c.fieldTranslation-meta.xml
+++ b/force-app/main/default/objectTranslations/ProgramEngagement__c-de/StartDate__c.fieldTranslation-meta.xml
@@ -2,5 +2,5 @@
 <CustomFieldTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
     <name>StartDate__c</name>
     <help>Wenn die Phase der Programmteilnahme &quot;Eingeschrieben&quot; oder &quot;Aktiv&quot; ist, ist der Standardwert für das Anfangsdatum der heutige Tag, wenn im Feld keine Angabe gemacht wird.</help>
-    <label>Startdatum</label>
+    <label>Anfangsdatum</label>
 </CustomFieldTranslation>

--- a/force-app/main/default/objectTranslations/ServiceParticipant__c-en_US/ServiceParticipant__c-en_US.objectTranslation-meta.xml
+++ b/force-app/main/default/objectTranslations/ServiceParticipant__c-en_US/ServiceParticipant__c-en_US.objectTranslation-meta.xml
@@ -11,7 +11,7 @@
     <layouts>
         <layout>Service Participant Layout</layout>
         <sections>
-            <label><!-- Custom Links --></label>
+            <label/>
             <section>Custom Links</section>
         </sections>
     </layouts>

--- a/force-app/main/default/objectTranslations/ServiceParticipant__c-fr_CA/ServiceParticipant__c-fr_CA.objectTranslation-meta.xml
+++ b/force-app/main/default/objectTranslations/ServiceParticipant__c-fr_CA/ServiceParticipant__c-fr_CA.objectTranslation-meta.xml
@@ -2,13 +2,13 @@
 <CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
     <caseValues>
         <plural>false</plural>
-        <value><!-- Service Participant --></value>
+        <value/>
     </caseValues>
     <caseValues>
         <plural>true</plural>
-        <value><!-- Service Participant --></value>
+        <value/>
     </caseValues>
-    <gender><!-- Masculine --></gender>
-    <nameFieldLabel><!-- Service Participant Name --></nameFieldLabel>
-    <startsWith><!-- Consonant --></startsWith>
+    <gender/>
+    <nameFieldLabel/>
+    <startsWith/>
 </CustomObjectTranslation>

--- a/force-app/main/default/objectTranslations/ServiceSchedule__c-en_US/ServiceSchedule__c-en_US.objectTranslation-meta.xml
+++ b/force-app/main/default/objectTranslations/ServiceSchedule__c-en_US/ServiceSchedule__c-en_US.objectTranslation-meta.xml
@@ -11,7 +11,7 @@
     <layouts>
         <layout>Service Schedule Layout</layout>
         <sections>
-            <label><!-- Custom Links --></label>
+            <label/>
             <section>Custom Links</section>
         </sections>
     </layouts>

--- a/force-app/main/default/objectTranslations/ServiceSchedule__c-fr_CA/ServiceSchedule__c-fr_CA.objectTranslation-meta.xml
+++ b/force-app/main/default/objectTranslations/ServiceSchedule__c-fr_CA/ServiceSchedule__c-fr_CA.objectTranslation-meta.xml
@@ -2,13 +2,13 @@
 <CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
     <caseValues>
         <plural>false</plural>
-        <value><!-- Service Schedule --></value>
+        <value/>
     </caseValues>
     <caseValues>
         <plural>true</plural>
-        <value><!-- Service Schedule --></value>
+        <value/>
     </caseValues>
-    <gender><!-- Masculine --></gender>
-    <nameFieldLabel><!-- Service Schedule Name --></nameFieldLabel>
-    <startsWith><!-- Consonant --></startsWith>
+    <gender/>
+    <nameFieldLabel/>
+    <startsWith/>
 </CustomObjectTranslation>

--- a/force-app/main/default/objectTranslations/ServiceSession__c-en_US/ServiceSession__c-en_US.objectTranslation-meta.xml
+++ b/force-app/main/default/objectTranslations/ServiceSession__c-en_US/ServiceSession__c-en_US.objectTranslation-meta.xml
@@ -11,7 +11,7 @@
     <layouts>
         <layout>Service Session Layout</layout>
         <sections>
-            <label><!-- Custom Links --></label>
+            <label/>
             <section>Custom Links</section>
         </sections>
     </layouts>

--- a/force-app/main/default/objectTranslations/ServiceSession__c-fr_CA/ServiceSession__c-fr_CA.objectTranslation-meta.xml
+++ b/force-app/main/default/objectTranslations/ServiceSession__c-fr_CA/ServiceSession__c-fr_CA.objectTranslation-meta.xml
@@ -2,13 +2,13 @@
 <CustomObjectTranslation xmlns="http://soap.sforce.com/2006/04/metadata">
     <caseValues>
         <plural>false</plural>
-        <value><!-- Service Session --></value>
+        <value/>
     </caseValues>
     <caseValues>
         <plural>true</plural>
-        <value><!-- Service Session --></value>
+        <value/>
     </caseValues>
-    <gender><!-- Masculine --></gender>
-    <nameFieldLabel><!-- Service Session Name --></nameFieldLabel>
-    <startsWith><!-- Consonant --></startsWith>
+    <gender/>
+    <nameFieldLabel/>
+    <startsWith/>
 </CustomObjectTranslation>

--- a/force-app/main/default/translations/de.translation-meta.xml
+++ b/force-app/main/default/translations/de.translation-meta.xml
@@ -81,6 +81,14 @@
         <label>Wählen Sie mindestens einen Kontakt aus, um fortzufahren.</label>
     </customLabels>
     <customLabels>
+        <name>Cant_Find_Participant</name>
+        <label>Können Sie den richtigen Teilnehmer nicht finden?</label>
+    </customLabels>
+    <customLabels>
+        <name>Cant_Find_Contact</name>
+        <label>Können den richtigen Kontakt nicht finden?</label>
+    </customLabels>
+    <customLabels>
         <name>TrackAttendance</name>
         <label>Teilnahme nachverfolgen</label>
     </customLabels>
@@ -115,6 +123,10 @@
     <customLabels>
         <name>Cancel</name>
         <label>Abbrechen</label>
+    </customLabels>
+    <customLabels>
+        <name>Cancel_and_Back</name>
+        <label>Abbrechen und zurück</label>
     </customLabels>
     <customLabels>
         <name>Clicking_Back_Button_In_Modal_Warning</name>
@@ -247,6 +259,10 @@
     <customLabels>
         <name>New_Program_Engagement</name>
         <label>Neue Programmteilnahme</label>
+    </customLabels>
+    <customLabels>
+        <name>New_Contact</name>
+        <label>Neuer Kontakt</label>
     </customLabels>
     <customLabels>
         <name>New_Service_Schedule</name>
@@ -531,6 +547,10 @@
     <customLabels>
         <name>Util_UnsupportedField</name>
         <label>Sie besitzen keinen Zugriff auf dieses Feld. Ihr Salesforce-Administrator kann Ihnen in der Sache weiterhelfen.</label>
+    </customLabels>
+    <customLabels>
+        <name>New</name>
+        <label>Neu</label>
     </customLabels>
     <customLabels>
         <name>UpsertOperationException</name>

--- a/force-app/main/default/translations/en_GB.translation-meta.xml
+++ b/force-app/main/default/translations/en_GB.translation-meta.xml
@@ -81,6 +81,14 @@
         <label>Select at least one Contact to continue.</label>
     </customLabels>
     <customLabels>
+        <name>Cant_Find_Participant</name>
+        <label>Can&apos;t find the right participant?</label>
+    </customLabels>
+    <customLabels>
+        <name>Cant_Find_Contact</name>
+        <label>Can&apos;t find the right Contact?</label>
+    </customLabels>
+    <customLabels>
         <name>TrackAttendance</name>
         <label>Track Attendance</label>
     </customLabels>
@@ -115,6 +123,10 @@
     <customLabels>
         <name>Cancel</name>
         <label>Cancel</label>
+    </customLabels>
+    <customLabels>
+        <name>Cancel_and_Back</name>
+        <label>Cancel &amp; Back</label>
     </customLabels>
     <customLabels>
         <name>Clicking_Back_Button_In_Modal_Warning</name>
@@ -247,6 +259,10 @@
     <customLabels>
         <name>New_Program_Engagement</name>
         <label>New Program Engagement</label>
+    </customLabels>
+    <customLabels>
+        <name>New_Contact</name>
+        <label>New Contact</label>
     </customLabels>
     <customLabels>
         <name>New_Service_Schedule</name>
@@ -531,6 +547,10 @@
     <customLabels>
         <name>Util_UnsupportedField</name>
         <label>You can&apos;t access this field. Your Salesforce admin can help with that.</label>
+    </customLabels>
+    <customLabels>
+        <name>New</name>
+        <label>New</label>
     </customLabels>
     <customLabels>
         <name>UpsertOperationException</name>

--- a/force-app/main/default/translations/es.translation-meta.xml
+++ b/force-app/main/default/translations/es.translation-meta.xml
@@ -81,6 +81,14 @@
         <label>Seleccione al menos un contacto para continuar.</label>
     </customLabels>
     <customLabels>
+        <name>Cant_Find_Participant</name>
+        <label>¿No puede encontrar el participante correcto?</label>
+    </customLabels>
+    <customLabels>
+        <name>Cant_Find_Contact</name>
+        <label>¿No puede encontrar el contacto correcto?</label>
+    </customLabels>
+    <customLabels>
         <name>TrackAttendance</name>
         <label>Seguimiento de asistencia</label>
     </customLabels>
@@ -115,6 +123,10 @@
     <customLabels>
         <name>Cancel</name>
         <label>Cancelar</label>
+    </customLabels>
+    <customLabels>
+        <name>Cancel_and_Back</name>
+        <label>Cancelar y volver</label>
     </customLabels>
     <customLabels>
         <name>Clicking_Back_Button_In_Modal_Warning</name>
@@ -247,6 +259,10 @@
     <customLabels>
         <name>New_Program_Engagement</name>
         <label>Nueva participación en programa</label>
+    </customLabels>
+    <customLabels>
+        <name>New_Contact</name>
+        <label>Nuevo contacto</label>
     </customLabels>
     <customLabels>
         <name>New_Service_Schedule</name>
@@ -531,6 +547,10 @@
     <customLabels>
         <name>Util_UnsupportedField</name>
         <label>No puede acceder a este campo. Su administrador de Salesforce puede ayudarle con ello.</label>
+    </customLabels>
+    <customLabels>
+        <name>New</name>
+        <label>Nuevo</label>
     </customLabels>
     <customLabels>
         <name>UpsertOperationException</name>

--- a/force-app/main/default/translations/es_MX.translation-meta.xml
+++ b/force-app/main/default/translations/es_MX.translation-meta.xml
@@ -81,6 +81,14 @@
         <label>Seleccione al menos un contacto para continuar.</label>
     </customLabels>
     <customLabels>
+        <name>Cant_Find_Participant</name>
+        <label>¿No puede encontrar el participante correcto?</label>
+    </customLabels>
+    <customLabels>
+        <name>Cant_Find_Contact</name>
+        <label>¿No puede encontrar el contacto correcto?</label>
+    </customLabels>
+    <customLabels>
         <name>TrackAttendance</name>
         <label>Seguimiento de asistencia</label>
     </customLabels>
@@ -115,6 +123,10 @@
     <customLabels>
         <name>Cancel</name>
         <label>Cancelar</label>
+    </customLabels>
+    <customLabels>
+        <name>Cancel_and_Back</name>
+        <label>Cancelar y volver</label>
     </customLabels>
     <customLabels>
         <name>Clicking_Back_Button_In_Modal_Warning</name>
@@ -247,6 +259,10 @@
     <customLabels>
         <name>New_Program_Engagement</name>
         <label>Nueva participación en programa</label>
+    </customLabels>
+    <customLabels>
+        <name>New_Contact</name>
+        <label>Nuevo contacto</label>
     </customLabels>
     <customLabels>
         <name>New_Service_Schedule</name>
@@ -531,6 +547,10 @@
     <customLabels>
         <name>Util_UnsupportedField</name>
         <label>No puede acceder a este campo. Su administrador de Salesforce puede ayudarle con ello.</label>
+    </customLabels>
+    <customLabels>
+        <name>New</name>
+        <label>Nuevo</label>
     </customLabels>
     <customLabels>
         <name>UpsertOperationException</name>

--- a/force-app/main/default/translations/fr.translation-meta.xml
+++ b/force-app/main/default/translations/fr.translation-meta.xml
@@ -81,6 +81,14 @@
         <label>Sélectionnez au moins un contact pour continuer.</label>
     </customLabels>
     <customLabels>
+        <name>Cant_Find_Participant</name>
+        <label>Vous ne trouvez pas le bon participant ?</label>
+    </customLabels>
+    <customLabels>
+        <name>Cant_Find_Contact</name>
+        <label>Vous ne trouvez pas le bon contact ?</label>
+    </customLabels>
+    <customLabels>
         <name>TrackAttendance</name>
         <label>Suivre les présences</label>
     </customLabels>
@@ -115,6 +123,10 @@
     <customLabels>
         <name>Cancel</name>
         <label>Annuler</label>
+    </customLabels>
+    <customLabels>
+        <name>Cancel_and_Back</name>
+        <label>Annuler et Retour</label>
     </customLabels>
     <customLabels>
         <name>Clicking_Back_Button_In_Modal_Warning</name>
@@ -247,6 +259,10 @@
     <customLabels>
         <name>New_Program_Engagement</name>
         <label>Nouvel engagement dans un programme</label>
+    </customLabels>
+    <customLabels>
+        <name>New_Contact</name>
+        <label>Nouveau contact</label>
     </customLabels>
     <customLabels>
         <name>New_Service_Schedule</name>
@@ -531,6 +547,10 @@
     <customLabels>
         <name>Util_UnsupportedField</name>
         <label>Vous ne pouvez pas accéder à ce champ. Demandez de l’aide à votre administrateur Salesforce.</label>
+    </customLabels>
+    <customLabels>
+        <name>New</name>
+        <label>Nouveau</label>
     </customLabels>
     <customLabels>
         <name>UpsertOperationException</name>

--- a/force-app/main/default/translations/ja.translation-meta.xml
+++ b/force-app/main/default/translations/ja.translation-meta.xml
@@ -81,6 +81,14 @@
         <label>続行するには 1 人以上の取引先責任者を選択します。</label>
     </customLabels>
     <customLabels>
+        <name>Cant_Find_Participant</name>
+        <label>適切な参加者が見つからない場合</label>
+    </customLabels>
+    <customLabels>
+        <name>Cant_Find_Contact</name>
+        <label>適切な取引先責任者が見つからない場合</label>
+    </customLabels>
+    <customLabels>
         <name>TrackAttendance</name>
         <label>出席を追跡</label>
     </customLabels>
@@ -115,6 +123,10 @@
     <customLabels>
         <name>Cancel</name>
         <label>キャンセル</label>
+    </customLabels>
+    <customLabels>
+        <name>Cancel_and_Back</name>
+        <label>キャンセルして戻る</label>
     </customLabels>
     <customLabels>
         <name>Clicking_Back_Button_In_Modal_Warning</name>
@@ -247,6 +259,10 @@
     <customLabels>
         <name>New_Program_Engagement</name>
         <label>新規プログラムエンゲージメント</label>
+    </customLabels>
+    <customLabels>
+        <name>New_Contact</name>
+        <label>新規取引先責任者</label>
     </customLabels>
     <customLabels>
         <name>New_Service_Schedule</name>
@@ -531,6 +547,10 @@
     <customLabels>
         <name>Util_UnsupportedField</name>
         <label>この項目にアクセスできません。Salesforce システム管理者にお問い合わせください。</label>
+    </customLabels>
+    <customLabels>
+        <name>New</name>
+        <label>新規</label>
     </customLabels>
     <customLabels>
         <name>UpsertOperationException</name>

--- a/force-app/main/default/translations/nl_NL.translation-meta.xml
+++ b/force-app/main/default/translations/nl_NL.translation-meta.xml
@@ -81,6 +81,14 @@
         <label>Selecteer ten minste één contactpersoon om door te gaan.</label>
     </customLabels>
     <customLabels>
+        <name>Cant_Find_Participant</name>
+        <label>Kunt u de juiste deelnemer niet vinden?</label>
+    </customLabels>
+    <customLabels>
+        <name>Cant_Find_Contact</name>
+        <label>Kunt u de juiste contactpersoon niet vinden?</label>
+    </customLabels>
+    <customLabels>
         <name>TrackAttendance</name>
         <label>Aanwezigheid bijhouden</label>
     </customLabels>
@@ -115,6 +123,10 @@
     <customLabels>
         <name>Cancel</name>
         <label>Annuleren</label>
+    </customLabels>
+    <customLabels>
+        <name>Cancel_and_Back</name>
+        <label>Annuleren en terug</label>
     </customLabels>
     <customLabels>
         <name>Clicking_Back_Button_In_Modal_Warning</name>
@@ -247,6 +259,10 @@
     <customLabels>
         <name>New_Program_Engagement</name>
         <label>Nieuwe programmabetrokkenheid</label>
+    </customLabels>
+    <customLabels>
+        <name>New_Contact</name>
+        <label>Nieuwe contactpersoon</label>
     </customLabels>
     <customLabels>
         <name>New_Service_Schedule</name>
@@ -531,6 +547,10 @@
     <customLabels>
         <name>Util_UnsupportedField</name>
         <label>U hebt geen toegang tot dit veld. Uw Salesforce-beheerder kan hierbij helpen.</label>
+    </customLabels>
+    <customLabels>
+        <name>New</name>
+        <label>Nieuw</label>
     </customLabels>
     <customLabels>
         <name>UpsertOperationException</name>


### PR DESCRIPTION
# Critical Changes

Localized UI for PMM - Winter '22 release

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
- [ ] Any net new LWC work has Sa11y tests & 50% or above lines JEST test coverage  
- [ ] CRUD/FLS is enforced in Apex
- [ ] Permission sets are updated to account for CRUD|FLS|Tab|Classes
- [ ] Field sets are updated to account for new fields
- [ ] UX approval or UX not necessary
- [ ] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: W-0000000: Work Name (https://github.com/SalesforceFoundation/PMM/pull/303)
- [ ] All **acceptance criteria** have been met
    - [ ] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [ ] PR contains draft release notes
- [ ] QE story level testing completed