### PR TITLE
Dynamic fields displayed on Attendance UI based on Field Set

### DIFF
--- a/force-app/main/default/classes/AttendanceController.cls
+++ b/force-app/main/default/classes/AttendanceController.cls
@@ -12,7 +12,7 @@ public with sharing class AttendanceController {
     private static ServiceDeliveryService service = new ServiceDeliveryService();
 
     @AuraEnabled(cacheable=true)
-    public static List<ServiceDelivery__c> generateRoster(Id sessionId) {
+    public static ServiceDeliveryService.Roster generateRoster(Id sessionId) {
         try {
             return service.generateRoster(sessionId);
         } catch (Exception ex) {

--- a/force-app/main/default/classes/AttendanceController_TEST.cls
+++ b/force-app/main/default/classes/AttendanceController_TEST.cls
@@ -15,13 +15,18 @@ public with sharing class AttendanceController_TEST {
     private static void shouldReturnServiceDeliveriesFromService() {
         String generateRoster = 'generateRoster';
         List<ServiceDelivery__c> serviceDeliveriesToReturn = new List<ServiceDelivery__c>();
-        serviceStub.withReturnValue(generateRoster, Id.class, serviceDeliveriesToReturn);
+        ServiceDeliveryService.Roster rosterToReturn = new ServiceDeliveryService.Roster(
+            null,
+            serviceDeliveriesToReturn
+        );
+        serviceStub.withReturnValue(generateRoster, Id.class, rosterToReturn);
         Id sessionId = TestUtil.mockId(ServiceSession__c.SObjectType);
         AttendanceController.service = (ServiceDeliveryService) serviceStub.createMock();
 
         Test.startTest();
         System.assert(
-            serviceDeliveriesToReturn === AttendanceController.generateRoster(sessionId),
+            serviceDeliveriesToReturn ===
+            AttendanceController.generateRoster(sessionId).deliveries,
             'Expected the controller to return the list returned by the service.'
         );
         Test.stopTest();

--- a/force-app/main/default/classes/FieldSetService.cls
+++ b/force-app/main/default/classes/FieldSetService.cls
@@ -163,7 +163,7 @@ public with sharing class FieldSetService {
      * @param String fieldSetName
      * @return      FieldSet
      */
-    private FieldSet getFieldSet(
+    public FieldSet getFieldSet(
         DescribeSObjectResult objectDescribe,
         String fieldSetName
     ) {

--- a/force-app/main/default/classes/ServiceDeliverySelector.cls
+++ b/force-app/main/default/classes/ServiceDeliverySelector.cls
@@ -10,12 +10,24 @@
 public with sharing class ServiceDeliverySelector {
     private QueryBuilder queryBuilder = new QueryBuilder();
 
-    public List<ServiceDelivery__c> getServiceDeliveriesBySessionId(Id sessionId) {
+    public String getAttendanceFieldSetName(Id scheduleId) {
+        // We want to bypass FLS because this is a system field that drives our UI
+        List<ServiceSchedule__c> schedules = [
+            SELECT Service__r.AttendanceFieldSet__c
+            FROM ServiceSchedule__c
+            WHERE Id = :scheduleId
+        ];
+
+        return schedules.isEmpty() ? null : schedules[0].Service__r.AttendanceFieldSet__c;
+    }
+
+    public List<ServiceDelivery__c> getServiceDeliveriesBySessionId(
+        FieldSet fieldSet,
+        Id sessionId
+    ) {
         if (!Schema.SObjectType.ServiceDelivery__c.isAccessible()) {
             return new List<ServiceDelivery__c>();
         }
-
-        FieldSet fieldSet = SObjectType.ServiceDelivery__c.FieldSets.Attendance_Service_Deliveries;
 
         queryBuilder.withSObjectType(ServiceDelivery__c.getSObjectType())
             .withSelectFields(fieldSet)

--- a/force-app/main/default/classes/ServiceDeliverySelector_TEST.cls
+++ b/force-app/main/default/classes/ServiceDeliverySelector_TEST.cls
@@ -11,6 +11,7 @@
 public with sharing class ServiceDeliverySelector_TEST {
     private static ServiceDeliverySelector selector = new ServiceDeliverySelector();
     private static BasicStub validatorStub = new BasicStub(PermissionValidator.class);
+    private static FieldSet defaultFieldSet = SObjectType.ServiceDelivery__c.FieldSets.Attendance_Service_Deliveries;
 
     @TestSetup
     private static void setupServiceSessionData() {
@@ -31,7 +32,10 @@ public with sharing class ServiceDeliverySelector_TEST {
         insert serviceDelivery.clone();
 
         Test.startTest();
-        actualDeliveries = selector.getServiceDeliveriesBySessionId(sessionId);
+        actualDeliveries = selector.getServiceDeliveriesBySessionId(
+            defaultFieldSet,
+            sessionId
+        );
         Test.stopTest();
 
         List<ServiceDelivery__c> sessionDeliveries = [
@@ -134,7 +138,10 @@ public with sharing class ServiceDeliverySelector_TEST {
 
         System.runAs(standardUser) {
             Test.startTest();
-            actualDeliveries = selector.getServiceDeliveriesBySessionId(sessionId);
+            actualDeliveries = selector.getServiceDeliveriesBySessionId(
+                defaultFieldSet,
+                sessionId
+            );
             Test.stopTest();
         }
 

--- a/force-app/main/default/classes/ServiceDeliveryService.cls
+++ b/force-app/main/default/classes/ServiceDeliveryService.cls
@@ -12,6 +12,8 @@ public with sharing class ServiceDeliveryService {
     private ServiceDeliverySelector deliverySelector = new ServiceDeliverySelector();
     @TestVisible
     private FieldBucketSelector bucketSelector = new FieldBucketSelector();
+    @TestVisible
+    private FieldSetService fieldSetService = new FieldSetService();
 
     @TestVisible
     private ServiceDeliveryDomain domain = new ServiceDeliveryDomain();
@@ -66,8 +68,19 @@ public with sharing class ServiceDeliveryService {
         set;
     }
 
-    public List<ServiceDelivery__c> generateRoster(Id sessionId) {
-        return createRows(sessionId);
+    public Roster generateRoster(Id sessionId) {
+        ServiceSession__c session = deliverySelector.getSession(sessionId);
+        FieldSet fieldSet = getFieldSet(session.ServiceSchedule__c);
+        List<ServiceDelivery__c> deliveries = createServiceDeliveries(fieldSet, session);
+
+        return new Roster(
+            fieldSetService.getFieldSetForLWC(
+                String.valueOf(ServiceDelivery__c.SObjectType),
+                fieldSet.getName(),
+                false
+            ),
+            deliveries
+        );
     }
 
     public void upsertServiceDeliveries(
@@ -154,22 +167,36 @@ public with sharing class ServiceDeliveryService {
         return result;
     }
 
-    private List<ServiceDelivery__c> createRows(Id sessionId) {
+    private FieldSet getFieldSet(Id scheduleId) {
+        FieldSet defaultFieldSet = SObjectType.ServiceDelivery__c.FieldSets.Attendance_Service_Deliveries;
+        String fieldSetName = deliverySelector.getAttendanceFieldSetName(scheduleId);
+        if (fieldSetName == null) {
+            return defaultFieldSet;
+        }
+        FieldSet fieldSet = fieldSetService.getFieldSet(
+            ServiceDelivery__c.SObjectType.getDescribe(),
+            fieldSetName
+        );
+
+        return fieldSet == null ? defaultFieldSet : fieldSet;
+    }
+
+    private List<ServiceDelivery__c> createServiceDeliveries(
+        FieldSet fieldSet,
+        ServiceSession__c session
+    ) {
         Set<Id> existingClients = new Set<Id>();
         List<ServiceDelivery__c> deliveries = new List<ServiceDelivery__c>(
-            deliverySelector.getServiceDeliveriesBySessionId(sessionId)
+            deliverySelector.getServiceDeliveriesBySessionId(fieldSet, session.Id)
         );
 
         for (ServiceDelivery__c delivery : deliveries) {
             existingClients.add(delivery.Contact__c);
         }
 
-        ServiceSession__c session = deliverySelector.getSession(sessionId);
-        Id scheduleId = session.ServiceSchedule__c;
-
         for (
             ServiceParticipant__c participant : deliverySelector.getServiceParticipantsByScheduleId(
-                scheduleId,
+                session.ServiceSchedule__c,
                 existingClients
             )
         ) {
@@ -229,6 +256,21 @@ public with sharing class ServiceDeliveryService {
         }
 
         return buckets;
+    }
+
+    public class Roster {
+        @AuraEnabled
+        public List<Map<String, Object>> fieldSet;
+        @AuraEnabled
+        public List<ServiceDelivery__c> deliveries;
+
+        public Roster(
+            List<Map<String, Object>> fieldSet,
+            List<ServiceDelivery__c> deliveries
+        ) {
+            this.fieldSet = fieldSet;
+            this.deliveries = deliveries;
+        }
     }
 
     public class ServiceDeliveryException extends Exception {

--- a/force-app/main/default/classes/ServiceDeliveryService_TEST.cls
+++ b/force-app/main/default/classes/ServiceDeliveryService_TEST.cls
@@ -15,6 +15,8 @@ public with sharing class ServiceDeliveryService_TEST {
     private static TestStub permValidatorStub;
     private static TestStub systemAccessStub;
 
+    private static FieldSet defaultFieldSet = SObjectType.ServiceDelivery__c.FieldSets.Attendance_Service_Deliveries;
+
     private static ServiceDeliveryService service = new ServiceDeliveryService();
 
     @IsTest
@@ -87,15 +89,20 @@ public with sharing class ServiceDeliveryService_TEST {
         Id sessionId = TestUtil.mockId(ServiceSession__c.SObjectType);
         Id scheduleId = TestUtil.mockId(ServiceSchedule__c.SObjectType);
         deliverySelectorStub = new StubBuilder(ServiceDeliverySelector.class)
-            .when('getServiceDeliveriesBySessionId', Id.class)
-            .calledWith(sessionId)
+            .when('getAttendanceFieldSetName', Id.class)
+            .calledWith(scheduleId)
+            .thenReturn(null)
+            .when('getServiceDeliveriesBySessionId', FieldSet.class, Id.class)
+            .calledWith(defaultFieldSet, sessionId)
             .thenReturn(new List<ServiceDelivery__c>())
             .when('getServiceParticipantsByScheduleId', Id.class, Set<Id>.class)
             .calledWith(scheduleId, new Set<Id>())
             .thenReturn(new List<ServiceParticipant__c>())
             .when('getSession', Id.class)
             .calledWith(sessionId)
-            .thenReturn(new ServiceSession__c(ServiceSchedule__c = scheduleId))
+            .thenReturn(
+                new ServiceSession__c(Id = sessionId, ServiceSchedule__c = scheduleId)
+            )
             .build();
 
         service.deliverySelector = (ServiceDeliverySelector) deliverySelectorStub.create();
@@ -114,15 +121,23 @@ public with sharing class ServiceDeliveryService_TEST {
         };
         Id scheduleId = TestUtil.mockId(ServiceSchedule__c.SObjectType);
         deliverySelectorStub = new StubBuilder(ServiceDeliverySelector.class)
-            .when('getServiceDeliveriesBySessionId', Id.class)
-            .calledWith(deliveriesToReturn[0].ServiceSession__c)
+            .when('getAttendanceFieldSetName', Id.class)
+            .calledWith(scheduleId)
+            .thenReturn(null)
+            .when('getServiceDeliveriesBySessionId', FieldSet.class, Id.class)
+            .calledWith(defaultFieldSet, deliveriesToReturn[0].ServiceSession__c)
             .thenReturn(deliveriesToReturn)
             .when('getServiceParticipantsByScheduleId', Id.class, Set<Id>.class)
             .calledWith(scheduleId, new Set<Id>{ deliveriesToReturn[0].Contact__c })
             .thenReturn(new List<ServiceParticipant__c>())
             .when('getSession', Id.class)
             .calledWith(deliveriesToReturn[0].ServiceSession__c)
-            .thenReturn(new ServiceSession__c(ServiceSchedule__c = scheduleId))
+            .thenReturn(
+                new ServiceSession__c(
+                    Id = deliveriesToReturn[0].ServiceSession__c,
+                    ServiceSchedule__c = scheduleId
+                )
+            )
             .build();
 
         service.deliverySelector = (ServiceDeliverySelector) deliverySelectorStub.create();
@@ -130,7 +145,7 @@ public with sharing class ServiceDeliveryService_TEST {
         Test.startTest();
         System.assertEquals(
             deliveriesToReturn,
-            service.generateRoster(deliveriesToReturn[0].ServiceSession__c),
+            service.generateRoster(deliveriesToReturn[0].ServiceSession__c).deliveries,
             'Expected only the service deliveries returned by the selector.'
         );
         Test.stopTest();
@@ -149,8 +164,11 @@ public with sharing class ServiceDeliveryService_TEST {
         };
         List<ServiceDelivery__c> actualDeliveries;
         deliverySelectorStub = new StubBuilder(ServiceDeliverySelector.class)
-            .when('getServiceDeliveriesBySessionId', Id.class)
-            .calledWith(sessionId)
+            .when('getAttendanceFieldSetName', Id.class)
+            .calledWith(scheduleId)
+            .thenReturn(null)
+            .when('getServiceDeliveriesBySessionId', FieldSet.class, Id.class)
+            .calledWith(defaultFieldSet, sessionId)
             .thenReturn(new List<ServiceDelivery__c>())
             .when('getServiceParticipantsByScheduleId', Id.class, Set<Id>.class)
             .calledWith(scheduleId, new Set<Id>())
@@ -169,7 +187,7 @@ public with sharing class ServiceDeliveryService_TEST {
         service.deliverySelector = (ServiceDeliverySelector) deliverySelectorStub.create();
 
         Test.startTest();
-        actualDeliveries = service.generateRoster(sessionId);
+        actualDeliveries = service.generateRoster(sessionId).deliveries;
         Test.stopTest();
 
         System.assertEquals(
@@ -218,21 +236,26 @@ public with sharing class ServiceDeliveryService_TEST {
         List<ServiceDelivery__c> actualDeliveries;
 
         deliverySelectorStub = new StubBuilder(ServiceDeliverySelector.class)
-            .when('getServiceDeliveriesBySessionId', Id.class)
-            .calledWith(sessionId)
+            .when('getAttendanceFieldSetName', Id.class)
+            .calledWith(scheduleId)
+            .thenReturn(null)
+            .when('getServiceDeliveriesBySessionId', FieldSet.class, Id.class)
+            .calledWith(defaultFieldSet, sessionId)
             .thenReturn(deliveriesToReturn)
             .when('getServiceParticipantsByScheduleId', Id.class, Set<Id>.class)
             .calledWith(scheduleId, new Set<Id>{ deliveriesToReturn[0].Contact__c })
             .thenReturn(participantsToReturn)
             .when('getSession', Id.class)
             .calledWith(sessionId)
-            .thenReturn(new ServiceSession__c(ServiceSchedule__c = scheduleId))
+            .thenReturn(
+                new ServiceSession__c(Id = sessionId, ServiceSchedule__c = scheduleId)
+            )
             .build();
 
         service.deliverySelector = (ServiceDeliverySelector) deliverySelectorStub.create();
 
         Test.startTest();
-        actualDeliveries = service.generateRoster(sessionId);
+        actualDeliveries = service.generateRoster(sessionId).deliveries;
         Test.stopTest();
 
         System.assertEquals(
@@ -348,7 +371,7 @@ public with sharing class ServiceDeliveryService_TEST {
         ];
 
         Test.startTest();
-        actualDeliveries = service.generateRoster(session.Id);
+        actualDeliveries = service.generateRoster(session.Id).deliveries;
         Test.stopTest();
 
         Integer countParticipants = [

--- a/force-app/main/default/classes/TestStub.cls
+++ b/force-app/main/default/classes/TestStub.cls
@@ -74,6 +74,8 @@ public with sharing class TestStub implements System.StubProvider {
         public void expectedToHaveBeenCalled() {
             String message =
                 'This bound method was called ' +
+                signature.methodName +
+                ' ' +
                 callCount +
                 'x and was expected to be called ';
             if (expectedCalls != null) {

--- a/force-app/main/default/layouts/Service__c-Service Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Service__c-Service Layout.layout-meta.xml
@@ -40,6 +40,10 @@
         <editHeading>true</editHeading>
         <label>System Information</label>
         <layoutColumns>
+        <layoutItems>
+                <behavior>Edit</behavior>
+                <field>AttendanceFieldSet__c</field>
+            </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
                 <field>ServiceDeliveryFieldSet__c</field>

--- a/force-app/main/default/lwc/attendance/__tests__/attendance.test.js
+++ b/force-app/main/default/lwc/attendance/__tests__/attendance.test.js
@@ -12,7 +12,6 @@ import Attendance from "c/attendance";
 import { getRecord } from "lightning/uiRecordApi";
 import { CurrentPageReference } from "lightning/navigation";
 import generateRoster from "@salesforce/apex/AttendanceController.generateRoster";
-import getFieldSet from "@salesforce/apex/FieldSetController.getFieldSetForLWC";
 import checkFieldPermissions from "@salesforce/apex/AttendanceController.checkFieldPermissions";
 import {
     registerApexTestWireAdapter,
@@ -20,8 +19,7 @@ import {
 } from "@salesforce/sfdx-lwc-jest";
 
 const mockGenerateRoster = require("./data/generateRoster.json");
-const mockGenerateRosterEmpty = require("../../__tests__/data/emptyList.json");
-const mockGetFieldSet = require("./data/getFieldSet.json");
+const mockGenerateRosterEmpty = require("./data/emptyRoster.json");
 const mockWiredSession = require("./data/wiredPendingSession.json");
 const mockWiredPermissions = require("./data/wiredPermissions.json");
 const mockWiredNoPermissions = require("./data/wiredNoPermissions.json");
@@ -29,7 +27,6 @@ const mockCurrentPageReference = require("./data/currentPageReference.json");
 
 //Register the  wire adapters
 const generateRosterAdapter = registerApexTestWireAdapter(generateRoster);
-const fieldSetAdapter = registerApexTestWireAdapter(getFieldSet);
 const wiredSessionAdapter = registerLdsTestWireAdapter(getRecord);
 const wiredPermissionsAdapter = registerApexTestWireAdapter(checkFieldPermissions);
 const wiredCurrentPageReference = registerApexTestWireAdapter(CurrentPageReference);
@@ -51,7 +48,6 @@ describe("c-attendance", () => {
     it("shows multiple returned rows with perms", async () => {
         document.body.appendChild(element);
         wiredSessionAdapter.emit(mockWiredSession);
-        fieldSetAdapter.emit(mockGetFieldSet);
         generateRosterAdapter.emit(mockGenerateRoster);
         wiredPermissionsAdapter.emit(mockWiredPermissions);
         wiredCurrentPageReference.emit(mockCurrentPageReference);
@@ -60,14 +56,13 @@ describe("c-attendance", () => {
             const attendanceRows = element.shadowRoot.querySelectorAll(
                 "c-attendance-row"
             );
-            expect(attendanceRows).toHaveLength(mockGenerateRoster.length);
+            expect(attendanceRows).toHaveLength(mockGenerateRoster.deliveries.length);
             global.isAccessible(element);
         });
     });
     it("shows empty state and no buttons when zero returned rows with no perms", async () => {
         document.body.appendChild(element);
         wiredSessionAdapter.emit(mockWiredSession);
-        fieldSetAdapter.emit(mockGetFieldSet);
         generateRosterAdapter.emit(mockGenerateRosterEmpty);
         wiredPermissionsAdapter.emit(mockWiredNoPermissions);
         wiredCurrentPageReference.emit(mockCurrentPageReference);
@@ -76,7 +71,9 @@ describe("c-attendance", () => {
             const attendanceRows = element.shadowRoot.querySelectorAll(
                 "c-attendance-row"
             );
-            expect(attendanceRows).toHaveLength(mockGenerateRosterEmpty.length);
+            expect(attendanceRows).toHaveLength(
+                mockGenerateRosterEmpty.deliveries.length
+            );
 
             const emptyState = element.shadowRoot.querySelectorAll("c-empty-state");
             expect(emptyState).toHaveLength(1);
@@ -95,7 +92,6 @@ describe("c-attendance", () => {
     it("shows empty state and no buttons when zero returned rows with perms", async () => {
         document.body.appendChild(element);
         wiredSessionAdapter.emit(mockWiredSession);
-        fieldSetAdapter.emit(mockGetFieldSet);
         generateRosterAdapter.emit(mockGenerateRosterEmpty);
         wiredPermissionsAdapter.emit(mockWiredPermissions);
         wiredCurrentPageReference.emit(mockCurrentPageReference);
@@ -104,7 +100,9 @@ describe("c-attendance", () => {
             const attendanceRows = element.shadowRoot.querySelectorAll(
                 "c-attendance-row"
             );
-            expect(attendanceRows).toHaveLength(mockGenerateRosterEmpty.length);
+            expect(attendanceRows).toHaveLength(
+                mockGenerateRosterEmpty.deliveries.length
+            );
 
             const emptyState = element.shadowRoot.querySelectorAll("c-empty-state");
             expect(emptyState).toHaveLength(1);
@@ -123,7 +121,6 @@ describe("c-attendance", () => {
     it("shows perms error when rows are returned with no perms", async () => {
         document.body.appendChild(element);
         wiredSessionAdapter.emit(mockWiredSession);
-        fieldSetAdapter.emit(mockGetFieldSet);
         generateRosterAdapter.emit(mockGenerateRoster);
         wiredPermissionsAdapter.emit(mockWiredNoPermissions);
         wiredCurrentPageReference.emit(mockCurrentPageReference);

--- a/force-app/main/default/lwc/attendance/__tests__/data/emptyRoster.json
+++ b/force-app/main/default/lwc/attendance/__tests__/data/emptyRoster.json
@@ -1,0 +1,41 @@
+{
+    "deliveries": [],
+    "fieldSet": [
+        {
+            "apiName": "Contact__c",
+            "label": "Client",
+            "type": "REFERENCE",
+            "isRequired": false,
+            "isAccessible": true,
+            "relationshipName": "Contact__r",
+            "referenceTo": "Contact",
+            "referenceNameField": "Name",
+            "isUpdateable": true
+        },
+        {
+            "apiName": "Quantity__c",
+            "label": "Quantity",
+            "type": "DOUBLE",
+            "isRequired": false,
+            "helpText": "A 2-decimal numeric field for Quantity of a Service Delivery expressed in the Unit of Measurement in the Service. For example, 30 minutes of tutoring where the Unit of Measure is hours, Quantity is .50.",
+            "isAccessible": true,
+            "isUpdateable": true
+        },
+        {
+            "apiName": "AttendanceStatus__c",
+            "label": "Attendance Status",
+            "type": "PICKLIST",
+            "isRequired": false,
+            "isAccessible": true,
+            "isUpdateable": true
+        },
+        {
+            "apiName": "CreatedDate",
+            "label": "Created Date",
+            "type": "DATETIME",
+            "isRequired": true,
+            "isAccessible": true,
+            "isUpdateable": false
+        }
+    ]
+}

--- a/force-app/main/default/lwc/attendance/__tests__/data/generateRoster.json
+++ b/force-app/main/default/lwc/attendance/__tests__/data/generateRoster.json
@@ -1,32 +1,88 @@
-[
-    {
-        "CreatedDate": "2020-11-06T17:11:52.000Z",
-        "Contact__r": { "Id": "003P000001Qmwu4IAB", "Name": "Aaron Valdez" },
-        "Contact__c": "003P000001Qmwu4IAB",
-        "Id": "a03P0000007hRjkIAE"
-    },
-    {
-        "ServiceSession__c": "a06P0000009loxhIAA",
-        "AttendanceStatus__c": "Present",
-        "Contact__r": { "Id": "003P000001QmwrfIAB", "Name": "Naima Crawford" },
-        "Contact__c": "003P000001QmwrfIAB",
-        "ProgramEngagement__c": "a01P0000009jLFmIAM",
-        "Service__c": "a07P0000009ArI3IAK"
-    },
-    {
-        "ServiceSession__c": "a06P0000009loxhIAA",
-        "AttendanceStatus__c": "Present",
-        "Contact__r": { "Id": "003P000001QmwsFIAR", "Name": "Ayanna Gonzalez" },
-        "Contact__c": "003P000001QmwsFIAR",
-        "ProgramEngagement__c": "a01P0000009jLG8IAM",
-        "Service__c": "a07P0000009ArI3IAK"
-    },
-    {
-        "ServiceSession__c": "a06P0000009loxhIAA",
-        "AttendanceStatus__c": "Present",
-        "Contact__r": { "Id": "003P000001QmwsYIAR", "Name": "Taniyah Rios" },
-        "Contact__c": "003P000001QmwsYIAR",
-        "ProgramEngagement__c": "a01P0000009jLGEIA2",
-        "Service__c": "a07P0000009ArI3IAK"
-    }
-]
+{
+    "deliveries": [
+        {
+            "AttendanceStatus__c": "Present",
+            "CreatedDate": "2022-01-28T15:48:06.000Z",
+            "Contact__r": { "Id": "0035400000mKMoAAAW", "Name": "Abraham Sims" },
+            "Contact__c": "0035400000mKMoAAAW",
+            "Id": "a0354000004vNiRAAU",
+            "Quantity__c": 3
+        },
+        {
+            "AttendanceStatus__c": "Present",
+            "CreatedDate": "2022-01-28T15:48:06.000Z",
+            "Contact__r": {
+                "Id": "0035400000mKMmjAAG",
+                "Name": "Ayanna Gonzalez"
+            },
+            "Contact__c": "0035400000mKMmjAAG",
+            "Id": "a0354000004vNiSAAU",
+            "Quantity__c": 2
+        },
+        {
+            "AttendanceStatus__c": "Unexcused Absence",
+            "CreatedDate": "2022-01-28T15:48:06.000Z",
+            "Contact__r": {
+                "Id": "0035400000mKMm2AAG",
+                "Name": "Naima Crawford"
+            },
+            "Contact__c": "0035400000mKMm2AAG",
+            "Id": "a0354000004vNiTAAU",
+            "Quantity__c": 0
+        },
+        {
+            "AttendanceStatus__c": "Excused Absence",
+            "CreatedDate": "2022-01-28T15:48:06.000Z",
+            "Contact__r": { "Id": "0035400000mKMn3AAG", "Name": "Taniyah Rios" },
+            "Contact__c": "0035400000mKMn3AAG",
+            "Id": "a0354000004vNiUAAU",
+            "Quantity__c": 1
+        },
+        {
+            "AttendanceStatus__c": "Present",
+            "CreatedDate": "2022-01-28T15:54:30.000Z",
+            "Contact__r": { "Id": "0035400000mKMmuAAG", "Name": "Alia Duarte" },
+            "Contact__c": "0035400000mKMmuAAG",
+            "Id": "a0354000004vNibAAE",
+            "Quantity__c": 2
+        }
+    ],
+    "fieldSet": [
+        {
+            "apiName": "Contact__c",
+            "label": "Client",
+            "type": "REFERENCE",
+            "isRequired": false,
+            "isAccessible": true,
+            "relationshipName": "Contact__r",
+            "referenceTo": "Contact",
+            "referenceNameField": "Name",
+            "isUpdateable": true
+        },
+        {
+            "apiName": "Quantity__c",
+            "label": "Quantity",
+            "type": "DOUBLE",
+            "isRequired": false,
+            "helpText": "A 2-decimal numeric field for Quantity of a Service Delivery expressed in the Unit of Measurement in the Service. For example, 30 minutes of tutoring where the Unit of Measure is hours, Quantity is .50.",
+            "isAccessible": true,
+            "isUpdateable": true
+        },
+        {
+            "apiName": "AttendanceStatus__c",
+            "label": "Attendance Status",
+            "type": "PICKLIST",
+            "isRequired": false,
+            "isAccessible": true,
+            "isUpdateable": true
+        },
+        {
+            "apiName": "CreatedDate",
+            "label": "Created Date",
+            "type": "DATETIME",
+            "isRequired": true,
+            "isAccessible": true,
+            "isUpdateable": false
+        }
+    ]
+}

--- a/force-app/main/default/lwc/attendance/attendance.js
+++ b/force-app/main/default/lwc/attendance/attendance.js
@@ -16,11 +16,9 @@ import { getRecord, updateRecord } from "lightning/uiRecordApi";
 import { ShowToastEvent } from "lightning/platformShowToastEvent";
 import { refreshApex } from "@salesforce/apex";
 import generateRoster from "@salesforce/apex/AttendanceController.generateRoster";
-import getFieldSet from "@salesforce/apex/FieldSetController.getFieldSetForLWC";
 import upsertRows from "@salesforce/apex/AttendanceController.upsertServiceDeliveries";
 import checkFieldPermissions from "@salesforce/apex/AttendanceController.checkFieldPermissions";
 
-import SERVICE_DELIVERY_OBJECT from "@salesforce/schema/ServiceDelivery__c";
 import SERVICE_SESSION_OBJECT from "@salesforce/schema/ServiceSession__c";
 import CONTACT_FIELD from "@salesforce/schema/ServiceDelivery__c.Contact__c";
 import QUANTITY_FIELD from "@salesforce/schema/ServiceDelivery__c.Quantity__c";
@@ -50,7 +48,6 @@ import BAD_TAB_HEADER from "@salesforce/label/c.Incorrect_Tab";
 import ATTENDANCE_TAB_MESSAGE from "@salesforce/label/c.Attendance_Tab_Message";
 import pmmFolder from "@salesforce/resourceUrl/pmm";
 
-const FIELD_SET_NAME = "Attendance_Service_Deliveries";
 const SHORT_DATA_TYPES = ["DOUBLE", "INTEGER", "BOOLEAN"];
 const LONG_DATA_TYPES = ["TEXTAREA", "PICKLIST", "REFERENCE"];
 const ID = "Id";
@@ -157,29 +154,18 @@ export default class Attendance extends NavigationMixin(LightningElement) {
         }
 
         if (result.data) {
-            this.serviceDeliveries = [...result.data];
+            this.serviceDeliveries = [...result.data.deliveries];
             this.serviceDeliveries.sort((a, b) => {
                 return getChildObjectByName(a, "Contact__r").Name >
                     getChildObjectByName(b, "Contact__r").Name
                     ? 1
                     : -1;
             });
+            this.configureFieldSet(result.data.fieldSet.map(a => ({ ...a })));
         } else if (result.error) {
             console.log(result.error);
         }
         this.showSpinner = false;
-    }
-
-    @wire(getFieldSet, {
-        objectName: SERVICE_DELIVERY_OBJECT.objectApiName,
-        fieldSetName: FIELD_SET_NAME,
-    })
-    wiredFields(result) {
-        if (result.data) {
-            this.configureFieldSet(result.data.map(a => ({ ...a })));
-        } else if (result.error) {
-            console.log(result.error);
-        }
     }
 
     connectedCallback() {

--- a/force-app/main/default/objects/Service__c/fields/AttendanceFieldSet__c.field-meta.xml
+++ b/force-app/main/default/objects/Service__c/fields/AttendanceFieldSet__c.field-meta.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>AttendanceFieldSet__c</fullName>
+    <externalId>false</externalId>
+    <label>Attendance Field Set</label>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>Picklist</type>
+    <valueSet>
+        <restricted>true</restricted>
+        <valueSetDefinition>
+            <sorted>false</sorted>
+            <value>
+                <fullName>Attendance_Service_Deliveries</fullName>
+                <default>true</default>
+                <label>Attendance Service Deliveries</label>
+            </value>
+        </valueSetDefinition>
+    </valueSet>
+</CustomField>

--- a/force-app/main/default/permissionsets/PMDM_Deliver.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/PMDM_Deliver.permissionset-meta.xml
@@ -438,6 +438,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Service__c.AttendanceFieldSet__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Service__c.ServiceDeliveryFieldSet__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/force-app/main/default/permissionsets/PMDM_Manage.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/PMDM_Manage.permissionset-meta.xml
@@ -438,6 +438,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>Service__c.AttendanceFieldSet__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>Service__c.ServiceDeliveryFieldSet__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/force-app/main/default/permissionsets/PMDM_View.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/PMDM_View.permissionset-meta.xml
@@ -413,6 +413,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Service__c.AttendanceFieldSet__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Service__c.ServiceDeliveryFieldSet__c</field>
         <readable>true</readable>
     </fieldPermissions>


### PR DESCRIPTION
# Critical Changes

# Changes
- A new field, AttendanceFieldSet__c, was added to the Service Object
- This new field will drive the fields that are displayed on the Attendance component on a Service Session record
- When no value is present we will continue to use the default Attendance_Service_Delivery field set

# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
~~Any net new LWC work has Sa11y tests & 50% or above lines JEST test coverage~~
- [x] CRUD/FLS is enforced in Apex
- [x] Permission sets are updated to account for CRUD|FLS|Tab|Classes
- [ ] Field sets are updated to account for new fields
- [x] UX approval or UX not necessary
- [x] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: W-0000000: Work Name (https://github.com/SalesforceFoundation/PMM/pull/303)
- [ ] All **acceptance criteria** have been met
    - [x] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [x] PR contains draft release notes
- [ ] QE story level testing completed