### PR TITLE
Attendance Component Row UI Enhancement

### DIFF
--- a/force-app/main/default/labels/CustomLabels.labels-meta.xml
+++ b/force-app/main/default/labels/CustomLabels.labels-meta.xml
@@ -329,8 +329,8 @@
         <fullName>Dont_Track_Attendance</fullName>
         <language>en_US</language>
         <protected>true</protected>
-        <shortDescription>Don't track attendance for this participant</shortDescription>
-        <value>Don't track attendance for this participant</value>
+        <shortDescription>Don't create an attendance service delivery for this person</shortDescription>
+        <value>Don't create an attendance service delivery for this person</value>
     </labels>
     <labels>
         <fullName>Enabled</fullName>

--- a/force-app/main/default/lwc/attendance/attendance.js
+++ b/force-app/main/default/lwc/attendance/attendance.js
@@ -48,8 +48,6 @@ import BAD_TAB_HEADER from "@salesforce/label/c.Incorrect_Tab";
 import ATTENDANCE_TAB_MESSAGE from "@salesforce/label/c.Attendance_Tab_Message";
 import pmmFolder from "@salesforce/resourceUrl/pmm";
 
-const SHORT_DATA_TYPES = ["DOUBLE", "INTEGER", "BOOLEAN"];
-const LONG_DATA_TYPES = ["TEXTAREA", "PICKLIST", "REFERENCE"];
 const ID = "Id";
 const COMPLETE = "Complete";
 const PENDING = "Pending";
@@ -229,17 +227,8 @@ export default class Attendance extends NavigationMixin(LightningElement) {
             field.isNormalField = false;
             field.isContactField = false;
 
-            if (SHORT_DATA_TYPES.includes(field.type)) {
-                field.size = 1;
-            } else if (LONG_DATA_TYPES.includes(field.type)) {
-                field.size = 3;
-            } else {
-                field.size = 2;
-            }
-
             if (field.apiName === this.fields.contact.fieldApiName) {
                 field.isContactField = true;
-                field.size = 2;
             } else if (field.apiName === this.fields.quantity.fieldApiName) {
                 field.isQuantityField = true;
                 field.variant = "label-hidden";

--- a/force-app/main/default/lwc/attendanceRow/attendanceRow.html
+++ b/force-app/main/default/lwc/attendanceRow/attendanceRow.html
@@ -16,112 +16,131 @@
             object-api-name={serviceDeliveryObject}
             density="comfy"
         >
-            <lightning-layout multiple-rows="true" horizontal-align="left">
-                <template for:each={fieldSet} for:item="field">
-                    <lightning-layout-item
-                        size="12"
-                        small-device-size="6"
-                        medium-device-size="3"
-                        large-device-size={field.size}
-                        key={field.apiName}
-                        class="slds-var-p-around_xx-small"
-                        disabled={rowDisabled}
+            <lightning-layout vertical-align="center">
+                <lightning-layout-item flexibility="grow">
+                    <lightning-layout
+                        multiple-rows="true"
+                        horizontal-align="left"
+                        class="attendance-row"
                     >
-                        <!-- CONTACT FIELD, ALWAYS OUTPUT, CUSTOM VALUE -->
-                        <template if:true={field.isContactField}>
-                            <div class="slds-form-element slds-form-element_stacked">
-                                <label
-                                    for={field.apiName}
-                                    class="slds-form-element__label"
-                                >
-                                    {field.label}
-                                </label>
-                                <div class="slds-form-element__static" id={field.apiName}>
-                                    {name}
-                                </div>
-                            </div>
-                        </template>
-
-                        <!-- QUANTITY FIELD, DYNAMIC INPUT/OUTPUT WITH CUSTOM LABEL -->
-                        <template if:true={field.isQuantityField}>
-                            <!-- INPUT -->
-                            <template if:false={readOnly}>
-                                <div class="slds-form-element slds-form-element_stacked">
-                                    <lightning-input
-                                        label={unitOfMeasurement}
-                                        onchange={handleQuantityChange}
-                                        type="number"
-                                        min="0"
-                                        step=".01"
-                                        value={quantity}
-                                        disabled={rowDisabled}
-                                    ></lightning-input>
-                                </div>
-                            </template>
-
-                            <!-- OUTPUT -->
-                            <template if:true={readOnly}>
-                                <div class="slds-form-element slds-form-element_stacked">
-                                    <label
-                                        for={field.apiName}
-                                        class="slds-form-element__label"
+                        <template for:each={fieldSet} for:item="field">
+                            <lightning-layout-item
+                                size="12"
+                                small-device-size="6"
+                                medium-device-size="3"
+                                large-device-size="3"
+                                key={field.apiName}
+                                class="slds-var-p-around_xx-small"
+                                disabled={rowDisabled}
+                                flexibility="grow"
+                            >
+                                <!-- CONTACT FIELD, ALWAYS OUTPUT, CUSTOM VALUE -->
+                                <template if:true={field.isContactField}>
+                                    <div
+                                        class="slds-form-element slds-form-element_stacked"
                                     >
-                                        {unitOfMeasurement}
-                                    </label>
-                                    <lightning-output-field
-                                        id={field.name}
-                                        variant="label-hidden"
-                                        field-name={field.apiName}
-                                    ></lightning-output-field>
-                                </div>
-                            </template>
+                                        <label
+                                            for={field.apiName}
+                                            class="slds-form-element__label"
+                                        >
+                                            {field.label}
+                                        </label>
+                                        <div
+                                            class="slds-form-element__static"
+                                            id={field.apiName}
+                                        >
+                                            {name}
+                                        </div>
+                                    </div>
+                                </template>
+
+                                <!-- QUANTITY FIELD, DYNAMIC INPUT/OUTPUT WITH CUSTOM LABEL -->
+                                <template if:true={field.isQuantityField}>
+                                    <!-- INPUT -->
+                                    <template if:false={readOnly}>
+                                        <div
+                                            class="slds-form-element slds-form-element_stacked"
+                                        >
+                                            <lightning-input
+                                                label={unitOfMeasurement}
+                                                onchange={handleQuantityChange}
+                                                type="number"
+                                                min="0"
+                                                step=".01"
+                                                value={quantity}
+                                                disabled={rowDisabled}
+                                            ></lightning-input>
+                                        </div>
+                                    </template>
+
+                                    <!-- OUTPUT -->
+                                    <template if:true={readOnly}>
+                                        <div
+                                            class="slds-form-element slds-form-element_stacked"
+                                        >
+                                            <label
+                                                for={field.apiName}
+                                                class="slds-form-element__label"
+                                            >
+                                                {unitOfMeasurement}
+                                            </label>
+                                            <lightning-output-field
+                                                id={field.name}
+                                                variant="label-hidden"
+                                                field-name={field.apiName}
+                                            ></lightning-output-field>
+                                        </div>
+                                    </template>
+                                </template>
+
+                                <!-- READ-ONLY FIELDS LIKE CREATED DATE -->
+                                <!-- extra special handling because of output-field bug that gets created date label wrong -->
+                                <template if:true={field.isOutputField}>
+                                    <template if:true={field.value}>
+                                        <div
+                                            class="slds-form-element slds-form-element_stacked"
+                                        >
+                                            <label
+                                                for={field.apiName}
+                                                class="slds-form-element__label"
+                                            >
+                                                {field.label}
+                                            </label>
+                                            <lightning-output-field
+                                                id={field.name}
+                                                variant="label-hidden"
+                                                field-name={field.apiName}
+                                            ></lightning-output-field>
+                                        </div>
+                                    </template>
+                                </template>
+
+                                <!-- ALL OTHER FIELDS WITHOUT SPECIAL HANDLING, DYNAMIC INPUT/OUTPUT -->
+                                <template if:true={field.isNormalField}>
+                                    <!-- INPUT -->
+                                    <template if:false={readOnly}>
+                                        <lightning-input-field
+                                            field-name={field.apiName}
+                                            onchange={handleInputChange}
+                                            value={field.value}
+                                            variant={field.variant}
+                                            disabled={rowDisabled}
+                                        >
+                                        </lightning-input-field>
+                                    </template>
+
+                                    <!-- OUTPUT -->
+                                    <template if:true={readOnly}>
+                                        <lightning-output-field
+                                            id={field.name}
+                                            field-name={field.apiName}
+                                        ></lightning-output-field>
+                                    </template>
+                                </template>
+                            </lightning-layout-item>
                         </template>
-
-                        <!-- READ-ONLY FIELDS LIKE CREATED DATE -->
-                        <!-- extra special handling because of output-field bug that gets created date label wrong -->
-                        <template if:true={field.isOutputField}>
-                            <template if:true={field.value}>
-                                <div class="slds-form-element slds-form-element_stacked">
-                                    <label
-                                        for={field.apiName}
-                                        class="slds-form-element__label"
-                                    >
-                                        {field.label}
-                                    </label>
-                                    <lightning-output-field
-                                        id={field.name}
-                                        variant="label-hidden"
-                                        field-name={field.apiName}
-                                    ></lightning-output-field>
-                                </div>
-                            </template>
-                        </template>
-
-                        <!-- ALL OTHER FIELDS WITHOUT SPECIAL HANDLING, DYNAMIC INPUT/OUTPUT -->
-                        <template if:true={field.isNormalField}>
-                            <!-- INPUT -->
-                            <template if:false={readOnly}>
-                                <lightning-input-field
-                                    field-name={field.apiName}
-                                    onchange={handleInputChange}
-                                    value={field.value}
-                                    variant={field.variant}
-                                    disabled={rowDisabled}
-                                >
-                                </lightning-input-field>
-                            </template>
-
-                            <!-- OUTPUT -->
-                            <template if:true={readOnly}>
-                                <lightning-output-field
-                                    id={field.name}
-                                    field-name={field.apiName}
-                                ></lightning-output-field>
-                            </template>
-                        </template>
-                    </lightning-layout-item>
-                </template>
-
+                    </lightning-layout>
+                </lightning-layout-item>
                 <!-- SKIP PARTICIPANT TOGGLE -->
                 <lightning-layout-item
                     class="slds-var-p-around_medium"
@@ -135,6 +154,7 @@
                         alternative-text={labels.skip}
                         onclick={handleToggleButton}
                         selected={rowDisabled}
+                        aria-label={labels.skip}
                     ></lightning-button-icon-stateful>
                 </lightning-layout-item>
             </lightning-layout>

--- a/force-app/main/default/staticresources/pmm/attendancePrintOverride.css
+++ b/force-app/main/default/staticresources/pmm/attendancePrintOverride.css
@@ -36,3 +36,10 @@
 div.slds-form-element__control > .slds-form-element__static {
     border: 0px;
 }
+
+.attendance-row label {
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}


### PR DESCRIPTION
# Critical Changes

# Changes
Updates the Service Delivery rows in the Attendance component to handle a greater number of fields.  
Fixes a situation where the fields are displayed unevenly when labels are on two lines.

# Issues Closed
[W-10398948](https://gus.lightning.force.com/a07EE00000dJnxwYAC)

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
- [ ] Any net new LWC work has Sa11y tests & 50% or above lines JEST test coverage  
- [ ] CRUD/FLS is enforced in Apex
- [ ] Permission sets are updated to account for CRUD|FLS|Tab|Classes
- [ ] Field sets are updated to account for new fields
- [ ] UX approval or UX not necessary
- [x] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: W-0000000: Work Name (https://github.com/SalesforceFoundation/PMM/pull/303)
- [ ] All **acceptance criteria** have been met
    - [x] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [x] PR contains draft release notes
- [ ] QE story level testing completed