### PR TITLE
Script to delete Rosa's PSA.

### DIFF
--- a/scripts/Delete_PMM_PSL_Assignments_Rosa.apex
+++ b/scripts/Delete_PMM_PSL_Assignments_Rosa.apex
@@ -1,0 +1,3 @@
+Set<Id> userIds = new Map<Id, User>([SELECT Id FROM User WHERE Alias = 'rosa']).keySet();
+Set<Id> permSetIds = new Map<Id, PermissionSet>([SELECT Id FROM PermissionSet WHERE Name LIKE 'PMDM_%']).keySet();
+delete [SELECT Id from PermissionSetAssignment WHERE PermissionSetId IN :permSetIds AND AssigneeId IN :userIds];


### PR DESCRIPTION
// Internal script for use with cci to easily switch Rosa's permission set assignments.

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
- [ ] Any net new LWC work has Sa11y tests & 50% or above lines JEST test coverage  
- [ ] CRUD/FLS is enforced in Apex
- [ ] Permission sets are updated to account for CRUD|FLS|Tab|Classes
- [ ] Field sets are updated to account for new fields
- [ ] UX approval or UX not necessary
- [ ] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: W-0000000: Work Name (https://github.com/SalesforceFoundation/PMM/pull/303)
- [ ] All **acceptance criteria** have been met
    - [ ] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [ ] PR contains draft release notes
- [ ] QE story level testing completed