### PR TITLE
Updated the locator for the Add Service participant modal save button

### DIFF
--- a/robot/pmm/resources/locators_52.py
+++ b/robot/pmm/resources/locators_52.py
@@ -53,6 +53,7 @@ pmm_lex_locators = {
         "override_checkbox": "//lightning-input[contains(@class,'slds-form-element_stacked')]/label[.//span[text()='{}']]/following-sibling::div/span/span",
         "input_text": "//lightning-input[contains(@class,'slds-form-element')][.//label[text()='{}']]/div/input[@class='slds-input']",
         "modal_button": "//button[contains(@class,'slds-button')]/span[text()='{}']",
+        "dialog_modal_button": "//lightning-button[@class='slds-var-m-left_x-small']/button[text()='{}']",
     },
     "related": {
         "button": "//article[contains(@class, 'slds-card slds-card_boundary')][.//span[@title='{}']]//button[text()='{}']",

--- a/robot/pmm/resources/pmm.py
+++ b/robot/pmm/resources/pmm.py
@@ -352,6 +352,16 @@ class pmm(object):
         element = self.selenium.driver.find_element_by_xpath(locator)
         self.selenium.driver.execute_script("arguments[0].click()", element)
 
+    def click_modal_dialog_button(self, label):
+        """Click a button on the new record dialog"""
+        locator = pmm_lex_locators["new_record"]["dialog_modal_button"].format(label)
+        self.selenium.wait_until_element_is_enabled(
+            locator, error="Button is not enabled"
+        )
+        self.selenium.set_focus_to_element(locator)
+        element = self.selenium.driver.find_element_by_xpath(locator)
+        self.selenium.driver.execute_script("arguments[0].click()", element)
+
     def populate_lightning_fields(self, **kwargs):
         """During winter 2020 part of the modal fields appear as lightning elements.
         This keyword validates , identifies the element and populates value"""

--- a/robot/pmm/tests/browser/ServiceSchedule/service_schedule_layout.robot
+++ b/robot/pmm/tests/browser/ServiceSchedule/service_schedule_layout.robot
@@ -54,7 +54,7 @@ SSL1: Add Service Participant quick action
     Validate Participant Is Added           ${contact1}[Name]
     Validate Participant Is Added           ${contact2}[Name]
     Validate Participant Is Added           ${contact3}[Name]
-    Click Dialog Button                     Save
+    Click Modal Dialog Button               Save
     Wait Until Modal is Closed
     Page Should Contain                     ${service_participant1}[Name]
     Page Should Contain                     ${contact2}[Name] - ${service_schedule}[Name]


### PR DESCRIPTION
# Critical Changes
  
# Changes
To resolve the NoErrorObjectAvailable error when running the SSL1: Add Service Participant quick action robot test , updated the locator for the Save button on the Add Service Participant modal. This modal will be displayed when the Add Service Participant button is clicked on the Service Schedule page layout.
To run the individual test run the below command in the terminal:
`cci task run robot -o test 'SSL1: Add Service Participant quick action'`
# Issues Closed
[W-10981883](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000umbVfYAI/view)
# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
~~- [ ] Any net new LWC work has Sa11y tests & 50% or above lines JEST test coverage~~  
~~- [ ] CRUD/FLS is enforced in Apex~~
~~- [ ] Permission sets are updated to account for CRUD|FLS|Tab|Classes~~
~~- [ ] Field sets are updated to account for new fields~~
~~- [ ] UX approval or UX not necessary~~
- [x] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: W-0000000: Work Name (https://github.com/SalesforceFoundation/PMM/pull/303)
- [ ] All **acceptance criteria** have been met
    - [x] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [x] PR contains draft release notes
- [ ] QE story level testing completed