### PR TITLE
Service Schedule Progress Bar Labels

### DIFF
--- a/force-app/main/default/classes/ServiceScheduleModel.cls
+++ b/force-app/main/default/classes/ServiceScheduleModel.cls
@@ -138,13 +138,14 @@ public with sharing class ServiceScheduleModel {
         'scheduleInformation' => System.Label.Service_Schedule_Information,
         'dateTime' => System.Label.Service_Schedule_Date_Time,
         'loading' => System.Label.Loading,
+        'scheduleInfo' => System.Label.Service_Schedule_Information,
         'addToServiceSchedule' => String.format(
             System.Label.Add_To_Record,
             new List<String>{ ServiceSchedule__c.SObjectType.getDescribe().getLabel() }
         ),
         'reviewSchedule' => String.format(
             System.Label.Review_Records,
-            new List<String>{ ServiceSession__c.SObjectType.getDescribe().getLabel() }
+            new List<String>{ ServiceSchedule__c.SObjectType.getDescribe().getLabel() }
         ),
         'serviceObjectApiName' => Service__c.SObjectType.getDescribe().getName()
     };

--- a/force-app/main/default/lwc/serviceScheduleCreator/serviceScheduleCreator.js
+++ b/force-app/main/default/lwc/serviceScheduleCreator/serviceScheduleCreator.js
@@ -89,7 +89,7 @@ export default class ServiceScheduleCreator extends NavigationMixin(LightningEle
 
     addSteps() {
         this._steps
-            .addStep("", this.labels.newSchedule, new NavigationItems().addNext())
+            .addStep("", this.labels.scheduleInfo, new NavigationItems().addNext())
             .addStep(
                 "",
                 this.serviceScheduleModel.labels.serviceSession.reviewSessions,


### PR DESCRIPTION
# Critical Changes

# Changes
Fixes missing and incorrect labels on the Service Schedule Wizard progress bar.

# Issues Closed
[W-10311109](https://gus.lightning.force.com/a07EE00000XtqtFYAR)
[W-10311100](https://gus.lightning.force.com/a07EE00000Xtqt6YAB)

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
- [ ] Any net new LWC work has Sa11y tests & 50% or above lines JEST test coverage  
- [ ] CRUD/FLS is enforced in Apex
- [ ] Permission sets are updated to account for CRUD|FLS|Tab|Classes
- [ ] Field sets are updated to account for new fields
- [x] UX approval or UX not necessary
- [x] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: W-0000000: Work Name (https://github.com/SalesforceFoundation/PMM/pull/303)
- [ ] All **acceptance criteria** have been met
    - [x] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [x] PR contains draft release notes
- [ ] QE story level testing completed