### PR TITLE
W-10433201 - Fix "too many queries" error for field set discovery

### DIFF
--- a/force-app/main/default/classes/FieldSetService.cls
+++ b/force-app/main/default/classes/FieldSetService.cls
@@ -239,7 +239,7 @@ public with sharing class FieldSetService {
             'isAccessible' => field.isAccessible(),
             'relationshipName' => field.getRelationshipName(),
             'referenceTo' => referenceObjectName,
-            'referenceNameField' => getNameFieldForObject(referenceObjectName),
+            'referenceNameField' => getNameFieldForReferenceField(field),
             'isUpdateable' => field.isUpdateable()
         };
     }
@@ -314,23 +314,25 @@ public with sharing class FieldSetService {
     }
 
     /**
-     * Platform limits the number of reference fields on an object so using this query
-     * within a loop of fields with a field set.
+     * Returns the API name of the "name" field of the object type referenced
+     * by this field.  If the field provided is not a lookup field, this method
+     * returns null.  If the lookup is polymorphic, then the name field for
+     * only one of the referenced types is returned.
      */
-    private String getNameFieldForObject(String sObjectApiName) {
-        if (sObjectApiName == null) {
-            return null;
+    private String getNameFieldForReferenceField(DescribeFieldResult field) {
+        List<Schema.SObjectType> references = field.getReferenceTo();
+        if (!references.isEmpty()) {
+            Schema.DescribeSObjectResult referencedType = references[0].getDescribe();
+            Map<String, Schema.SObjectField> fields = referencedType.fields.getMap();
+            for (Schema.SObjectField referenceField : fields.values()) {
+                Schema.DescribeFieldResult referenceFieldDescribe = referenceField.getDescribe();
+                if (referenceFieldDescribe.isNameField()) {
+                    return referenceFieldDescribe.getName();
+                }
+            }
         }
 
-        List<FieldDefinition> fieldDefinitions = [
-            SELECT QualifiedApiName
-            FROM FieldDefinition
-            WHERE
-                EntityDefinition.QualifiedApiName = :sObjectApiName
-                AND IsNameField = TRUE
-        ];
-
-        return fieldDefinitions.isEmpty() ? null : fieldDefinitions[0].QualifiedApiName;
+        return null;
     }
 
     private class FieldSetException extends Exception {

--- a/force-app/main/default/classes/FieldSetService_TEST.cls
+++ b/force-app/main/default/classes/FieldSetService_TEST.cls
@@ -285,107 +285,75 @@ public with sharing class FieldSetService_TEST {
 
     @IsTest
     private static void shouldReturnNullNameFieldForNonReferenceField() {
-        String message = 'When getFieldForLWC is called with a non-lookup ' +
+        String message =
+            'When getFieldForLWC is called with a non-lookup ' +
             'field, the returned map should have a null value for both ' +
             'referenceTo and referenceNameField';
 
-        Map<String, Object> f = (new FieldSetService()).getfieldforLWC(
-            Schema.Contact.Name.getDescribe()
-        );
+        Map<String, Object> f = (new FieldSetService())
+            .getfieldforLWC(Schema.Contact.Name.getDescribe());
 
-        System.assertEquals(
-            null,
-            f.get('referenceTo'),
-            message
-        );
+        System.assertEquals(null, f.get('referenceTo'), message);
 
-        System.assertEquals(
-            null,
-            f.get('referenceNameField'),
-            message
-        );
+        System.assertEquals(null, f.get('referenceNameField'), message);
     }
 
     @IsTest
     private static void shouldReturnNameFieldForPolymorphicLookupField() {
-        String message = 'When getFieldForLWC is called with a polymorphic ' +
+        String message =
+            'When getFieldForLWC is called with a polymorphic ' +
             'lookup field, the return map should have the name and name field of ' +
             'the "first" object type referenced by the polymorphic lookup';
 
-        Map<String, Object> f = (new FieldSetService()).getfieldforLWC(
-            Schema.Case.OwnerId.getDescribe()
-        );
+        Map<String, Object> f = (new FieldSetService())
+            .getfieldforLWC(Schema.Case.OwnerId.getDescribe());
 
-        System.assertEquals(
-            'Group',
-            f.get('referenceTo'),
-            message
-        );
+        System.assertEquals('Group', f.get('referenceTo'), message);
 
-        System.assertEquals(
-            'Name',
-            f.get('referenceNameField'),
-            message
-        );
+        System.assertEquals('Name', f.get('referenceNameField'), message);
     }
 
     @IsTest
     private static void shouldReturnNameFieldForPolymorphicLookupField2() {
-        String message = 'When getFieldForLWC is called with a polymorphic ' +
+        String message =
+            'When getFieldForLWC is called with a polymorphic ' +
             'lookup field, the return map should have the name and name field of ' +
             'the "first" object type referenced by the polymorphic lookup, ' +
             'even if this object has a non-standard name field';
 
-        Map<String, Object> f = (new FieldSetService()).getfieldforLWC(
-            Schema.PermissionSet.LicenseId.getDescribe()
-        );
+        Map<String, Object> f = (new FieldSetService())
+            .getfieldforLWC(Schema.PermissionSet.LicenseId.getDescribe());
 
-        System.assertEquals(
-            'PermissionSetLicense',
-            f.get('referenceTo'),
-            message
-        );
+        System.assertEquals('PermissionSetLicense', f.get('referenceTo'), message);
 
-        System.assertEquals(
-            'DeveloperName',
-            f.get('referenceNameField'),
-            message
-        );
+        System.assertEquals('DeveloperName', f.get('referenceNameField'), message);
     }
 
     @IsTest
     private static void shouldReturnNameFieldForStandardLookupField() {
-        String message = 'When getFieldForLWC is called with a lookup field to ' +
+        String message =
+            'When getFieldForLWC is called with a lookup field to ' +
             'a standard object, the return map should have the name and name ' +
             'field of the standard object';
 
-        Map<String, Object> f = (new FieldSetService()).getfieldforLWC(
-            Schema.Case.ParentId.getDescribe()
-        );
+        Map<String, Object> f = (new FieldSetService())
+            .getfieldforLWC(Schema.Case.ParentId.getDescribe());
 
-        System.assertEquals(
-            'Case',
-            f.get('referenceTo'),
-            message
-        );
+        System.assertEquals('Case', f.get('referenceTo'), message);
 
-        System.assertEquals(
-            'CaseNumber',
-            f.get('referenceNameField'),
-            message
-        );
+        System.assertEquals('CaseNumber', f.get('referenceNameField'), message);
     }
 
     @IsTest
     private static void shouldReturnNameFieldForPackagedLookupField() {
-        String message = 'When getFieldForLWC is called with a lookup field to ' +
+        String message =
+            'When getFieldForLWC is called with a lookup field to ' +
             'an object in the same package, the return map should have the name ' +
             'and name field of the referenced object with the namespace ' +
             'prefixed if the code is running in a namespaced context';
 
-        Map<String, Object> f = (new FieldSetService()).getfieldforLWC(
-            Schema.ProgramEngagement__c.Program__c.getDescribe()
-        );
+        Map<String, Object> f = (new FieldSetService())
+            .getfieldforLWC(Schema.ProgramEngagement__c.Program__c.getDescribe());
 
         String expectedObjectName = 'Program__c';
 
@@ -397,16 +365,8 @@ public with sharing class FieldSetService_TEST {
             expectedObjectName = namespacePrefix + '__Program__c';
         }
 
-        System.assertEquals(
-            expectedObjectName,
-            f.get('referenceTo'),
-            message
-        );
+        System.assertEquals(expectedObjectName, f.get('referenceTo'), message);
 
-        System.assertEquals(
-            'Name',
-            f.get('referenceNameField'),
-            message
-        );
+        System.assertEquals('Name', f.get('referenceNameField'), message);
     }
 }

--- a/force-app/main/default/classes/FieldSetService_TEST.cls
+++ b/force-app/main/default/classes/FieldSetService_TEST.cls
@@ -282,4 +282,131 @@ public with sharing class FieldSetService_TEST {
             'The exception message was not as expected.'
         );
     }
+
+    @IsTest
+    private static void shouldReturnNullNameFieldForNonReferenceField() {
+        String message = 'When getFieldForLWC is called with a non-lookup ' +
+            'field, the returned map should have a null value for both ' +
+            'referenceTo and referenceNameField';
+
+        Map<String, Object> f = (new FieldSetService()).getfieldforLWC(
+            Schema.Contact.Name.getDescribe()
+        );
+
+        System.assertEquals(
+            null,
+            f.get('referenceTo'),
+            message
+        );
+
+        System.assertEquals(
+            null,
+            f.get('referenceNameField'),
+            message
+        );
+    }
+
+    @IsTest
+    private static void shouldReturnNameFieldForPolymorphicLookupField() {
+        String message = 'When getFieldForLWC is called with a polymorphic ' +
+            'lookup field, the return map should have the name and name field of ' +
+            'the "first" object type referenced by the polymorphic lookup';
+
+        Map<String, Object> f = (new FieldSetService()).getfieldforLWC(
+            Schema.Case.OwnerId.getDescribe()
+        );
+
+        System.assertEquals(
+            'Group',
+            f.get('referenceTo'),
+            message
+        );
+
+        System.assertEquals(
+            'Name',
+            f.get('referenceNameField'),
+            message
+        );
+    }
+
+    @IsTest
+    private static void shouldReturnNameFieldForPolymorphicLookupField2() {
+        String message = 'When getFieldForLWC is called with a polymorphic ' +
+            'lookup field, the return map should have the name and name field of ' +
+            'the "first" object type referenced by the polymorphic lookup, ' +
+            'even if this object has a non-standard name field';
+
+        Map<String, Object> f = (new FieldSetService()).getfieldforLWC(
+            Schema.PermissionSet.LicenseId.getDescribe()
+        );
+
+        System.assertEquals(
+            'PermissionSetLicense',
+            f.get('referenceTo'),
+            message
+        );
+
+        System.assertEquals(
+            'DeveloperName',
+            f.get('referenceNameField'),
+            message
+        );
+    }
+
+    @IsTest
+    private static void shouldReturnNameFieldForStandardLookupField() {
+        String message = 'When getFieldForLWC is called with a lookup field to ' +
+            'a standard object, the return map should have the name and name ' +
+            'field of the standard object';
+
+        Map<String, Object> f = (new FieldSetService()).getfieldforLWC(
+            Schema.Case.ParentId.getDescribe()
+        );
+
+        System.assertEquals(
+            'Case',
+            f.get('referenceTo'),
+            message
+        );
+
+        System.assertEquals(
+            'CaseNumber',
+            f.get('referenceNameField'),
+            message
+        );
+    }
+
+    @IsTest
+    private static void shouldReturnNameFieldForPackagedLookupField() {
+        String message = 'When getFieldForLWC is called with a lookup field to ' +
+            'an object in the same package, the return map should have the name ' +
+            'and name field of the referenced object with the namespace ' +
+            'prefixed if the code is running in a namespaced context';
+
+        Map<String, Object> f = (new FieldSetService()).getfieldforLWC(
+            Schema.ProgramEngagement__c.Program__c.getDescribe()
+        );
+
+        String expectedObjectName = 'Program__c';
+
+        String className = String.valueOf(FieldSetService_TEST.class);
+        Boolean isNamespaced = className.contains('.');
+
+        if (isNamespaced) {
+            String namespacePrefix = className.substringBefore('.');
+            expectedObjectName = namespacePrefix + '__Program__c';
+        }
+
+        System.assertEquals(
+            expectedObjectName,
+            f.get('referenceTo'),
+            message
+        );
+
+        System.assertEquals(
+            'Name',
+            f.get('referenceNameField'),
+            message
+        );
+    }
 }


### PR DESCRIPTION
Changing how related object name fields are discovered

In FieldSetService, when retrieving fields for a field set (or other purposes), when preparing the data structure that contains details about a particular field, if a lookup field is being represented the referenced object name and the name of the field on the referenced object that represents the name of the referenced object is determined and included in the returned data structure representing the lookup field.

The way determination of the name field of a referenced object was being done was to issue a SOQL query against the FieldDefinition table.  However, when many fieldsets are being processed, this was causing this SOQL query to be run for every lookup field that was included.  In some cases, this was causing an exception in customer orgs because of "too many SOQL queries".

To remediate this issue, this change replaces the logic of determining the name field of an object type referenced by a lookup field with code that will use the schema describe results within Apex to iterate over fields of the referenced object and find the one that has the 'isNameField' property set to true.

This change is able to avoid governor limit exceptions for too many SOQL queries, and does not seem to run into any additional limits even in situations where many field sets with many lookups are defined in the org (150 field sets with 4 lookup fields each, e.g.).

# Critical Changes

# Changes

* Fixed issue where having a large number of field sets defined in an org would cause an error when visiting the BSDT tool.

# Issues Closed

* Fixes [W-10433201](https://gus.lightning.force.com/lightning/r/a07EE00000fAJBXYA4/view)

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below

- [x] Link the pull request and work item by PR comment and Chatter post respectively
- [ ] All **acceptance criteria** have been met
    - [x] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [x] PR contains draft release notes
- [ ] QE story level testing completed