### PR TITLE
Allow fields of type Time to be used in Components surfacing field set fields

### DIFF
--- a/force-app/main/default/classes/FieldSetService.cls
+++ b/force-app/main/default/classes/FieldSetService.cls
@@ -8,9 +8,6 @@
  */
 
 public with sharing class FieldSetService {
-    @TestVisible
-    private Set<String> unsupportedFieldTypes = new Set<String>{ 'TIME' };
-
     public Map<String, Object> getFieldSetsByName(String objectName) {
         SObjectType sObjectType = Schema.getGlobalDescribe().get(objectName);
 
@@ -112,23 +109,20 @@ public with sharing class FieldSetService {
         List<FieldInfo> fieldInfos = new List<FieldInfo>();
 
         for (Schema.FieldSetMember memberField : fieldSet.fields) {
-            if (!fieldTypeIsSupported(memberField, allowRelationshipFields)) {
-                // Skipping unsupported field types and fields from related objects.
-                // NOTE: If we ever determine we want to allow reference fields
-                // we can overload this method with a Boolean flag
-                continue;
+            // Skipping fields from related objects when not allowed
+            if (allowRelationshipFields || !memberField.getFieldPath().contains('.')) {
+                FieldInfo fieldSetField = new FieldInfo(memberField);
+
+                DescribeFieldResult fieldDescribe = getCompoundFieldDescribe(
+                    objectDescribe,
+                    fieldSetField.getDescribe(),
+                    memberField.getFieldPath()
+                );
+
+                fieldSetField.setDescribe(fieldDescribe);
+
+                fieldInfos.add(fieldSetField);
             }
-            FieldInfo fieldSetField = new FieldInfo(memberField);
-
-            DescribeFieldResult fieldDescribe = getCompoundFieldDescribe(
-                objectDescribe,
-                fieldSetField.getDescribe(),
-                memberField.getFieldPath()
-            );
-
-            fieldSetField.setDescribe(fieldDescribe);
-
-            fieldInfos.add(fieldSetField);
         }
 
         return fieldInfos;
@@ -170,14 +164,6 @@ public with sharing class FieldSetService {
         }
 
         return getFieldInfos(objectDescribe, fieldSet, allowRelationshipFields);
-    }
-
-    private Boolean fieldTypeIsSupported(
-        Schema.FieldSetMember memberField,
-        Boolean allowRelationshipFields
-    ) {
-        return !(unsupportedFieldTypes.contains(memberField.getType().name()) ||
-        (!allowRelationshipFields && memberField.getFieldPath().contains('.')));
     }
 
     /**

--- a/force-app/main/default/classes/FieldSetService_TEST.cls
+++ b/force-app/main/default/classes/FieldSetService_TEST.cls
@@ -104,49 +104,6 @@ public with sharing class FieldSetService_TEST {
     }
 
     @IsTest
-    private static void shouldSkipUnsupportedFieldTypes() {
-        Test.startTest();
-
-        FieldSetService fieldSetService = new FieldSetService();
-        fieldSetService.unsupportedFieldTypes = new Set<String>{ 'DATE' };
-        Schema.FieldSet fieldSet = Schema.SObjectType.ProgramEngagement__c.FieldSets.CreateProgramEngagement;
-
-        List<Map<String, Object>> fieldsResult = fieldSetService.getFieldSetForLWC(
-            String.valueOf(ProgramEngagement__c.SObjectType),
-            fieldSet.getName(),
-            false
-        );
-
-        Test.stopTest();
-
-        Map<String, Map<String, Object>> fieldsResultByApiName = new Map<String, Map<String, Object>>();
-        for (Map<String, Object> fieldMap : fieldsResult) {
-            fieldsResultByApiName.put(String.valueof(fieldMap.get('apiName')), fieldMap);
-        }
-
-        for (Schema.FieldSetMember fieldSetMember : fieldSet.getFields()) {
-            if (fieldSetMember.getType().name() == 'DATE') {
-                System.assert(
-                    !fieldsResultByApiName.containsKey(fieldSetMember.getFieldPath()),
-                    'The field should have been skipped: ' + fieldSetMember.getFieldPath()
-                );
-                continue;
-            }
-
-            System.assert(
-                fieldsResultByApiName.containsKey(fieldSetMember.getFieldPath()),
-                'The field should not have been skipped: ' + fieldSetMember.getFieldPath()
-            );
-        }
-
-        System.assertNotEquals(
-            fieldSet.getFields().size(),
-            fieldsResult.size(),
-            'Expected the fieldsResult size to be less than the fieldSet size.'
-        );
-    }
-
-    @IsTest
     private static void shouldReturnCompoundFieldDescribe() {
         String expectedFieldName = String.valueOf(Contact.MailingAddress);
         DescribeFieldResult actualField = new FieldSetService()

--- a/force-app/main/default/lwc/attendanceRow/attendanceRow.js
+++ b/force-app/main/default/lwc/attendanceRow/attendanceRow.js
@@ -8,7 +8,7 @@
  */
 
 import { LightningElement, api, track } from "lwc";
-import { getChildObjectByName } from "c/util";
+import { getChildObjectByName, formatTime } from "c/util";
 import { getRecordNotifyChange } from "lightning/uiRecordApi";
 
 import SERVICE_DELIVERY_OBJECT from "@salesforce/schema/ServiceDelivery__c";
@@ -20,6 +20,7 @@ import SKIP_LABEL from "@salesforce/label/c.Dont_Track_Attendance";
 
 // TODO: create design parameters for default status and "present" statuses
 const PRESENT_STATUS = "Present";
+const TIME = "TIME";
 
 export default class AttendanceRow extends LightningElement {
     @track localRecord;
@@ -95,6 +96,9 @@ export default class AttendanceRow extends LightningElement {
             this.localFieldSet = this.localFieldSet.map(a => ({ ...a }));
             this.localFieldSet.forEach(field => {
                 field.value = this.record[field.apiName];
+                if (field.type === TIME && field.value >= 0) {
+                    field.value = formatTime(field.value);
+                }
             });
         }
     }

--- a/force-app/main/default/lwc/formattedField/formattedField.js
+++ b/force-app/main/default/lwc/formattedField/formattedField.js
@@ -9,6 +9,7 @@
 
 import { LightningElement, api } from "lwc";
 import TIME_ZONE from "@salesforce/i18n/timeZone";
+import { formatTime } from "c/util";
 
 const NUMBER_TYPES = ["DOUBLE", "INTEGER", "LONG", "CURRENCY"];
 const DATE_TIME = "DATETIME";
@@ -71,15 +72,7 @@ export default class FormattedField extends LightningElement {
         }
 
         if (this.isTime) {
-            let ms = val % 1000;
-            val = (val - ms) / 1000;
-            let secs = val % 60;
-            val = (val - secs) / 60;
-            let mins = val % 60;
-            let hrs = (val - mins) / 60;
-            hrs = hrs < 10 ? "0" + hrs : hrs;
-            mins = mins < 10 ? "0" + mins : mins;
-            val = hrs + ":" + mins + ":00.000Z";
+            val = formatTime(val);
         }
 
         return val;

--- a/force-app/main/default/lwc/newServiceSchedule/newServiceSchedule.js
+++ b/force-app/main/default/lwc/newServiceSchedule/newServiceSchedule.js
@@ -8,7 +8,7 @@
  */
 
 import { LightningElement, api, track, wire } from "lwc";
-import { format } from "c/util";
+import { format, formatTime } from "c/util";
 import { getRecord } from "lightning/uiRecordApi";
 import { loadStyle } from "lightning/platformResourceLoader";
 import getDayNum from "@salesforce/apex/ServiceScheduleCreatorController.getDayNum";
@@ -43,6 +43,7 @@ const LASTDAY = "LastDayOfMonth";
 const LARGE_SIZE = 12;
 const SMALL_SIZE = 6;
 const DAYS = ["SU", "MO", "TU", "WE", "TH", "FR", "SA"];
+const TIME = "TIME";
 export default class NewServiceSchedule extends LightningElement {
     @api recordTypeId;
     @api serviceId;
@@ -213,6 +214,10 @@ export default class NewServiceSchedule extends LightningElement {
                 let field = { ...member };
                 field.size = SMALL_SIZE;
                 field.value = this._serviceScheduleModel.serviceSchedule[field.apiName];
+                if (field.type === TIME && field.value >= 0) {
+                    field.value = formatTime(field.value);
+                }
+
                 return field;
             });
 

--- a/force-app/main/default/lwc/participantSelector/participantSelector.js
+++ b/force-app/main/default/lwc/participantSelector/participantSelector.js
@@ -8,7 +8,7 @@
  */
 
 import { LightningElement, track, api, wire } from "lwc";
-import { format } from "c/util";
+import { format, formatTime } from "c/util";
 import { refreshApex } from "@salesforce/apex";
 
 import getSelectParticipantModel from "@salesforce/apex/ServiceScheduleCreatorController.getSelectParticipantModel";
@@ -33,6 +33,8 @@ import save from "@salesforce/label/c.Save";
 import saveAndNew from "@salesforce/label/c.Save_New";
 import cantFind from "@salesforce/label/c.Cant_Find_Participant";
 import newLabel from "@salesforce/label/c.New";
+
+const TIME = "TIME";
 
 export default class ParticipantSelector extends LightningElement {
     @api serviceId;
@@ -203,6 +205,12 @@ export default class ParticipantSelector extends LightningElement {
                 // Flatten relationship fields
                 let programEngagement = { ...engagement };
                 for (const [field, value] of Object.entries(programEngagement)) {
+                    let isTimeField =
+                        this.fieldByFieldPath[field] &&
+                        this.fieldByFieldPath[field].type === TIME;
+                    if (isTimeField) {
+                        programEngagement[field] = formatTime(value);
+                    }
                     if (typeof value === "object") {
                         for (const [parentField, parentValue] of Object.entries(value)) {
                             programEngagement[field + parentField] = parentValue;

--- a/force-app/main/default/lwc/serviceScheduleReview/serviceScheduleReview.html
+++ b/force-app/main/default/lwc/serviceScheduleReview/serviceScheduleReview.html
@@ -1,3 +1,4 @@
+<!-- sldsValidatorIgnore -->
 <!--
   - /*
   -  * Copyright (c) 2020, salesforce.com, inc.
@@ -102,7 +103,11 @@
                             class="slds-var-p-right_x-small"
                         >
                         </lightning-icon>
-                        {field.value}
+                        <lightning-formatted-time
+                            if:true={field.isTime}
+                            value={field.value}
+                        ></lightning-formatted-time>
+                        <template if:false={field.isTime}> {field.value} </template>
                     </template>
                 </c-output-field>
             </template>

--- a/force-app/main/default/lwc/serviceScheduleReview/serviceScheduleReview.js
+++ b/force-app/main/default/lwc/serviceScheduleReview/serviceScheduleReview.js
@@ -8,12 +8,14 @@
  */
 
 import { LightningElement, api, track } from "lwc";
-import { format } from "c/util";
+import { format, formatTime } from "c/util";
 import REVIEW_RECORDS from "@salesforce/label/c.Review_Records";
 import TOTAL_SESSIONS_LABEL from "@salesforce/label/c.Total_Sessions";
 import DATE_AND_TIME from "@salesforce/label/c.Service_Schedule_Date_Time";
 import TIME_ZONE from "@salesforce/i18n/timeZone";
 import CONTACT_OBJECT from "@salesforce/schema/Contact";
+
+const TIME = "TIME";
 
 export default class ServiceScheduleReview extends LightningElement {
     _serviceScheduleModel;
@@ -76,6 +78,11 @@ export default class ServiceScheduleReview extends LightningElement {
                       field.referenceNameField
                   ]
                 : this._serviceScheduleModel.serviceSchedule[field.apiName];
+
+            if (field.type === TIME && field.value >= 0) {
+                field.value = formatTime(field.value);
+                field.isTime = true;
+            }
         });
     }
 

--- a/force-app/main/default/lwc/util/util.js
+++ b/force-app/main/default/lwc/util/util.js
@@ -307,6 +307,20 @@ const prefixNamespace = value => {
     return namespace + value;
 };
 
+const formatTime = value => {
+    let ms = value % 1000;
+    value = (value - ms) / 1000;
+    let secs = value % 60;
+    value = (value - secs) / 60;
+    let mins = value % 60;
+    let hrs = (value - mins) / 60;
+    hrs = hrs < 10 ? "0" + hrs : hrs;
+    mins = mins < 10 ? "0" + mins : mins;
+    value = hrs + ":" + mins + ":00.000Z";
+
+    return value;
+};
+
 export {
     isString,
     showToast,
@@ -322,4 +336,5 @@ export {
     debouncify,
     createUUID,
     prefixNamespace,
+    formatTime,
 };


### PR DESCRIPTION
# Critical Changes

# Changes
- Fields of type Time were previously not supported on Lightning Record components. Now that it is we will also allow the usage on our custom components. The time field is not fully supported in Lightning Datatable and will display in a raw time format.

# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
~~Any net new LWC work has Sa11y tests & 50% or above lines JEST test coverage~~
~~CRUD/FLS is enforced in Apex~~
~~Permission sets are updated to account for CRUD|FLS|Tab|Classes~~
~~Field sets are updated to account for new fields~~
~~UX approval or UX not necessary~~
- [x] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: W-0000000: Work Name (https://github.com/SalesforceFoundation/CaseMan/pull/303)
- [ ] All **acceptance criteria** have been met
    - [x] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [x] PR contains draft release notes
- [ ] QE story level testing completed