### PR TITLE
Modal Close A11y Contrast

### DIFF
--- a/force-app/main/default/lwc/modal/modal.html
+++ b/force-app/main/default/lwc/modal/modal.html
@@ -26,6 +26,8 @@
                         icon-name="utility:close"
                         icon-class="slds-button_icon-inverse"
                         onclick={handleDialogClose}
+                        variant="bare-inverse"
+                        size="large"
                     ></lightning-button-icon>
 
                     <template if:true={hasHeaderString}>


### PR DESCRIPTION
# Critical Changes

# Changes
Increases the color contrast when the modal's close button is focused.  Aligns with core.

# Issues Closed
[W-10311112](https://gus.lightning.force.com/a07EE00000XtqtIYAR)

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
- [ ] Any net new LWC work has Sa11y tests & 50% or above lines JEST test coverage  
- [ ] CRUD/FLS is enforced in Apex
- [ ] Permission sets are updated to account for CRUD|FLS|Tab|Classes
- [ ] Field sets are updated to account for new fields
- [x] UX approval or UX not necessary
- [x] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: W-0000000: Work Name (https://github.com/SalesforceFoundation/PMM/pull/303)
- [ ] All **acceptance criteria** have been met
    - [x] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [x] PR contains draft release notes
- [ ] QE story level testing completed