### PR TITLE
Filter Service Participants that show up on Track Attendance by status, role and stage

### DIFF
--- a/force-app/main/default/classes/AttendanceController.cls
+++ b/force-app/main/default/classes/AttendanceController.cls
@@ -12,9 +12,26 @@ public with sharing class AttendanceController {
     private static ServiceDeliveryService service = new ServiceDeliveryService();
 
     @AuraEnabled(cacheable=true)
-    public static ServiceDeliveryService.Roster generateRoster(Id sessionId) {
+    public static ServiceDeliveryService.Roster generateRoster(
+        Id sessionId,
+        String omittedServiceParticipantStatuses,
+        String omittedProgramEngagementRoles,
+        String omittedProgramEngagementStages
+    ) {
+        System.debug(' ***** [AC] ' + omittedServiceParticipantStatuses);
+        System.debug(' ***** [AC] ' + omittedProgramEngagementRoles);
+        System.debug(' ***** [AC] ' + omittedProgramEngagementStages);
+
         try {
-            return service.generateRoster(sessionId);
+            ServiceDeliveryService.Filters filters = null;
+
+            filters = new ServiceDeliveryService.Filters(
+                omittedServiceParticipantStatuses,
+                omittedProgramEngagementRoles,
+                omittedProgramEngagementStages
+            );
+
+            return service.generateRoster(sessionId, filters);
         } catch (Exception ex) {
             throw Util.getAuraHandledException(ex);
         }

--- a/force-app/main/default/classes/AttendanceController.cls
+++ b/force-app/main/default/classes/AttendanceController.cls
@@ -18,10 +18,6 @@ public with sharing class AttendanceController {
         String omittedProgramEngagementRoles,
         String omittedProgramEngagementStages
     ) {
-        System.debug(' ***** [AC] ' + omittedServiceParticipantStatuses);
-        System.debug(' ***** [AC] ' + omittedProgramEngagementRoles);
-        System.debug(' ***** [AC] ' + omittedProgramEngagementStages);
-
         try {
             ServiceDeliveryService.Filters filters = null;
 

--- a/force-app/main/default/classes/AttendanceController_TEST.cls
+++ b/force-app/main/default/classes/AttendanceController_TEST.cls
@@ -19,32 +19,43 @@ public with sharing class AttendanceController_TEST {
             null,
             serviceDeliveriesToReturn
         );
-        serviceStub.withReturnValue(generateRoster, Id.class, rosterToReturn);
+        serviceStub.withReturnValue(
+            generateRoster,
+            new List<Type>{ Id.class, ServiceDeliveryService.Filters.class },
+            rosterToReturn
+        );
         Id sessionId = TestUtil.mockId(ServiceSession__c.SObjectType);
         AttendanceController.service = (ServiceDeliveryService) serviceStub.createMock();
 
         Test.startTest();
         System.assert(
             serviceDeliveriesToReturn ===
-            AttendanceController.generateRoster(sessionId).deliveries,
+            AttendanceController.generateRoster(sessionId, '', '', '').deliveries,
             'Expected the controller to return the list returned by the service.'
         );
         Test.stopTest();
 
-        serviceStub.assertCalledWith(generateRoster, Id.class, sessionId);
+        serviceStub.assertCalledWith(
+            generateRoster,
+            new List<Type>{ Id.class, ServiceDeliveryService.Filters.class },
+            new List<Object>{ sessionId, new ServiceDeliveryService.Filters('', '', '') }
+        );
     }
 
     @IsTest
     private static void shouldRethrowExceptionFromService() {
         String generateRoster = 'generateRoster';
         Id sessionId = TestUtil.mockId(ServiceSession__c.SObjectType);
-        serviceStub.withThrowException(generateRoster, Id.class);
+        serviceStub.withThrowException(
+            generateRoster,
+            new List<Type>{ Id.class, ServiceDeliveryService.Filters.class }
+        );
         AttendanceController.service = (ServiceDeliveryService) serviceStub.createMock();
         Exception actualException;
 
         Test.startTest();
         try {
-            AttendanceController.generateRoster(sessionId);
+            AttendanceController.generateRoster(sessionId, '', '', '');
         } catch (Exception ex) {
             actualException = ex;
         }
@@ -56,7 +67,11 @@ public with sharing class AttendanceController_TEST {
             'Expected the controller to rethrow the exception from the service.'
         );
 
-        serviceStub.assertCalledWith(generateRoster, Id.class, sessionId);
+        serviceStub.assertCalledWith(
+            generateRoster,
+            new List<Type>{ Id.class, ServiceDeliveryService.Filters.class },
+            new List<Object>{ sessionId, new ServiceDeliveryService.Filters('', '', '') }
+        );
     }
 
     @IsTest

--- a/force-app/main/default/classes/ServiceDeliverySelector.cls
+++ b/force-app/main/default/classes/ServiceDeliverySelector.cls
@@ -67,9 +67,12 @@ public with sharing class ServiceDeliverySelector {
                 Id,
                 Contact__c,
                 Contact__r.Name,
-                Service__c,
                 ProgramEngagement__c,
-                Service__r.UnitOfMeasurement__c
+                ProgramEngagement__r.Stage__c,
+                ProgramEngagement__r.Role__c,
+                Service__c,
+                Service__r.UnitOfMeasurement__c,
+                Status__c
             FROM ServiceParticipant__c
             WHERE
                 ServiceSchedule__c = :scheduleId

--- a/force-app/main/default/classes/ServiceDeliveryService.cls
+++ b/force-app/main/default/classes/ServiceDeliveryService.cls
@@ -314,15 +314,15 @@ public with sharing class ServiceDeliveryService {
 
         public Boolean shouldInclude(ServiceParticipant__c participant) {
             if (
-                filterIncludes(
+                valueIsFiltered(
                     excludedServiceParticipantStatuses,
                     participant.Status__c
                 ) ||
-                filterIncludes(
+                valueIsFiltered(
                     excludedProgramEngagementRoles,
                     participant.ProgramEngagement__r.Role__c
                 ) ||
-                filterIncludes(
+                valueIsFiltered(
                     excludedProgramEngagementStages,
                     participant.ProgramEngagement__r.Stage__c
                 )
@@ -332,7 +332,7 @@ public with sharing class ServiceDeliveryService {
             return true;
         }
 
-        private Boolean filterIncludes(Set<String> filter, String value) {
+        private Boolean valueIsFiltered(Set<String> filter, String value) {
             if (filter != null && filter.size() > 0 && value != null) {
                 return filter.contains(value.toLowerCase());
             }

--- a/force-app/main/default/classes/ServiceDeliveryService.cls
+++ b/force-app/main/default/classes/ServiceDeliveryService.cls
@@ -314,19 +314,29 @@ public with sharing class ServiceDeliveryService {
 
         public Boolean shouldInclude(ServiceParticipant__c participant) {
             if (
-                excludedServiceParticipantStatuses.contains(
-                    participant.Status__c.toLowerCase()
+                filterIncludes(
+                    excludedServiceParticipantStatuses,
+                    participant.Status__c
                 ) ||
-                excludedProgramEngagementRoles.contains(
-                    participant.ProgramEngagement__r.Role__c.toLowerCase()
+                filterIncludes(
+                    excludedProgramEngagementRoles,
+                    participant.ProgramEngagement__r.Role__c
                 ) ||
-                excludedProgramEngagementStages.contains(
-                    participant.ProgramEngagement__r.Stage__c.toLowerCase()
+                filterIncludes(
+                    excludedProgramEngagementStages,
+                    participant.ProgramEngagement__r.Stage__c
                 )
             ) {
                 return false;
             }
             return true;
+        }
+
+        private Boolean filterIncludes(Set<String> filter, String value) {
+            if (filter != null && filter.size() > 0 && value != null) {
+                return filter.contains(value.toLowerCase());
+            }
+            return false;
         }
 
         private void setFilters(

--- a/force-app/main/default/classes/ServiceDeliveryService.cls
+++ b/force-app/main/default/classes/ServiceDeliveryService.cls
@@ -207,7 +207,7 @@ public with sharing class ServiceDeliveryService {
         );
 
         for (ServiceParticipant__c participant : participants) {
-            if (filters != null && filters.shouldInclude(participant)) {
+            if (filters == null || filters.shouldInclude(participant)) {
                 deliveries.add(createServiceDelivery(session, participant));
             }
         }

--- a/force-app/main/default/classes/ServiceDeliveryService.cls
+++ b/force-app/main/default/classes/ServiceDeliveryService.cls
@@ -294,15 +294,15 @@ public with sharing class ServiceDeliveryService {
             List<String> peStages = omitProgramEngagementStages.split(',');
 
             for (Integer i = 0; i < spStatuses.size(); i++) {
-                spStatuses[i] = spStatuses[i].trim();
+                spStatuses[i] = spStatuses[i].trim().toLowerCase();
             }
 
             for (Integer i = 0; i < peRoles.size(); i++) {
-                peRoles[i] = peRoles[i].trim();
+                peRoles[i] = peRoles[i].trim().toLowerCase();
             }
 
             for (Integer i = 0; i < peStages.size(); i++) {
-                peStages[i] = peStages[i].trim();
+                peStages[i] = peStages[i].trim().toLowerCase();
             }
 
             setFilters(
@@ -312,26 +312,16 @@ public with sharing class ServiceDeliveryService {
             );
         }
 
-        public Filters(
-            Set<String> excludedServiceParticipantStatuses,
-            Set<String> excludedProgramEngagementRoles,
-            Set<String> excludedProgramEngagementStages
-        ) {
-            setFilters(
-                excludedServiceParticipantStatuses,
-                excludedProgramEngagementRoles,
-                excludedProgramEngagementStages
-            );
-        }
-
         public Boolean shouldInclude(ServiceParticipant__c participant) {
             if (
-                excludedServiceParticipantStatuses.contains(participant.Status__c) ||
+                excludedServiceParticipantStatuses.contains(
+                    participant.Status__c.toLowerCase()
+                ) ||
                 excludedProgramEngagementRoles.contains(
-                    participant.ProgramEngagement__r.Role__c
+                    participant.ProgramEngagement__r.Role__c.toLowerCase()
                 ) ||
                 excludedProgramEngagementStages.contains(
-                    participant.ProgramEngagement__r.Stage__c
+                    participant.ProgramEngagement__r.Stage__c.toLowerCase()
                 )
             ) {
                 return false;

--- a/force-app/main/default/classes/ServiceDeliveryService.cls
+++ b/force-app/main/default/classes/ServiceDeliveryService.cls
@@ -193,44 +193,24 @@ public with sharing class ServiceDeliveryService {
     ) {
         Set<Id> existingClients = new Set<Id>();
 
-        // Get initial list of pre-existing service deliveries on the service session
         List<ServiceDelivery__c> deliveries = new List<ServiceDelivery__c>(
             deliverySelector.getServiceDeliveriesBySessionId(fieldSet, session.Id)
         );
 
-        System.debug(
-            ' **** ServiceDeliveryService.createServiceDeliveres() # of deliveries: ' +
-            deliveries.size()
-        );
-
-        // get initial list of pre-existing clients from the deliveries
         for (ServiceDelivery__c delivery : deliveries) {
             existingClients.add(delivery.Contact__c);
         }
 
-        // gets service participants for the service schedule NOT related to existing clients
         List<ServiceParticipant__c> participants = deliverySelector.getServiceParticipantsByScheduleId(
             session.ServiceSchedule__c,
             existingClients
         );
 
-        System.debug(
-            ' **** ServiceDeliveryService.createServiceDeliveres() # of participants: ' +
-            participants.size()
-        );
-
-        // for each participant NOT previuosly related to a service delivery, create a service delivery
-        // and add it to the list
         for (ServiceParticipant__c participant : participants) {
             if (filters != null && filters.shouldInclude(participant)) {
                 deliveries.add(createServiceDelivery(session, participant));
             }
         }
-
-        System.debug(
-            ' **** ServiceDeliveryService.createServiceDeliveres() FINAL # of deliveries: ' +
-            deliveries.size()
-        );
 
         return deliveries;
     }
@@ -309,14 +289,27 @@ public with sharing class ServiceDeliveryService {
             String omitProgramEngagementRoles,
             String omitProgramEngagementStages
         ) {
-            this(
-                new Set<String>(omitServiceParticipantStatuses.split(',')),
-                new Set<String>(omitProgramEngagementRoles.split(',')),
-                new Set<String>(omitProgramEngagementStages.split(','))
+            List<String> spStatuses = omitServiceParticipantStatuses.split(',');
+            List<String> peRoles = omitProgramEngagementRoles.split(',');
+            List<String> peStages = omitProgramEngagementStages.split(',');
+
+            for (Integer i = 0; i < spStatuses.size(); i++) {
+                spStatuses[i] = spStatuses[i].trim();
+            }
+
+            for (Integer i = 0; i < peRoles.size(); i++) {
+                peRoles[i] = peRoles[i].trim();
+            }
+
+            for (Integer i = 0; i < peStages.size(); i++) {
+                peStages[i] = peStages[i].trim();
+            }
+
+            setFilters(
+                new Set<String>(spStatuses),
+                new Set<String>(peRoles),
+                new Set<String>(peStages)
             );
-            System.debug(' **** [SDS] ' + omitServiceParticipantStatuses);
-            System.debug(' **** [SDS] ' + omitProgramEngagementRoles);
-            System.debug(' **** [SDS] ' + omitProgramEngagementStages);
         }
 
         public Filters(
@@ -324,21 +317,14 @@ public with sharing class ServiceDeliveryService {
             Set<String> excludedProgramEngagementRoles,
             Set<String> excludedProgramEngagementStages
         ) {
-            this.excludedServiceParticipantStatuses = excludedServiceParticipantStatuses;
-            this.excludedProgramEngagementRoles = excludedProgramEngagementRoles;
-            this.excludedProgramEngagementStages = excludedProgramEngagementStages;
+            setFilters(
+                excludedServiceParticipantStatuses,
+                excludedProgramEngagementRoles,
+                excludedProgramEngagementStages
+            );
         }
 
         public Boolean shouldInclude(ServiceParticipant__c participant) {
-            System.debug(
-                '**** participant status:' +
-                participant.Status__c +
-                ' PE Role:' +
-                participant.ProgramEngagement__r.Role__c +
-                ' PE Stage: ' +
-                participant.ProgramEngagement__r.Stage__c
-            );
-
             if (
                 excludedServiceParticipantStatuses.contains(participant.Status__c) ||
                 excludedProgramEngagementRoles.contains(
@@ -351,6 +337,16 @@ public with sharing class ServiceDeliveryService {
                 return false;
             }
             return true;
+        }
+
+        private void setFilters(
+            Set<String> excludedServiceParticipantStatuses,
+            Set<String> excludedProgramEngagementRoles,
+            Set<String> excludedProgramEngagementStages
+        ) {
+            this.excludedServiceParticipantStatuses = excludedServiceParticipantStatuses;
+            this.excludedProgramEngagementRoles = excludedProgramEngagementRoles;
+            this.excludedProgramEngagementStages = excludedProgramEngagementStages;
         }
     }
 

--- a/force-app/main/default/classes/ServiceDeliveryService.cls
+++ b/force-app/main/default/classes/ServiceDeliveryService.cls
@@ -68,10 +68,15 @@ public with sharing class ServiceDeliveryService {
         set;
     }
 
-    public Roster generateRoster(Id sessionId) {
+    public Roster generateRoster(Id sessionId, ServiceDeliveryService.Filters filters) {
         ServiceSession__c session = deliverySelector.getSession(sessionId);
         FieldSet fieldSet = getFieldSet(session.ServiceSchedule__c);
-        List<ServiceDelivery__c> deliveries = createServiceDeliveries(fieldSet, session);
+
+        List<ServiceDelivery__c> deliveries = createServiceDeliveries(
+            fieldSet,
+            session,
+            filters
+        );
 
         return new Roster(
             fieldSetService.getFieldSetForLWC(
@@ -183,25 +188,49 @@ public with sharing class ServiceDeliveryService {
 
     private List<ServiceDelivery__c> createServiceDeliveries(
         FieldSet fieldSet,
-        ServiceSession__c session
+        ServiceSession__c session,
+        ServiceDeliveryService.Filters filters
     ) {
         Set<Id> existingClients = new Set<Id>();
+
+        // Get initial list of pre-existing service deliveries on the service session
         List<ServiceDelivery__c> deliveries = new List<ServiceDelivery__c>(
             deliverySelector.getServiceDeliveriesBySessionId(fieldSet, session.Id)
         );
 
+        System.debug(
+            ' **** ServiceDeliveryService.createServiceDeliveres() # of deliveries: ' +
+            deliveries.size()
+        );
+
+        // get initial list of pre-existing clients from the deliveries
         for (ServiceDelivery__c delivery : deliveries) {
             existingClients.add(delivery.Contact__c);
         }
 
-        for (
-            ServiceParticipant__c participant : deliverySelector.getServiceParticipantsByScheduleId(
-                session.ServiceSchedule__c,
-                existingClients
-            )
-        ) {
-            deliveries.add(createServiceDelivery(session, participant));
+        // gets service participants for the service schedule NOT related to existing clients
+        List<ServiceParticipant__c> participants = deliverySelector.getServiceParticipantsByScheduleId(
+            session.ServiceSchedule__c,
+            existingClients
+        );
+
+        System.debug(
+            ' **** ServiceDeliveryService.createServiceDeliveres() # of participants: ' +
+            participants.size()
+        );
+
+        // for each participant NOT previuosly related to a service delivery, create a service delivery
+        // and add it to the list
+        for (ServiceParticipant__c participant : participants) {
+            if (filters != null && filters.shouldInclude(participant)) {
+                deliveries.add(createServiceDelivery(session, participant));
+            }
         }
+
+        System.debug(
+            ' **** ServiceDeliveryService.createServiceDeliveres() FINAL # of deliveries: ' +
+            deliveries.size()
+        );
 
         return deliveries;
     }
@@ -267,6 +296,61 @@ public with sharing class ServiceDeliveryService {
         ) {
             this.fieldSet = fieldSet;
             this.deliveries = deliveries;
+        }
+    }
+
+    public class Filters {
+        private Set<String> excludedServiceParticipantStatuses;
+        private Set<String> excludedProgramEngagementRoles;
+        private Set<String> excludedProgramEngagementStages;
+
+        public Filters(
+            String omitServiceParticipantStatuses,
+            String omitProgramEngagementRoles,
+            String omitProgramEngagementStages
+        ) {
+            this(
+                new Set<String>(omitServiceParticipantStatuses.split(',')),
+                new Set<String>(omitProgramEngagementRoles.split(',')),
+                new Set<String>(omitProgramEngagementStages.split(','))
+            );
+            System.debug(' **** [SDS] ' + omitServiceParticipantStatuses);
+            System.debug(' **** [SDS] ' + omitProgramEngagementRoles);
+            System.debug(' **** [SDS] ' + omitProgramEngagementStages);
+        }
+
+        public Filters(
+            Set<String> excludedServiceParticipantStatuses,
+            Set<String> excludedProgramEngagementRoles,
+            Set<String> excludedProgramEngagementStages
+        ) {
+            this.excludedServiceParticipantStatuses = excludedServiceParticipantStatuses;
+            this.excludedProgramEngagementRoles = excludedProgramEngagementRoles;
+            this.excludedProgramEngagementStages = excludedProgramEngagementStages;
+        }
+
+        public Boolean shouldInclude(ServiceParticipant__c participant) {
+            System.debug(
+                '**** participant status:' +
+                participant.Status__c +
+                ' PE Role:' +
+                participant.ProgramEngagement__r.Role__c +
+                ' PE Stage: ' +
+                participant.ProgramEngagement__r.Stage__c
+            );
+
+            if (
+                excludedServiceParticipantStatuses.contains(participant.Status__c) ||
+                excludedProgramEngagementRoles.contains(
+                    participant.ProgramEngagement__r.Role__c
+                ) ||
+                excludedProgramEngagementStages.contains(
+                    participant.ProgramEngagement__r.Stage__c
+                )
+            ) {
+                return false;
+            }
+            return true;
         }
     }
 

--- a/force-app/main/default/classes/ServiceDeliveryService_TEST.cls
+++ b/force-app/main/default/classes/ServiceDeliveryService_TEST.cls
@@ -81,7 +81,7 @@ public with sharing class ServiceDeliveryService_TEST {
         service.deliverySelector = (ServiceDeliverySelector) deliverySelectorStub.create();
 
         Test.startTest();
-        service.generateRoster(sessionId);
+        service.generateRoster(sessionId, null);
         Test.stopTest();
 
         deliverySelectorStub.assertCalledAsExpected();
@@ -118,7 +118,8 @@ public with sharing class ServiceDeliveryService_TEST {
         Test.startTest();
         System.assertEquals(
             deliveriesToReturn,
-            service.generateRoster(deliveriesToReturn[0].ServiceSession__c).deliveries,
+            service.generateRoster(deliveriesToReturn[0].ServiceSession__c, null)
+                .deliveries,
             'Expected only the service deliveries returned by the selector.'
         );
         Test.stopTest();
@@ -160,7 +161,7 @@ public with sharing class ServiceDeliveryService_TEST {
         service.deliverySelector = (ServiceDeliverySelector) deliverySelectorStub.create();
 
         Test.startTest();
-        actualDeliveries = service.generateRoster(sessionId).deliveries;
+        actualDeliveries = service.generateRoster(sessionId, null).deliveries;
         Test.stopTest();
 
         System.assertEquals(
@@ -228,7 +229,7 @@ public with sharing class ServiceDeliveryService_TEST {
         service.deliverySelector = (ServiceDeliverySelector) deliverySelectorStub.create();
 
         Test.startTest();
-        actualDeliveries = service.generateRoster(sessionId).deliveries;
+        actualDeliveries = service.generateRoster(sessionId, null).deliveries;
         Test.stopTest();
 
         System.assertEquals(
@@ -344,7 +345,7 @@ public with sharing class ServiceDeliveryService_TEST {
         ];
 
         Test.startTest();
-        actualDeliveries = service.generateRoster(session.Id).deliveries;
+        actualDeliveries = service.generateRoster(session.Id, null).deliveries;
         Test.stopTest();
 
         Integer countParticipants = [

--- a/force-app/main/default/classes/ServiceDeliveryService_TEST.cls
+++ b/force-app/main/default/classes/ServiceDeliveryService_TEST.cls
@@ -20,6 +20,45 @@ public with sharing class ServiceDeliveryService_TEST {
     private static ServiceDeliveryService service = new ServiceDeliveryService();
 
     @IsTest
+    private static void shouldFilterParticipants() {
+        ServiceParticipant__c enrolledParticipant = createMockParticipant();
+
+        ServiceDeliveryService.Filters filterOutEnrolled = new ServiceDeliveryService.Filters(
+            'Enrolled',
+            '',
+            ''
+        );
+
+        ServiceDeliveryService.Filters filterOutWaitlisted = new ServiceDeliveryService.Filters(
+            'Waitlisted',
+            '',
+            ''
+        );
+
+        ServiceDeliveryService.Filters filterOutBoth = new ServiceDeliveryService.Filters(
+            'waitlisted, ENROLLED',
+            '',
+            ''
+        );
+
+        System.AssertEquals(
+            false,
+            filterOutEnrolled.shouldInclude(enrolledParticipant),
+            'Enrolled participant should NOT be included by filter excluding enrolled'
+        );
+        System.AssertEquals(
+            true,
+            filterOutWaitlisted.shouldInclude(enrolledParticipant),
+            'Enrolled participant SHOULD be included by filter excluding only waitlisted'
+        );
+        System.AssertEquals(
+            false,
+            filterOutBoth.shouldInclude(enrolledParticipant),
+            'Enrolled participant should NOT be included by filter excluding both enrolled and waitlisted'
+        );
+    }
+
+    @IsTest
     private static void shouldGetBuckets() {
         List<String> bucketNames = new List<String>{ 'Absent', 'Present' };
 
@@ -399,7 +438,8 @@ public with sharing class ServiceDeliveryService_TEST {
         return new ServiceParticipant__c(
             Id = TestUtil.mockId(ServiceParticipant__c.SObjectType),
             Contact__c = TestUtil.mockId(Contact.SObjectType),
-            ProgramEngagement__c = TestUtil.mockId(ProgramEngagement__c.SObjectType)
+            ProgramEngagement__c = TestUtil.mockId(ProgramEngagement__c.SObjectType),
+            Status__c = 'Enrolled'
         );
     }
 

--- a/force-app/main/default/lwc/attendance/attendance.js
+++ b/force-app/main/default/lwc/attendance/attendance.js
@@ -57,6 +57,10 @@ const ITEM_PAGE_NAVIGATION_TYPE = "standard__navItemPage";
 const ATTENDANCE_TAB = "Attendance";
 export default class Attendance extends NavigationMixin(LightningElement) {
     @api recordId;
+    @api omitServiceParticipantStatuses;
+    @api omitProgramEngagementRoles;
+    @api omitProgramEngagementStages;
+
     @track serviceDeliveries;
     @track fieldSet;
 
@@ -146,7 +150,12 @@ export default class Attendance extends NavigationMixin(LightningElement) {
         }
     }
 
-    @wire(generateRoster, { sessionId: "$recordId" })
+    @wire(generateRoster, {
+        sessionId: "$recordId",
+        omittedServiceParticipantStatuses: "$omittedServiceParticipantStatuses",
+        omittedProgramEngagementRoles: "$omittedProgramEngagementRoles",
+        omittedProgramEngagementStages: "$omittedProgramEngagementStages",
+    })
     wiredServiceDeliveries(result) {
         this.wiredServiceDeliveriesResult = result;
         if (!(result.data || result.error)) {
@@ -170,6 +179,20 @@ export default class Attendance extends NavigationMixin(LightningElement) {
 
     connectedCallback() {
         loadStyle(this, pmmFolder + "/attendancePrintOverride.css");
+    }
+
+    get omittedServiceParticipantStatuses() {
+        return this.omitServiceParticipantStatuses
+            ? this.omitServiceParticipantStatuses
+            : "";
+    }
+
+    get omittedProgramEngagementRoles() {
+        return this.omitProgramEngagementRoles ? this.omitProgramEngagementRoles : "";
+    }
+
+    get omittedProgramEngagementStages() {
+        return this.omitProgramEngagementStages ? this.omitProgramEngagementStages : "";
     }
 
     get hasServiceDeliveries() {

--- a/force-app/main/default/lwc/attendance/attendance.js-meta.xml
+++ b/force-app/main/default/lwc/attendance/attendance.js-meta.xml
@@ -61,7 +61,7 @@
                       type="String" />
             <property name="omitProgramEngagementStages"
                       label="Excluded Program Engagement Stages"
-                      description="A comma-delimeted list of API stage values to omit"
+                      description="A comma-separated list of the API values used to exclude participants from Attendance Tracker."
                       default=""
                       type="String" />   
         </targetConfig>

--- a/force-app/main/default/lwc/attendance/attendance.js-meta.xml
+++ b/force-app/main/default/lwc/attendance/attendance.js-meta.xml
@@ -28,6 +28,23 @@
                       label="Excluded Program Engagement Stages"
                       description="A comma-separated list of the API values used to exclude participants from Attendance Tracker."
                       default=""
+                      type="String" />   
+        </targetConfig>
+        <targetConfig targets="lightning__AppPage">
+            <property name="omitServiceParticipantStatuses" 
+                      label="Excluded Service Participant Statuses"
+                      description="A comma-separated list of the API values used to exclude participants from Attendance Tracker." 
+                      default=""
+                      type="String" />
+            <property name="omitProgramEngagementRoles"
+                      label="Excluded Program Engagement Roles"
+                      description="A comma-separated list of the API values used to exclude participants from Attendance Tracker." 
+                      default=""
+                      type="String" />
+            <property name="omitProgramEngagementStages"
+                      label="Excluded Program Engagement Stages"
+                      description="A comma-separated list of the API values used to exclude participants from Attendance Tracker."
+                      default=""
                       type="String" />          
         </targetConfig>
         <targetConfig targets="lightningCommunity__Default">
@@ -44,7 +61,7 @@
                       type="String" />
             <property name="omitProgramEngagementStages"
                       label="Excluded Program Engagement Stages"
-                      description="A comma-separated list of the API values used to exclude participants from Attendance Tracker."
+                      description="A comma-delimeted list of API stage values to omit"
                       default=""
                       type="String" />   
         </targetConfig>

--- a/force-app/main/default/lwc/attendance/attendance.js-meta.xml
+++ b/force-app/main/default/lwc/attendance/attendance.js-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>53.0</apiVersion>
     <isExposed>true</isExposed>
     <masterLabel>Attendance</masterLabel>
     <targets>
@@ -16,17 +16,17 @@
             </objects>
             <property name="omitServiceParticipantStatuses" 
                       label="Excluded Service Participant Statuses"
-                      description="A comma-delimeted list of API status values to omit" 
+                      description="A comma-separated list of the API values used to exclude participants from Attendance Tracker." 
                       default=""
                       type="String" />
             <property name="omitProgramEngagementRoles"
                       label="Excluded Program Engagement Roles"
-                      description="A comma-delimeted list of API role values to omit" 
+                      description="A comma-separated list of the API values used to exclude participants from Attendance Tracker." 
                       default=""
                       type="String" />
             <property name="omitProgramEngagementStages"
                       label="Excluded Program Engagement Stages"
-                      description="A comma-delimeted list of API stage values to omit"
+                      description="A comma-separated list of the API values used to exclude participants from Attendance Tracker."
                       default=""
                       type="String" />          
         </targetConfig>
@@ -34,17 +34,17 @@
             <property name="recordId" type="String" label="Record ID" default="{!recordId}"/>
             <property name="omitServiceParticipantStatuses" 
                       label="Excluded Service Participant Statuses"
-                      description="A comma-delimeted list of API status values to omit" 
+                      description="A comma-separated list of the API values used to exclude participants from Attendance Tracker." 
                       default=""
                       type="String" />
             <property name="omitProgramEngagementRoles"
                       label="Excluded Program Engagement Roles"
-                      description="A comma-delimeted list of API role values to omit" 
+                      description="A comma-separated list of the API values used to exclude participants from Attendance Tracker." 
                       default=""
                       type="String" />
             <property name="omitProgramEngagementStages"
                       label="Excluded Program Engagement Stages"
-                      description="A comma-delimeted list of API stage values to omit"
+                      description="A comma-separated list of the API values used to exclude participants from Attendance Tracker."
                       default=""
                       type="String" />   
         </targetConfig>

--- a/force-app/main/default/lwc/attendance/attendance.js-meta.xml
+++ b/force-app/main/default/lwc/attendance/attendance.js-meta.xml
@@ -14,9 +14,40 @@
             <objects>
                 <object>ServiceSession__c</object>
             </objects>
+            <property name="omitServiceParticipantStatuses" 
+                      label="Excluded Service Participant Statuses"
+                      description="A comma-delimeted list of API status values to omit" 
+                      default=""
+                      type="String" />
+            <property name="omitProgramEngagementRoles"
+                      label="Excluded Program Engagement Roles"
+                      description="A comma-delimeted list of API role values to omit" 
+                      default=""
+                      type="String" />
+            <property name="omitProgramEngagementStages"
+                      label="Excluded Program Engagement Stages"
+                      description="A comma-delimeted list of API stage values to omit"
+                      default=""
+                      type="String" />          
         </targetConfig>
         <targetConfig targets="lightningCommunity__Default">
             <property name="recordId" type="String" label="Record ID" default="{!recordId}"/>
+            <property name="omitServiceParticipantStatuses" 
+                      label="Excluded Service Participant Statuses"
+                      description="A comma-delimeted list of API status values to omit" 
+                      default=""
+                      type="String" />
+            <property name="omitProgramEngagementRoles"
+                      label="Excluded Program Engagement Roles"
+                      description="A comma-delimeted list of API role values to omit" 
+                      default=""
+                      type="String" />
+            <property name="omitProgramEngagementStages"
+                      label="Excluded Program Engagement Stages"
+                      description="A comma-delimeted list of API stage values to omit"
+                      default=""
+                      type="String" />   
         </targetConfig>
     </targetConfigs>
+
 </LightningComponentBundle>


### PR DESCRIPTION
This work adds design properties to the attendance tracker component (visible on the service session page) to allow admins to filter untracked participants by the Status of Service Participant and Role or Stage of the Program Engagement related to the record. If no filters are specified (what customers will experience at the time this feature is released) than no filtering is applied, meaning that the customer experience should be unchanged until they chose to apply filters. 

# Critical Changes

# Changes

# Issues Closed
- [W-9655326](https://gus.lightning.force.com/a07AH000000SBNjYAO)

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
- ~[] Any net new LWC work has Sa11y tests & 50% or above lines JEST test coverage~
- [X] CRUD/FLS is enforced in Apex
- ~[ ] Permission sets are updated to account for CRUD|FLS|Tab|Classes~
- ~[ ] Field sets are updated to account for new fields~
- [X] UX approval or UX not necessary
- [X] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: W-0000000: Work Name (https://github.com/SalesforceFoundation/PMM/pull/303)
- [ ] All **acceptance criteria** have been met
    - [X] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [ ] PR contains draft release notes
- [ ] QE story level testing completed