### PR TITLE
Add buckets for service sessions

### DIFF
--- a/force-app/main/default/classes/AttendanceController.cls
+++ b/force-app/main/default/classes/AttendanceController.cls
@@ -39,4 +39,21 @@ public with sharing class AttendanceController {
             throw Util.getAuraHandledException(ex);
         }
     }
+
+    @AuraEnabled(cacheable=true)
+    public static Map<String, List<String>> getServiceSessionStatusBuckets(
+        List<String> bucketNames,
+        String objectType,
+        String bucketedField
+    ) {
+        try {
+            Schema.SObjectType objType = Schema.getGlobalDescribe().get(objectType);
+            Schema.SObjectField objField = objType.getDescribe()
+                .fields.getMap()
+                .get(bucketedField);
+            return service.getStatusBuckets(bucketNames, objType, objField);
+        } catch (Exception ex) {
+            throw Util.getAuraHandledException(ex);
+        }
+    }
 }

--- a/force-app/main/default/classes/AttendanceController.cls
+++ b/force-app/main/default/classes/AttendanceController.cls
@@ -11,6 +11,9 @@ public with sharing class AttendanceController {
     @TestVisible
     private static ServiceDeliveryService service = new ServiceDeliveryService();
 
+    @TestVisible
+    private static ServiceSessionService sessionService = new ServiceSessionService();
+
     @AuraEnabled(cacheable=true)
     public static ServiceDeliveryService.Roster generateRoster(Id sessionId) {
         try {
@@ -41,17 +44,9 @@ public with sharing class AttendanceController {
     }
 
     @AuraEnabled(cacheable=true)
-    public static Map<String, List<String>> getServiceSessionStatusBuckets(
-        List<String> bucketNames,
-        String objectType,
-        String bucketedField
-    ) {
+    public static Map<String, List<String>> getServiceSessionStatusBuckets() {
         try {
-            Schema.SObjectType objType = Schema.getGlobalDescribe().get(objectType);
-            Schema.SObjectField objField = objType.getDescribe()
-                .fields.getMap()
-                .get(bucketedField);
-            return service.getStatusBuckets(bucketNames, objType, objField);
+            return sessionService.getServiceSessionStatusBuckets();
         } catch (Exception ex) {
             throw Util.getAuraHandledException(ex);
         }

--- a/force-app/main/default/classes/AttendanceController_TEST.cls
+++ b/force-app/main/default/classes/AttendanceController_TEST.cls
@@ -179,8 +179,8 @@ public with sharing class AttendanceController_TEST {
         Test.startTest();
         Map<String, List<String>> actualValues = AttendanceController.getServiceSessionStatusBuckets(
             bucketNames,
-            'ServiceSession__c',
-            'Status__c'
+            Util.prefixNamespace('ServiceSession__c'),
+            Util.prefixNamespace('Status__c')
         );
 
         Test.stopTest();

--- a/force-app/main/default/classes/AttendanceController_TEST.cls
+++ b/force-app/main/default/classes/AttendanceController_TEST.cls
@@ -151,4 +151,79 @@ public with sharing class AttendanceController_TEST {
 
         serviceStub.assertCalled(methodName);
     }
+
+    @IsTest
+    private static void testGetServiceSessionStatusBuckets() {
+        List<String> bucketNames = new List<String>{ 'Complete', 'Pending' };
+        String methodName = 'getStatusBuckets';
+        Schema.SObjectType objectType = ServiceSession__c.SObjectType;
+        Schema.SObjectField bucketedField = ServiceSession__c.Status__c;
+
+        Map<String, List<String>> expectedValues = new Map<String, List<String>>();
+        expectedValues.put('Complete', new List<String>{ 'Complete' });
+        expectedValues.put('Pending', new List<String>{ 'Pending' });
+
+        TestStub serviceDeliveryStub = new StubBuilder(ServiceDeliveryService.class)
+            .when(
+                methodName,
+                List<String>.class,
+                Schema.sObjectType.class,
+                Schema.SObjectField.class
+            )
+            .calledWith(bucketNames, objectType, bucketedField)
+            .thenReturn(expectedValues)
+            .build();
+
+        AttendanceController.service = (ServiceDeliveryService) serviceDeliveryStub.create();
+
+        Test.startTest();
+        Map<String, List<String>> actualValues = AttendanceController.getServiceSessionStatusBuckets(
+            bucketNames,
+            'ServiceSession__c',
+            'Status__c'
+        );
+
+        Test.stopTest();
+
+        System.assertEquals(
+            expectedValues,
+            actualValues,
+            'Expected the controller to return list delivered by service.'
+        );
+
+        serviceDeliveryStub.assertCalledAsExpected();
+    }
+
+    @IsTest
+    private static void testGetServiceSessionStatusBucketsWithException() {
+        String methodName = 'getStatusBuckets';
+        Exception actualException;
+
+        TestStub serviceDeliveryStub = new StubBuilder(ServiceDeliveryService.class)
+            .when(
+                methodName,
+                List<String>.class,
+                Schema.sObjectType.class,
+                Schema.SObjectField.class
+            )
+            .calledWith(null, null, null)
+            .thenThrowException()
+            .build();
+
+        AttendanceController.service = (ServiceDeliveryService) serviceDeliveryStub.create();
+
+        Test.startTest();
+        try {
+            AttendanceController.getServiceSessionStatusBuckets(null, null, null);
+        } catch (Exception ex) {
+            actualException = ex;
+        }
+
+        Test.stopTest();
+
+        System.assert(
+            actualException instanceof AuraHandledException,
+            actualException.getTypeName() + ': Expected an aura handled exception.'
+        );
+    }
 }

--- a/force-app/main/default/classes/AttendanceController_TEST.cls
+++ b/force-app/main/default/classes/AttendanceController_TEST.cls
@@ -155,33 +155,22 @@ public with sharing class AttendanceController_TEST {
     @IsTest
     private static void testGetServiceSessionStatusBuckets() {
         List<String> bucketNames = new List<String>{ 'Complete', 'Pending' };
-        String methodName = 'getStatusBuckets';
-        Schema.SObjectType objectType = ServiceSession__c.SObjectType;
-        Schema.SObjectField bucketedField = ServiceSession__c.Status__c;
+        String methodName = 'getServiceSessionStatusBuckets';
 
         Map<String, List<String>> expectedValues = new Map<String, List<String>>();
         expectedValues.put('Complete', new List<String>{ 'Complete' });
         expectedValues.put('Pending', new List<String>{ 'Pending' });
 
-        TestStub serviceDeliveryStub = new StubBuilder(ServiceDeliveryService.class)
-            .when(
-                methodName,
-                List<String>.class,
-                Schema.sObjectType.class,
-                Schema.SObjectField.class
-            )
-            .calledWith(bucketNames, objectType, bucketedField)
+        TestStub serviceSessionStub = new StubBuilder(ServiceSessionService.class)
+            .when(methodName)
+            .called()
             .thenReturn(expectedValues)
             .build();
 
-        AttendanceController.service = (ServiceDeliveryService) serviceDeliveryStub.create();
+        AttendanceController.sessionService = (ServiceSessionService) serviceSessionStub.create();
 
         Test.startTest();
-        Map<String, List<String>> actualValues = AttendanceController.getServiceSessionStatusBuckets(
-            bucketNames,
-            Util.prefixNamespace('ServiceSession__c'),
-            Util.prefixNamespace('Status__c')
-        );
+        Map<String, List<String>> actualValues = AttendanceController.getServiceSessionStatusBuckets();
 
         Test.stopTest();
 
@@ -191,30 +180,25 @@ public with sharing class AttendanceController_TEST {
             'Expected the controller to return list delivered by service.'
         );
 
-        serviceDeliveryStub.assertCalledAsExpected();
+        serviceSessionStub.assertCalledAsExpected();
     }
 
     @IsTest
     private static void testGetServiceSessionStatusBucketsWithException() {
-        String methodName = 'getStatusBuckets';
+        String methodName = 'getServiceSessionStatusBuckets';
         Exception actualException;
 
-        TestStub serviceDeliveryStub = new StubBuilder(ServiceDeliveryService.class)
-            .when(
-                methodName,
-                List<String>.class,
-                Schema.sObjectType.class,
-                Schema.SObjectField.class
-            )
-            .calledWith(null, null, null)
+        TestStub serviceSessionStub = new StubBuilder(ServiceSessionService.class)
+            .when(methodName)
+            .called()
             .thenThrowException()
             .build();
 
-        AttendanceController.service = (ServiceDeliveryService) serviceDeliveryStub.create();
+        AttendanceController.sessionService = (ServiceSessionService) serviceSessionStub.create();
 
         Test.startTest();
         try {
-            AttendanceController.getServiceSessionStatusBuckets(null, null, null);
+            AttendanceController.getServiceSessionStatusBuckets();
         } catch (Exception ex) {
             actualException = ex;
         }

--- a/force-app/main/default/classes/RecentServiceSessionController.cls
+++ b/force-app/main/default/classes/RecentServiceSessionController.cls
@@ -37,13 +37,9 @@ public with sharing class RecentServiceSessionController {
     }
 
     @AuraEnabled(cacheable=true)
-    public static List<String> getServiceSessionStatusBuckets(
-        String serviceSessionStatus
-    ) {
+    public static Map<String, List<String>> getServiceSessionStatusBuckets() {
         try {
-            return new List<String>(
-                serviceSessionService.getServiceSessionStatusBuckets(serviceSessionStatus)
-            );
+            return serviceSessionService.getServiceSessionStatusBuckets();
         } catch (Exception e) {
             throw Util.getAuraHandledException(e);
         }

--- a/force-app/main/default/classes/RecentServiceSessionController.cls
+++ b/force-app/main/default/classes/RecentServiceSessionController.cls
@@ -35,4 +35,17 @@ public with sharing class RecentServiceSessionController {
     public static Map<String, String> getMenuOptions() {
         return DATE_LITERAL_OPTIONS;
     }
+
+    @AuraEnabled(cacheable=true)
+    public static List<String> getServiceSessionStatusBuckets(
+        String serviceSessionStatus
+    ) {
+        try {
+            return new List<String>(
+                serviceSessionService.getServiceSessionStatusBuckets(serviceSessionStatus)
+            );
+        } catch (Exception e) {
+            throw Util.getAuraHandledException(e);
+        }
+    }
 }

--- a/force-app/main/default/classes/RecentServiceSessionController_TEST.cls
+++ b/force-app/main/default/classes/RecentServiceSessionController_TEST.cls
@@ -118,28 +118,30 @@ public with sharing class RecentServiceSessionController_TEST {
 
     @IsTest
     private static void testGetCompleteServiceSessionStatuses() {
-        String completedStatus = 'Complete';
         String methodName = 'getServiceSessionStatusBuckets';
-        Set<String> completeStatusesToReturn = new Set<String>{ 'Complete' };
+        Map<String, List<String>> expectedStatusesToReturn = new Map<String, List<String>>();
+        expectedStatusesToReturn.put('Complete', new List<String>{ 'Complete' });
+        expectedStatusesToReturn.put('Pending', new List<String>{ 'Pending' });
 
         TestStub serviceSessionServiceStub = new StubBuilder(ServiceSessionService.class)
-            .when(methodName, String.class)
-            .calledWith(completedStatus)
-            .thenReturn(completeStatusesToReturn)
+            .when(methodName)
+            .called()
+            .thenReturn(expectedStatusesToReturn)
             .build();
 
         RecentServiceSessionController.serviceSessionService = (ServiceSessionService) serviceSessionServiceStub.create();
 
         Test.startTest();
-        System.assertEquals(
-            new List<String>(completeStatusesToReturn),
-            (List<String>) RecentServiceSessionController.getServiceSessionStatusBuckets(
-                'Complete'
-            ),
-            'Expected the controller to return list delivered by service.'
-        );
+        Map<String, List<String>> returnedStatuses = new Map<String, List<String>>();
+        returnedStatuses = RecentServiceSessionController.getServiceSessionStatusBuckets();
+
         Test.stopTest();
 
+        System.assertEquals(
+            expectedStatusesToReturn,
+            returnedStatuses,
+            'Expected the controller to return list delivered by service.'
+        );
         serviceSessionServiceStub.assertCalledAsExpected();
     }
 
@@ -149,8 +151,8 @@ public with sharing class RecentServiceSessionController_TEST {
         Exception actualException;
 
         TestStub serviceSessionServiceStub = new StubBuilder(ServiceSessionService.class)
-            .when(methodName, String.class)
-            .calledWith(null)
+            .when(methodName)
+            .called()
             .thenThrowException()
             .build();
 
@@ -158,7 +160,7 @@ public with sharing class RecentServiceSessionController_TEST {
 
         Test.startTest();
         try {
-            RecentServiceSessionController.getServiceSessionStatusBuckets(null);
+            RecentServiceSessionController.getServiceSessionStatusBuckets();
         } catch (Exception ex) {
             actualException = ex;
         }

--- a/force-app/main/default/classes/RecentServiceSessionController_TEST.cls
+++ b/force-app/main/default/classes/RecentServiceSessionController_TEST.cls
@@ -115,4 +115,59 @@ public with sharing class RecentServiceSessionController_TEST {
             'Actual dateliteral options not the same as expected dateLiteral options'
         );
     }
+
+    @IsTest
+    private static void testGetCompleteServiceSessionStatuses() {
+        String completedStatus = 'Complete';
+        String methodName = 'getServiceSessionStatusBuckets';
+        Set<String> completeStatusesToReturn = new Set<String>{ 'Complete' };
+
+        TestStub serviceSessionServiceStub = new StubBuilder(ServiceSessionService.class)
+            .when(methodName, String.class)
+            .calledWith(completedStatus)
+            .thenReturn(completeStatusesToReturn)
+            .build();
+
+        RecentServiceSessionController.serviceSessionService = (ServiceSessionService) serviceSessionServiceStub.create();
+
+        Test.startTest();
+        System.assertEquals(
+            new List<String>(completeStatusesToReturn),
+            (List<String>) RecentServiceSessionController.getServiceSessionStatusBuckets(
+                'Complete'
+            ),
+            'Expected the controller to return list delivered by service.'
+        );
+        Test.stopTest();
+
+        serviceSessionServiceStub.assertCalledAsExpected();
+    }
+
+    @IsTest
+    private static void testGetCompleteServiceSessionStatusesWithException() {
+        String methodName = 'getServiceSessionStatusBuckets';
+        Exception actualException;
+
+        TestStub serviceSessionServiceStub = new StubBuilder(ServiceSessionService.class)
+            .when(methodName, String.class)
+            .calledWith(null)
+            .thenThrowException()
+            .build();
+
+        RecentServiceSessionController.serviceSessionService = (ServiceSessionService) serviceSessionServiceStub.create();
+
+        Test.startTest();
+        try {
+            RecentServiceSessionController.getServiceSessionStatusBuckets(null);
+        } catch (Exception ex) {
+            actualException = ex;
+        }
+
+        Test.stopTest();
+
+        System.assert(
+            actualException instanceof AuraHandledException,
+            actualException.getTypeName() + ': Expected an aura handled exception.'
+        );
+    }
 }

--- a/force-app/main/default/classes/ServiceDeliveryService.cls
+++ b/force-app/main/default/classes/ServiceDeliveryService.cls
@@ -61,7 +61,12 @@ public with sharing class ServiceDeliveryService {
     private Map<String, List<String>> statusBuckets {
         get {
             if (statusBuckets == null) {
-                statusBuckets = getStatusBuckets();
+                List<String> bucketNames = new List<String>{ ABSENT, PRESENT };
+                statusBuckets = getStatusBuckets(
+                    bucketNames,
+                    ServiceDelivery__c.SObjectType,
+                    ServiceDelivery__c.AttendanceStatus__c
+                );
             }
             return statusBuckets;
         }
@@ -232,18 +237,21 @@ public with sharing class ServiceDeliveryService {
         return (ServiceDelivery__c) deliveryRecord;
     }
 
-    private Map<String, List<String>> getStatusBuckets() {
-        List<String> bucketNames = new List<String>{ ABSENT, PRESENT };
+    public Map<String, List<String>> getStatusBuckets(
+        List<String> bucketNames,
+        Schema.SObjectType objectType,
+        Schema.SObjectField bucketedField
+    ) {
         Map<String, List<String>> buckets = new Map<String, List<String>>();
-
-        Schema.SObjectType serviceDeliverySObjType = ServiceDelivery__c.SObjectType;
-        Schema.SObjectField statusField = ServiceDelivery__c.AttendanceStatus__c;
+        System.debug('bucketNames : ' + bucketNames);
+        System.debug('objectType : ' + objectType);
+        System.debug('bucketedField : ' + bucketedField);
 
         for (
             Bucket__mdt bucket : bucketSelector.getBuckets(
                 bucketNames,
-                serviceDeliverySObjType,
-                statusField
+                objectType,
+                bucketedField
             )
         ) {
             buckets.put(bucket.DeveloperName, new List<String>());

--- a/force-app/main/default/classes/ServiceDeliveryService.cls
+++ b/force-app/main/default/classes/ServiceDeliveryService.cls
@@ -61,12 +61,7 @@ public with sharing class ServiceDeliveryService {
     private Map<String, List<String>> statusBuckets {
         get {
             if (statusBuckets == null) {
-                List<String> bucketNames = new List<String>{ ABSENT, PRESENT };
-                statusBuckets = getStatusBuckets(
-                    bucketNames,
-                    ServiceDelivery__c.SObjectType,
-                    ServiceDelivery__c.AttendanceStatus__c
-                );
+                statusBuckets = getStatusBuckets();
             }
             return statusBuckets;
         }
@@ -237,21 +232,18 @@ public with sharing class ServiceDeliveryService {
         return (ServiceDelivery__c) deliveryRecord;
     }
 
-    public Map<String, List<String>> getStatusBuckets(
-        List<String> bucketNames,
-        Schema.SObjectType objectType,
-        Schema.SObjectField bucketedField
-    ) {
+    private Map<String, List<String>> getStatusBuckets() {
+        List<String> bucketNames = new List<String>{ ABSENT, PRESENT };
         Map<String, List<String>> buckets = new Map<String, List<String>>();
-        System.debug('bucketNames : ' + bucketNames);
-        System.debug('objectType : ' + objectType);
-        System.debug('bucketedField : ' + bucketedField);
+
+        Schema.SObjectType serviceDeliverySObjType = ServiceDelivery__c.SObjectType;
+        Schema.SObjectField statusField = ServiceDelivery__c.AttendanceStatus__c;
 
         for (
             Bucket__mdt bucket : bucketSelector.getBuckets(
                 bucketNames,
-                objectType,
-                bucketedField
+                serviceDeliverySObjType,
+                statusField
             )
         ) {
             buckets.put(bucket.DeveloperName, new List<String>());

--- a/force-app/main/default/classes/ServiceSessionSelector.cls
+++ b/force-app/main/default/classes/ServiceSessionSelector.cls
@@ -47,10 +47,8 @@ public with sharing class ServiceSessionSelector {
             String.valueOf(ServiceSession__c.Status__c) + ' IN :allowedSessionStatuses'
         );
 
-        System.debug('allowedSessionStatuses : ' + allowedSessionStatuses);
         queryBuilder.withOrderBy(String.valueOf(ServiceSession__c.SessionStart__c));
 
-        System.debug(queryBuilder.buildSoqlQuery());
         allSessions = Database.query(queryBuilder.buildSoqlQuery());
 
         return Security.stripInaccessible(AccessType.READABLE, allSessions).getRecords();

--- a/force-app/main/default/classes/ServiceSessionSelector.cls
+++ b/force-app/main/default/classes/ServiceSessionSelector.cls
@@ -15,7 +15,7 @@ public with sharing class ServiceSessionSelector {
 
     public List<ServiceSession__c> getServiceSessionsByStartDate(String dateLiteral) {
         List<ServiceSession__c> allSessions = new List<ServiceSession__c>();
-        Set<String> allowedSessionStatuses = getServiceSessionStatusBuckets();
+        Set<String> allowedSessionStatuses = getAllowedServiceSessionStatusValues();
 
         if (!Schema.SObjectType.ServiceSession__c.isAccessible()) {
             return new List<ServiceSession__c>();
@@ -54,7 +54,7 @@ public with sharing class ServiceSessionSelector {
         return Security.stripInaccessible(AccessType.READABLE, allSessions).getRecords();
     }
 
-    public Set<String> getServiceSessionStatusBuckets() {
+    public Set<String> getAllowedServiceSessionStatusValues() {
         List<String> bucketNames = new List<String>{ 'Pending', 'Complete' };
         Set<String> statuses = new Set<String>();
 

--- a/force-app/main/default/classes/ServiceSessionSelector.cls
+++ b/force-app/main/default/classes/ServiceSessionSelector.cls
@@ -10,9 +10,12 @@
 public with sharing class ServiceSessionSelector {
     private static final String RECENT_SESSIONS_VIEW = 'RecentSessionsView';
 
+    @TestVisible
+    private FieldBucketSelector bucketSelector = new FieldBucketSelector();
+
     public List<ServiceSession__c> getServiceSessionsByStartDate(String dateLiteral) {
         List<ServiceSession__c> allSessions = new List<ServiceSession__c>();
-        Set<String> allowedSessionStatuses = new Set<String>{ 'Pending', 'Complete' };
+        Set<String> allowedSessionStatuses = getServiceSessionStatusBuckets();
 
         if (!Schema.SObjectType.ServiceSession__c.isAccessible()) {
             return new List<ServiceSession__c>();
@@ -44,10 +47,34 @@ public with sharing class ServiceSessionSelector {
             String.valueOf(ServiceSession__c.Status__c) + ' IN :allowedSessionStatuses'
         );
 
+        System.debug('allowedSessionStatuses : ' + allowedSessionStatuses);
         queryBuilder.withOrderBy(String.valueOf(ServiceSession__c.SessionStart__c));
 
+        System.debug(queryBuilder.buildSoqlQuery());
         allSessions = Database.query(queryBuilder.buildSoqlQuery());
 
         return Security.stripInaccessible(AccessType.READABLE, allSessions).getRecords();
+    }
+
+    public Set<String> getServiceSessionStatusBuckets() {
+        List<String> bucketNames = new List<String>{ 'Pending', 'Complete' };
+        Set<String> statuses = new Set<String>();
+
+        Schema.SObjectType serviceSessionSObjType = ServiceSession__c.SObjectType;
+        Schema.SObjectField serviceSessionStatusField = ServiceSession__c.Status__c;
+
+        for (
+            Bucket__mdt bucket : bucketSelector.getBuckets(
+                bucketNames,
+                serviceSessionSObjType,
+                serviceSessionStatusField
+            )
+        ) {
+            for (BucketedValue__mdt value : bucket.BucketedValues__r) {
+                statuses.add(value.Value__c);
+            }
+        }
+
+        return statuses;
     }
 }

--- a/force-app/main/default/classes/ServiceSessionService.cls
+++ b/force-app/main/default/classes/ServiceSessionService.cls
@@ -11,6 +11,9 @@ public with sharing class ServiceSessionService {
     @TestVisible
     private ServiceSessionSelector serviceSessionSelector = new ServiceSessionSelector();
 
+    @TestVisible
+    private FieldBucketSelector bucketSelector = new FieldBucketSelector();
+
     public Map<String, List<ServiceSession__c>> getServiceSessionsByStartDate(
         String dateLiteral
     ) {
@@ -37,5 +40,27 @@ public with sharing class ServiceSessionService {
         }
 
         return serviceSessions;
+    }
+
+    public Set<String> getServiceSessionStatusBuckets(String serviceSessionStatus) {
+        List<String> bucketNames = new List<String>{ serviceSessionStatus };
+        Set<String> statuses = new Set<String>();
+
+        Schema.SObjectType serviceSessionSObjType = ServiceSession__c.SObjectType;
+        Schema.SObjectField serviceSessionStatusField = ServiceSession__c.Status__c;
+
+        for (
+            Bucket__mdt bucket : bucketSelector.getBuckets(
+                bucketNames,
+                serviceSessionSObjType,
+                serviceSessionStatusField
+            )
+        ) {
+            for (BucketedValue__mdt value : bucket.BucketedValues__r) {
+                statuses.add(value.Value__c);
+            }
+        }
+
+        return statuses;
     }
 }

--- a/force-app/main/default/classes/ServiceSessionService.cls
+++ b/force-app/main/default/classes/ServiceSessionService.cls
@@ -14,6 +14,10 @@ public with sharing class ServiceSessionService {
     @TestVisible
     private FieldBucketSelector bucketSelector = new FieldBucketSelector();
 
+    @TestVisible
+    private static final String COMPLETE = 'Complete';
+    private static final String PENDING = 'Pending';
+
     public Map<String, List<ServiceSession__c>> getServiceSessionsByStartDate(
         String dateLiteral
     ) {
@@ -42,25 +46,26 @@ public with sharing class ServiceSessionService {
         return serviceSessions;
     }
 
-    public Set<String> getServiceSessionStatusBuckets(String serviceSessionStatus) {
-        List<String> bucketNames = new List<String>{ serviceSessionStatus };
-        Set<String> statuses = new Set<String>();
+    public Map<String, List<String>> getServiceSessionStatusBuckets() {
+        List<String> bucketNames = new List<String>{ COMPLETE, PENDING };
+        Map<String, List<String>> buckets = new Map<String, List<String>>();
 
         Schema.SObjectType serviceSessionSObjType = ServiceSession__c.SObjectType;
-        Schema.SObjectField serviceSessionStatusField = ServiceSession__c.Status__c;
+        Schema.SObjectField bucketedField = ServiceSession__c.Status__c;
 
         for (
             Bucket__mdt bucket : bucketSelector.getBuckets(
                 bucketNames,
                 serviceSessionSObjType,
-                serviceSessionStatusField
+                bucketedField
             )
         ) {
+            buckets.put(bucket.DeveloperName, new List<String>());
             for (BucketedValue__mdt value : bucket.BucketedValues__r) {
-                statuses.add(value.Value__c);
+                buckets.get(bucket.DeveloperName).add(value.Value__c);
             }
         }
 
-        return statuses;
+        return buckets;
     }
 }

--- a/force-app/main/default/classes/ServiceSessionService_TEST.cls
+++ b/force-app/main/default/classes/ServiceSessionService_TEST.cls
@@ -89,9 +89,8 @@ public with sharing class ServiceSessionService_TEST {
 
     @IsTest
     private static void testGetServiceSessionStatusBuckets() {
-        String status = 'Complete';
         String methodName = 'getBuckets';
-        List<String> bucketNames = new List<String>{ status };
+        List<String> bucketNames = new List<String>{ 'Complete', 'Pending' };
 
         Schema.SObjectType serviceSessionSObjType = ServiceSession__c.SObjectType;
         Schema.SObjectField statusField = ServiceSession__c.Status__c;
@@ -111,20 +110,20 @@ public with sharing class ServiceSessionService_TEST {
 
         service.bucketSelector = (FieldBucketSelector) bucketSelectorStub.create();
 
-        Set<String> expectedStatuses = new Set<String>{ status };
+        Map<String, List<String>> expectedStatuses = new Map<String, List<String>>();
+        expectedStatuses.put('Complete', new List<String>{ 'Complete' });
+        expectedStatuses.put('Pending', new List<String>{ 'Pending' });
 
         Test.startTest();
-        Set<String> returnedStatuses = service.getServiceSessionStatusBuckets(status);
+        Map<String, List<String>> returnedStatuses = service.getServiceSessionStatusBuckets();
         Test.stopTest();
 
-        for (String statusName : expectedStatuses) {
-            System.assert(
-                returnedStatuses.contains(statusName),
-                'Expected the status ' +
-                statusName +
-                ' to be returned.'
-            );
-        }
+        System.assertEquals(
+            expectedStatuses,
+            returnedStatuses,
+            'Expected values is not the same as actual values'
+        );
+
         bucketSelectorStub.assertCalledAsExpected();
     }
 
@@ -137,8 +136,8 @@ public with sharing class ServiceSessionService_TEST {
             .withMockId()
             .build();
 
-        List<BucketedValue__mdt> statusValues = new List<BucketedValue__mdt>();
-        statusValues.add(
+        List<BucketedValue__mdt> completeValues = new List<BucketedValue__mdt>();
+        completeValues.add(
             (BucketedValue__mdt) new TestUtil.BucketedValueBuilder()
                 .withDeveloperName('Complete')
                 .withQualifiedApiName(Util.prefixNamespace('Complete'))
@@ -148,14 +147,33 @@ public with sharing class ServiceSessionService_TEST {
                 .build()
         );
 
-        Bucket__mdt statusBucket = (Bucket__mdt) new TestUtil.BucketBuilder()
+        List<BucketedValue__mdt> pendingValues = new List<BucketedValue__mdt>();
+        pendingValues.add(
+            (BucketedValue__mdt) new TestUtil.BucketedValueBuilder()
+                .withDeveloperName('Pending')
+                .withQualifiedApiName(Util.prefixNamespace('Pending'))
+                .withBucket('Pending')
+                .withValue('Pending')
+                .withMockId()
+                .build()
+        );
+
+        Bucket__mdt completeBucket = (Bucket__mdt) new TestUtil.BucketBuilder()
             .withBucketedField(bucketedField)
-            .withBucketedValues(statusValues)
+            .withBucketedValues(completeValues)
             .withDeveloperName('Complete')
             .withQualifiedApiName(Util.prefixNamespace('Complete'))
             .withMockId()
             .build();
 
-        return new List<Bucket__mdt>{ statusBucket };
+        Bucket__mdt pendingBucket = (Bucket__mdt) new TestUtil.BucketBuilder()
+            .withBucketedField(bucketedField)
+            .withBucketedValues(pendingValues)
+            .withDeveloperName('Pending')
+            .withQualifiedApiName(Util.prefixNamespace('Pending'))
+            .withMockId()
+            .build();
+
+        return new List<Bucket__mdt>{ completeBucket, pendingBucket };
     }
 }

--- a/force-app/main/default/classes/ServiceSessionService_TEST.cls
+++ b/force-app/main/default/classes/ServiceSessionService_TEST.cls
@@ -9,6 +9,8 @@
 
 @IsTest
 public with sharing class ServiceSessionService_TEST {
+    private static TestStub bucketSelectorStub;
+
     private static BasicStub serviceSelectorStub = new BasicStub(
         ServiceSessionSelector.class
     );
@@ -83,5 +85,77 @@ public with sharing class ServiceSessionService_TEST {
         );
 
         serviceSelectorStub.assertCalledWith(methodName, String.class, dateLiteral);
+    }
+
+    @IsTest
+    private static void testGetServiceSessionStatusBuckets() {
+        String status = 'Complete';
+        String methodName = 'getBuckets';
+        List<String> bucketNames = new List<String>{ status };
+
+        Schema.SObjectType serviceSessionSObjType = ServiceSession__c.SObjectType;
+        Schema.SObjectField statusField = ServiceSession__c.Status__c;
+
+        List<Bucket__mdt> statusBuckets = createStatusBuckets();
+
+        bucketSelectorStub = new StubBuilder(FieldBucketSelector.class)
+            .when(
+                methodName,
+                List<String>.class,
+                Schema.SObjectType.class,
+                Schema.SObjectField.class
+            )
+            .calledWith(bucketNames, serviceSessionSObjType, statusField)
+            .thenReturn(statusBuckets)
+            .build();
+
+        service.bucketSelector = (FieldBucketSelector) bucketSelectorStub.create();
+
+        Set<String> expectedStatuses = new Set<String>{ status };
+
+        Test.startTest();
+        Set<String> returnedStatuses = service.getServiceSessionStatusBuckets(status);
+        Test.stopTest();
+
+        for (String statusName : expectedStatuses) {
+            System.assert(
+                returnedStatuses.contains(statusName),
+                'Expected the status ' +
+                statusName +
+                ' to be returned.'
+            );
+        }
+        bucketSelectorStub.assertCalledAsExpected();
+    }
+
+    private static List<Bucket__mdt> createStatusBuckets() {
+        BucketedField__mdt bucketedField = (BucketedField__mdt) new TestUtil.BucketedFieldBuilder()
+            .withDeveloperName('ServiceSessionStatuses')
+            .withQualifiedApiName(Util.prefixNamespace('ServiceSessionStatuses'))
+            .withField('Status__c')
+            .withObject('ServiceSession__c')
+            .withMockId()
+            .build();
+
+        List<BucketedValue__mdt> statusValues = new List<BucketedValue__mdt>();
+        statusValues.add(
+            (BucketedValue__mdt) new TestUtil.BucketedValueBuilder()
+                .withDeveloperName('Complete')
+                .withQualifiedApiName(Util.prefixNamespace('Complete'))
+                .withBucket('Complete')
+                .withValue('Complete')
+                .withMockId()
+                .build()
+        );
+
+        Bucket__mdt statusBucket = (Bucket__mdt) new TestUtil.BucketBuilder()
+            .withBucketedField(bucketedField)
+            .withBucketedValues(statusValues)
+            .withDeveloperName('Complete')
+            .withQualifiedApiName(Util.prefixNamespace('Complete'))
+            .withMockId()
+            .build();
+
+        return new List<Bucket__mdt>{ statusBucket };
     }
 }

--- a/force-app/main/default/customMetadata/Bucket.Complete.md-meta.xml
+++ b/force-app/main/default/customMetadata/Bucket.Complete.md-meta.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Complete</label>
+    <protected>false</protected>
+    <values>
+        <field>BucketedField__c</field>
+        <value xsi:type="xsd:string">Service_Session_Statuses</value>
+    </values>
+</CustomMetadata>

--- a/force-app/main/default/customMetadata/Bucket.Complete.md-meta.xml
+++ b/force-app/main/default/customMetadata/Bucket.Complete.md-meta.xml
@@ -4,6 +4,6 @@
     <protected>false</protected>
     <values>
         <field>BucketedField__c</field>
-        <value xsi:type="xsd:string">Service_Session_Statuses</value>
+        <value xsi:type="xsd:string">ServiceSessionStatuses</value>
     </values>
 </CustomMetadata>

--- a/force-app/main/default/customMetadata/Bucket.Pending.md-meta.xml
+++ b/force-app/main/default/customMetadata/Bucket.Pending.md-meta.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Pending</label>
+    <protected>false</protected>
+    <values>
+        <field>BucketedField__c</field>
+        <value xsi:type="xsd:string">Service_Session_Statuses</value>
+    </values>
+</CustomMetadata>

--- a/force-app/main/default/customMetadata/Bucket.Pending.md-meta.xml
+++ b/force-app/main/default/customMetadata/Bucket.Pending.md-meta.xml
@@ -4,6 +4,6 @@
     <protected>false</protected>
     <values>
         <field>BucketedField__c</field>
-        <value xsi:type="xsd:string">Service_Session_Statuses</value>
+        <value xsi:type="xsd:string">ServiceSessionStatuses</value>
     </values>
 </CustomMetadata>

--- a/force-app/main/default/customMetadata/BucketedField.ServiceSessionStatuses.md-meta.xml
+++ b/force-app/main/default/customMetadata/BucketedField.ServiceSessionStatuses.md-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Service Session Statuses</label>
+    <protected>false</protected>
+    <values>
+        <field>Field__c</field>
+        <value xsi:type="xsd:string">Status__c</value>
+    </values>
+    <values>
+        <field>Object__c</field>
+        <value xsi:type="xsd:string">ServiceSession__c</value>
+    </values>
+</CustomMetadata>

--- a/force-app/main/default/customMetadata/BucketedValue.Complete.md-meta.xml
+++ b/force-app/main/default/customMetadata/BucketedValue.Complete.md-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Complete</label>
+    <protected>false</protected>
+    <values>
+        <field>Bucket__c</field>
+        <value xsi:type="xsd:string">Complete</value>
+    </values>
+    <values>
+        <field>Value__c</field>
+        <value xsi:type="xsd:string">Complete</value>
+    </values>
+</CustomMetadata>

--- a/force-app/main/default/customMetadata/BucketedValue.Pending.md-meta.xml
+++ b/force-app/main/default/customMetadata/BucketedValue.Pending.md-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Pending</label>
+    <protected>false</protected>
+    <values>
+        <field>Bucket__c</field>
+        <value xsi:type="xsd:string">Pending</value>
+    </values>
+    <values>
+        <field>Value__c</field>
+        <value xsi:type="xsd:string">Pending</value>
+    </values>
+</CustomMetadata>

--- a/force-app/main/default/lwc/attendance/__tests__/attendance.test.js
+++ b/force-app/main/default/lwc/attendance/__tests__/attendance.test.js
@@ -13,7 +13,7 @@ import { getRecord } from "lightning/uiRecordApi";
 import { CurrentPageReference } from "lightning/navigation";
 import generateRoster from "@salesforce/apex/AttendanceController.generateRoster";
 import checkFieldPermissions from "@salesforce/apex/AttendanceController.checkFieldPermissions";
-import getSessionStatusBuckets from "@salesforce/apex/AttendanceController.getServiceSessionStatusBuckets";
+import getServiceSessionStatusBuckets from "@salesforce/apex/AttendanceController.getServiceSessionStatusBuckets";
 
 import {
     registerApexTestWireAdapter,
@@ -33,7 +33,7 @@ const generateRosterAdapter = registerApexTestWireAdapter(generateRoster);
 const wiredSessionAdapter = registerLdsTestWireAdapter(getRecord);
 const wiredPermissionsAdapter = registerApexTestWireAdapter(checkFieldPermissions);
 const wiredGetSessionStatusesAdapter = registerApexTestWireAdapter(
-    getSessionStatusBuckets
+    getServiceSessionStatusBuckets
 );
 const wiredCurrentPageReference = registerApexTestWireAdapter(CurrentPageReference);
 

--- a/force-app/main/default/lwc/attendance/__tests__/attendance.test.js
+++ b/force-app/main/default/lwc/attendance/__tests__/attendance.test.js
@@ -13,6 +13,8 @@ import { getRecord } from "lightning/uiRecordApi";
 import { CurrentPageReference } from "lightning/navigation";
 import generateRoster from "@salesforce/apex/AttendanceController.generateRoster";
 import checkFieldPermissions from "@salesforce/apex/AttendanceController.checkFieldPermissions";
+import getSessionStatusBuckets from "@salesforce/apex/AttendanceController.getServiceSessionStatusBuckets";
+
 import {
     registerApexTestWireAdapter,
     registerLdsTestWireAdapter,
@@ -23,12 +25,16 @@ const mockGenerateRosterEmpty = require("./data/emptyRoster.json");
 const mockWiredSession = require("./data/wiredPendingSession.json");
 const mockWiredPermissions = require("./data/wiredPermissions.json");
 const mockWiredNoPermissions = require("./data/wiredNoPermissions.json");
+const mockwiredGetSessionStatuses = require("./data/wiredGetSessionStatuses.json");
 const mockCurrentPageReference = require("./data/currentPageReference.json");
 
 //Register the  wire adapters
 const generateRosterAdapter = registerApexTestWireAdapter(generateRoster);
 const wiredSessionAdapter = registerLdsTestWireAdapter(getRecord);
 const wiredPermissionsAdapter = registerApexTestWireAdapter(checkFieldPermissions);
+const wiredGetSessionStatusesAdapter = registerApexTestWireAdapter(
+    getSessionStatusBuckets
+);
 const wiredCurrentPageReference = registerApexTestWireAdapter(CurrentPageReference);
 
 jest.mock("c/attendanceRow");
@@ -50,6 +56,7 @@ describe("c-attendance", () => {
         wiredSessionAdapter.emit(mockWiredSession);
         generateRosterAdapter.emit(mockGenerateRoster);
         wiredPermissionsAdapter.emit(mockWiredPermissions);
+        wiredGetSessionStatusesAdapter.emit(mockwiredGetSessionStatuses);
         wiredCurrentPageReference.emit(mockCurrentPageReference);
 
         return global.flushPromises().then(async () => {

--- a/force-app/main/default/lwc/attendance/__tests__/data/wiredGetSessionStatuses.json
+++ b/force-app/main/default/lwc/attendance/__tests__/data/wiredGetSessionStatuses.json
@@ -1,0 +1,1 @@
+{ "Complete": ["Complete"], "Pending": ["Pending"] }

--- a/force-app/main/default/lwc/attendance/attendance.js
+++ b/force-app/main/default/lwc/attendance/attendance.js
@@ -18,7 +18,7 @@ import { refreshApex } from "@salesforce/apex";
 import generateRoster from "@salesforce/apex/AttendanceController.generateRoster";
 import upsertRows from "@salesforce/apex/AttendanceController.upsertServiceDeliveries";
 import checkFieldPermissions from "@salesforce/apex/AttendanceController.checkFieldPermissions";
-import getSessionStatusBuckets from "@salesforce/apex/AttendanceController.getServiceSessionStatusBuckets";
+import getServiceSessionStatusBuckets from "@salesforce/apex/AttendanceController.getServiceSessionStatusBuckets";
 
 import SERVICE_SESSION_OBJECT from "@salesforce/schema/ServiceSession__c";
 import CONTACT_FIELD from "@salesforce/schema/ServiceDelivery__c.Contact__c";
@@ -51,7 +51,6 @@ import pmmFolder from "@salesforce/resourceUrl/pmm";
 
 const COMPLETE = "Complete";
 const PENDING = "Pending";
-const SESSION_STATUSES = [COMPLETE, PENDING];
 const ID = "Id";
 const ITEM_PAGE_NAVIGATION_TYPE = "standard__navItemPage";
 const ATTENDANCE_TAB = "Attendance";
@@ -170,11 +169,7 @@ export default class Attendance extends NavigationMixin(LightningElement) {
         this.showSpinner = false;
     }
 
-    @wire(getSessionStatusBuckets, {
-        bucketNames: SESSION_STATUSES,
-        objectType: SERVICE_SESSION_OBJECT.objectApiName,
-        bucketedField: SESSION_STATUS_FIELD.fieldApiName,
-    })
+    @wire(getServiceSessionStatusBuckets, {})
     wiredGetSessionStatuses(result) {
         if (!result) {
             return;

--- a/force-app/main/default/lwc/attendance/attendance.js
+++ b/force-app/main/default/lwc/attendance/attendance.js
@@ -177,7 +177,7 @@ export default class Attendance extends NavigationMixin(LightningElement) {
         objectType: SERVICE_SESSION_OBJECT.objectApiName,
         bucketedField: SESSION_STATUS_FIELD.fieldApiName,
     })
-    getSessionStatuses(result) {
+    wiredGetSessionStatuses(result) {
         if (!result) {
             return;
         }

--- a/force-app/main/default/lwc/recentSessions/recentSessions.html
+++ b/force-app/main/default/lwc/recentSessions/recentSessions.html
@@ -113,7 +113,7 @@
                                             <div onkeydown={listEscapeHandler}>
                                                 <c-session-card
                                                     output-fields={outputFields}
-                                                    completed-statuses={completedStatuses}
+                                                    complete-bucketed-statuses={completeBucketedStatuses}
                                                     session={session}
                                                 ></c-session-card>
                                             </div>

--- a/force-app/main/default/lwc/recentSessions/recentSessions.html
+++ b/force-app/main/default/lwc/recentSessions/recentSessions.html
@@ -113,6 +113,7 @@
                                             <div onkeydown={listEscapeHandler}>
                                                 <c-session-card
                                                     output-fields={outputFields}
+                                                    completed-statuses={completedStatuses}
                                                     session={session}
                                                 ></c-session-card>
                                             </div>

--- a/force-app/main/default/lwc/recentSessions/recentSessions.js
+++ b/force-app/main/default/lwc/recentSessions/recentSessions.js
@@ -9,7 +9,7 @@
 
 import { LightningElement, wire, track, api } from "lwc";
 import getServiceSessions from "@salesforce/apex/RecentServiceSessionController.getServiceSessionsByStartDate";
-import getServiceSessionStatuses from "@salesforce/apex/RecentServiceSessionController.getServiceSessionStatusBuckets";
+import getServiceSessionStatusBuckets from "@salesforce/apex/RecentServiceSessionController.getServiceSessionStatusBuckets";
 import getMenuOptions from "@salesforce/apex/RecentServiceSessionController.getMenuOptions";
 import { loadStyle } from "lightning/platformResourceLoader";
 import { getObjectInfo } from "lightning/uiObjectInfoApi";
@@ -44,8 +44,8 @@ export default class RecentSessions extends LightningElement {
     @track sessionsData = [];
     @track sessionIds;
     @track menuItems = [];
+    @track completeBucketedStatuses = [];
     @api flexipageRegionWidth;
-    completedStatuses = [];
 
     _sessionsData;
     hasLoaded = false;
@@ -147,14 +147,20 @@ export default class RecentSessions extends LightningElement {
         }
     }
 
-    @wire(getServiceSessionStatuses, { serviceSessionStatus: COMPLETE })
-    wiredCompletedStatus(result, error) {
+    @wire(getServiceSessionStatusBuckets, {})
+    wiredServiceSessionStatusBuckets(result, error) {
         if (!result) {
             return;
         }
 
         if (result.data) {
-            this.completedStatuses = result.data;
+            for (const [key, value] of Object.entries(result.data)) {
+                if (key.toLowerCase() === COMPLETE.toLowerCase()) {
+                    this.completeBucketedStatuses = value.map(status =>
+                        status.toLowerCase()
+                    );
+                }
+            }
         } else if (error) {
             console.log(error);
         }

--- a/force-app/main/default/lwc/recentSessions/recentSessions.js
+++ b/force-app/main/default/lwc/recentSessions/recentSessions.js
@@ -9,6 +9,7 @@
 
 import { LightningElement, wire, track, api } from "lwc";
 import getServiceSessions from "@salesforce/apex/RecentServiceSessionController.getServiceSessionsByStartDate";
+import getServiceSessionStatuses from "@salesforce/apex/RecentServiceSessionController.getServiceSessionStatusBuckets";
 import getMenuOptions from "@salesforce/apex/RecentServiceSessionController.getMenuOptions";
 import { loadStyle } from "lightning/platformResourceLoader";
 import { getObjectInfo } from "lightning/uiObjectInfoApi";
@@ -38,11 +39,13 @@ const MEDIUM_REGION_WIDTH = 768;
 const SMALL = "SMALL";
 const MEDIUM = "MEDIUM";
 const LARGE = "LARGE";
+const COMPLETE = "Complete";
 export default class RecentSessions extends LightningElement {
     @track sessionsData = [];
     @track sessionIds;
     @track menuItems = [];
     @api flexipageRegionWidth;
+    completedStatuses = [];
 
     _sessionsData;
     hasLoaded = false;
@@ -139,6 +142,19 @@ export default class RecentSessions extends LightningElement {
                 this.menuItems.push(menuItem);
             }
             this.handleGetServiceSessions();
+        } else if (error) {
+            console.log(error);
+        }
+    }
+
+    @wire(getServiceSessionStatuses, { serviceSessionStatus: COMPLETE })
+    wiredCompletedStatus(result, error) {
+        if (!result) {
+            return;
+        }
+
+        if (result.data) {
+            this.completedStatuses = result.data;
         } else if (error) {
             console.log(error);
         }

--- a/force-app/main/default/lwc/sessionCard/sessionCard.js
+++ b/force-app/main/default/lwc/sessionCard/sessionCard.js
@@ -32,7 +32,7 @@ export default class SessionCard extends NavigationMixin(LightningElement) {
 
     _session;
     _outputFields;
-    _completedStatuses;
+    _completeBucketedStatuses;
 
     labels = {
         sucess: SUCCESS_LABEL,
@@ -58,14 +58,12 @@ export default class SessionCard extends NavigationMixin(LightningElement) {
     }
 
     @api
-    set completedStatuses(value) {
-        this._completedStatuses = value.map(status => {
-            return status.toLowerCase();
-        });
+    set completeBucketedStatuses(value) {
+        this._completeBucketedStatuses = value;
     }
 
-    get completedStatuses() {
-        return this._completedStatuses;
+    get completeBucketedStatuses() {
+        return this._completeBucketedStatuses;
     }
 
     @api
@@ -74,8 +72,11 @@ export default class SessionCard extends NavigationMixin(LightningElement) {
 
         for (const [key, val] of Object.entries(value)) {
             if (key === this.fields.status) {
-                if (this.completedStatuses && this.completedStatuses.length > 0) {
-                    this._session.showCompleteIcon = this.completedStatuses.includes(
+                if (
+                    this.completeBucketedStatuses &&
+                    this.completeBucketedStatuses.length > 0
+                ) {
+                    this._session.showCompleteIcon = this.completeBucketedStatuses.includes(
                         val.toLowerCase()
                     );
                 }

--- a/force-app/main/default/lwc/sessionCard/sessionCard.js
+++ b/force-app/main/default/lwc/sessionCard/sessionCard.js
@@ -22,7 +22,6 @@ import SESSION_START_DATE from "@salesforce/schema/ServiceSession__c.SessionStar
 import STATUS_FIELD from "@salesforce/schema/ServiceSession__c.Status__c";
 import SERVICE_LINK_FIELD from "@salesforce/schema/ServiceSession__c.ServiceLink__c";
 
-const COMPLETE = "Complete";
 const STRING = "STRING";
 
 export default class SessionCard extends NavigationMixin(LightningElement) {
@@ -33,6 +32,7 @@ export default class SessionCard extends NavigationMixin(LightningElement) {
 
     _session;
     _outputFields;
+    _completedStatuses;
 
     labels = {
         sucess: SUCCESS_LABEL,
@@ -58,12 +58,27 @@ export default class SessionCard extends NavigationMixin(LightningElement) {
     }
 
     @api
+    set completedStatuses(value) {
+        this._completedStatuses = value.map(status => {
+            return status.toLowerCase();
+        });
+    }
+
+    get completedStatuses() {
+        return this._completedStatuses;
+    }
+
+    @api
     set session(value) {
         this._session = { ...value };
+
         for (const [key, val] of Object.entries(value)) {
             if (key === this.fields.status) {
-                this._session.showCompleteIcon =
-                    val.toLowerCase() === COMPLETE.toLowerCase();
+                if (this.completedStatuses && this.completedStatuses.length > 0) {
+                    this._session.showCompleteIcon = this.completedStatuses.includes(
+                        val.toLowerCase()
+                    );
+                }
             } else if (key === this.fields.primaryServiceProvider) {
                 this._session.hasServiceProviderValue = val !== undefined;
             } else if (key === this.fields.attendanceSummary) {


### PR DESCRIPTION
# Critical Changes

# Changes
Created a new Bucketed Field metadata for service session status
Created 2 new buckets to represent the service session status. The two new buckets are Pending and Complete
Now the recent sessions component will be driven off of the bucket fields. Any status value under the Complete bucket will show up with a green checkmark on the component
If there is a status that is not part of any of the buckets then that status will not show up on the recent service session component
The attendance component is also driven off of the bucket values. Any status value under the Complete bucket will put the component in read only mode with an update button
Any status under the Pending bucket will put the attendance component in edit mode and the users will see the submit button.
# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
~~- [ ] Any net new LWC work has Sa11y tests & 50% or above lines JEST test coverage~~  
~~- [ ] CRUD/FLS is enforced in Apex~~
~~- [ ] Permission sets are updated to account for CRUD|FLS|Tab|Classes~~
~~- [ ] Field sets are updated to account for new fields~~
~~- [ ] UX approval or UX not necessary~~
- [x] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: W-0000000: Work Name (https://github.com/SalesforceFoundation/PMM/pull/303)
- [ ] All **acceptance criteria** have been met
    - [x] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [x] PR contains draft release notes
- [ ] QE story level testing completed