### PR TITLE
 Participant rollup on ServiceSchedule

### DIFF
--- a/force-app/main/default/classes/ServiceParticipantRollupsService.cls
+++ b/force-app/main/default/classes/ServiceParticipantRollupsService.cls
@@ -7,16 +7,16 @@
  *
  */
 public with sharing class ServiceParticipantRollupsService {
-    private static String ENROLLED = 'Enrolled';
     private static Set<String> FEATUREGATE_NAME = new Set<String>{
         'ServiceParticipantsToServiceSchedule'
     };
+    @TestVisible
+    private ServiceScheduleSelector scheduleSelector = new ServiceScheduleSelector();
 
     public void processParticipantRollups(List<ServiceParticipant__c> participants) {
-        Integer participantCount;
         Set<Id> serviceScheduleIds = new Set<Id>();
         List<ServiceSchedule__c> serviceSchedulesToUpdate = new List<ServiceSchedule__c>();
-        Map<Id, ServiceSchedule__c> schedules = new Map<Id, ServiceSchedule__c>();
+        List<ServiceSchedule__c> schedules = new List<ServiceSchedule__c>();
         Boolean isfeatureGateActive = getFeatureGateStatus();
 
         if (isfeatureGateActive) {
@@ -24,39 +24,22 @@ public with sharing class ServiceParticipantRollupsService {
                 serviceScheduleIds.add(participant.ServiceSchedule__c);
             }
 
-            schedules = getServiceSchedules(serviceScheduleIds);
+            schedules = scheduleSelector.getSchedulesWithParticipants(serviceScheduleIds);
 
-            for (ServiceSchedule__c schedule : schedules.values()) {
-                participantCount = 0;
-                for (
-                    ServiceParticipant__c serviceParticipant : schedule.ServiceParticipants__r
+            for (ServiceSchedule__c schedule : schedules) {
+                if (
+                    schedule.ParticipantsEnrolled__c !=
+                    schedule.ServiceParticipants__r.size()
                 ) {
-                    if (serviceParticipant.Status__c != ENROLLED) {
-                        continue;
-                    }
-                    participantCount++;
+                    schedule.ParticipantsEnrolled__c = schedule.ServiceParticipants__r.size();
+                    serviceSchedulesToUpdate.add(schedule);
                 }
-                schedule.ParticipantsEnrolled__c = participantCount;
-                serviceSchedulesToUpdate.add(schedule);
             }
 
             if (!serviceSchedulesToUpdate.isEmpty()) {
                 update serviceSchedulesToUpdate;
             }
         }
-    }
-
-    private Map<Id, ServiceSchedule__c> getServiceSchedules(Set<Id> scheduleIds) {
-        return new Map<Id, ServiceSchedule__c>(
-            [
-                SELECT
-                    Id,
-                    ParticipantsEnrolled__c,
-                    (SELECT Id, Status__c FROM ServiceParticipants__r)
-                FROM ServiceSchedule__c
-                WHERE Id IN :scheduleIds
-            ]
-        );
     }
 
     private Boolean getFeatureGateStatus() {

--- a/force-app/main/default/classes/ServiceParticipantRollupsService.cls
+++ b/force-app/main/default/classes/ServiceParticipantRollupsService.cls
@@ -1,0 +1,51 @@
+public with sharing class ServiceParticipantRollupsService {
+    private Integer participantEnrolledCount = 0;
+
+    public void processInsertedParticipants(List<ServiceParticipant__c> participants) {
+        processServiceSchedules(participants);
+    }
+
+    private void processServiceSchedules(List<ServiceParticipant__c> participants) {
+        Set<Id> serviceScheduleIds = new Set<Id>();
+        List<ServiceSchedule__c> serviceSchedules = new List<ServiceSchedule__c>();
+
+        for (ServiceParticipant__c participant : participants) {
+            serviceScheduleIds.add(participant.ServiceSchedule__c);
+        }
+
+        List<ServiceSchedule__c> schedules = new List<ServiceSchedule__c>();
+
+        schedules = getServiceSchedules(serviceScheduleIds);
+
+        for (ServiceSchedule__c schedule : schedules) {
+            for (ServiceParticipant__c participant : schedule.ServiceParticipants__r) {
+                if (participant.Status__c != 'Enrolled') {
+                    continue;
+                }
+
+                if (schedule.ParticipantsEnrolled__c == null) {
+                    schedule.ParticipantsEnrolled__c = 0;
+                }
+                schedule.ParticipantsEnrolled__c++;
+            }
+            serviceSchedules.add(schedule);
+        }
+
+        if (!serviceSchedules.isEmpty()) {
+            update serviceSchedules;
+        }
+    }
+
+    private List<ServiceSchedule__c> getServiceSchedules(Set<Id> scheduleIds) {
+        return new List<ServiceSchedule__c>(
+            [
+                SELECT
+                    Id,
+                    ParticipantsEnrolled__c,
+                    (SELECT Id, Status__c FROM ServiceParticipants__r)
+                FROM ServiceSchedule__c
+                WHERE Id IN :scheduleIds
+            ]
+        );
+    }
+}

--- a/force-app/main/default/classes/ServiceParticipantRollupsService.cls
+++ b/force-app/main/default/classes/ServiceParticipantRollupsService.cls
@@ -1,7 +1,12 @@
+/*
+ *
+ *  * Copyright (c) 2022, salesforce.com, inc.
+ *  * All rights reserved.
+ *  * SPDX-License-Identifier: BSD-3-Clause
+ *  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ *
+ */
 public with sharing class ServiceParticipantRollupsService {
-    @TestVisible
-    private FieldBucketSelector bucketSelector = new FieldBucketSelector();
-
     private static String ENROLLED = 'Enrolled';
     private static Set<String> FEATUREGATE_NAME = new Set<String>{
         'ServiceParticipantsToServiceSchedule'

--- a/force-app/main/default/classes/ServiceParticipantRollupsService.cls
+++ b/force-app/main/default/classes/ServiceParticipantRollupsService.cls
@@ -1,80 +1,69 @@
 public with sharing class ServiceParticipantRollupsService {
+    @TestVisible
+    private FieldBucketSelector bucketSelector = new FieldBucketSelector();
+
     private static String ENROLLED = 'Enrolled';
+    private static Set<String> FEATUREGATE_NAME = new Set<String>{
+        'ServiceParticipantsToServiceSchedule'
+    };
 
     public void processInsertedParticipants(List<ServiceParticipant__c> participants) {
+        Integer participantCount;
         Set<Id> serviceScheduleIds = new Set<Id>();
-        Map<Id, ServiceSchedule__c> serviceSchedules = new Map<Id, ServiceSchedule__c>();
+        List<ServiceSchedule__c> serviceSchedulesToUpdate = new List<ServiceSchedule__c>();
         Map<Id, ServiceSchedule__c> schedules = new Map<Id, ServiceSchedule__c>();
+        Boolean isfeatureGateActive = getFeatureGateStatus();
 
-        for (ServiceParticipant__c participant : participants) {
-            serviceScheduleIds.add(participant.ServiceSchedule__c);
-        }
-
-        schedules = getServiceSchedules(serviceScheduleIds);
-
-        for (ServiceParticipant__c serviceParticipant : participants) {
-            ServiceSchedule__c schedule = schedules.get(
-                serviceParticipant.ServiceSchedule__c
-            );
-
-            if (serviceParticipant.Status__c != ENROLLED) {
-                continue;
+        if (isfeatureGateActive) {
+            for (ServiceParticipant__c participant : participants) {
+                serviceScheduleIds.add(participant.ServiceSchedule__c);
             }
 
-            if (schedule.ParticipantsEnrolled__c == null) {
-                schedule.ParticipantsEnrolled__c = 0;
+            schedules = getServiceSchedules(serviceScheduleIds);
+
+            for (ServiceSchedule__c schedule : schedules.values()) {
+                participantCount = 0;
+                for (
+                    ServiceParticipant__c serviceParticipant : schedule.ServiceParticipants__r
+                ) {
+                    if (serviceParticipant.Status__c != ENROLLED) {
+                        continue;
+                    }
+                    participantCount++;
+                }
+                schedule.ParticipantsEnrolled__c = participantCount;
+                serviceSchedulesToUpdate.add(schedule);
             }
 
-            schedule.ParticipantsEnrolled__c++;
-
-            serviceSchedules.put(schedule.Id, schedule);
-        }
-
-        if (!serviceSchedules.isEmpty()) {
-            update serviceSchedules.values();
-        }
-    }
-
-    public void processDeletedServiceParticipants(
-        List<ServiceParticipant__c> participants
-    ) {
-        Set<Id> serviceScheduleIds = new Set<Id>();
-        Map<Id, ServiceSchedule__c> serviceSchedules = new Map<Id, ServiceSchedule__c>();
-
-        for (ServiceParticipant__c participant : participants) {
-            serviceScheduleIds.add(participant.ServiceSchedule__c);
-        }
-
-        Map<Id, ServiceSchedule__c> schedules = new Map<Id, ServiceSchedule__c>();
-
-        schedules = getServiceSchedules(serviceScheduleIds);
-
-        for (ServiceParticipant__c serviceParticipant : participants) {
-            ServiceSchedule__c schedule = schedules.get(
-                serviceParticipant.ServiceSchedule__c
-            );
-
-            if (serviceParticipant.Status__c != ENROLLED) {
-                continue;
+            if (!serviceSchedulesToUpdate.isEmpty()) {
+                update serviceSchedulesToUpdate;
             }
-
-            schedule.ParticipantsEnrolled__c--;
-
-            serviceSchedules.put(schedule.Id, schedule);
-        }
-
-        if (!serviceSchedules.isEmpty()) {
-            update serviceSchedules.values();
         }
     }
 
     private Map<Id, ServiceSchedule__c> getServiceSchedules(Set<Id> scheduleIds) {
         return new Map<Id, ServiceSchedule__c>(
             [
-                SELECT Id, ParticipantsEnrolled__c
+                SELECT
+                    Id,
+                    ParticipantsEnrolled__c,
+                    (SELECT Id, Status__c FROM ServiceParticipants__r)
                 FROM ServiceSchedule__c
                 WHERE Id IN :scheduleIds
             ]
         );
+    }
+
+    private Boolean getFeatureGateStatus() {
+        List<FeatureGate__mdt> features = CustomMetadataSelector.getInstance()
+            .getAllFeatureGates();
+
+        for (FeatureGate__mdt feature : features) {
+            if (feature.IsActive__c && FEATUREGATE_NAME.contains(feature.DeveloperName)) {
+                return feature.IsActive__c;
+            }
+        }
+
+        return false;
     }
 }

--- a/force-app/main/default/classes/ServiceParticipantRollupsService.cls
+++ b/force-app/main/default/classes/ServiceParticipantRollupsService.cls
@@ -12,7 +12,7 @@ public with sharing class ServiceParticipantRollupsService {
         'ServiceParticipantsToServiceSchedule'
     };
 
-    public void processInsertedParticipants(List<ServiceParticipant__c> participants) {
+    public void processParticipantRollups(List<ServiceParticipant__c> participants) {
         Integer participantCount;
         Set<Id> serviceScheduleIds = new Set<Id>();
         List<ServiceSchedule__c> serviceSchedulesToUpdate = new List<ServiceSchedule__c>();

--- a/force-app/main/default/classes/ServiceParticipantRollupsService.cls
+++ b/force-app/main/default/classes/ServiceParticipantRollupsService.cls
@@ -1,48 +1,75 @@
 public with sharing class ServiceParticipantRollupsService {
-    private Integer participantEnrolledCount = 0;
+    private static String ENROLLED = 'Enrolled';
 
     public void processInsertedParticipants(List<ServiceParticipant__c> participants) {
-        processServiceSchedules(participants);
-    }
-
-    private void processServiceSchedules(List<ServiceParticipant__c> participants) {
         Set<Id> serviceScheduleIds = new Set<Id>();
-        List<ServiceSchedule__c> serviceSchedules = new List<ServiceSchedule__c>();
+        Map<Id, ServiceSchedule__c> serviceSchedules = new Map<Id, ServiceSchedule__c>();
+        Map<Id, ServiceSchedule__c> schedules = new Map<Id, ServiceSchedule__c>();
 
         for (ServiceParticipant__c participant : participants) {
             serviceScheduleIds.add(participant.ServiceSchedule__c);
         }
 
-        List<ServiceSchedule__c> schedules = new List<ServiceSchedule__c>();
-
         schedules = getServiceSchedules(serviceScheduleIds);
 
-        for (ServiceSchedule__c schedule : schedules) {
-            for (ServiceParticipant__c participant : schedule.ServiceParticipants__r) {
-                if (participant.Status__c != 'Enrolled') {
-                    continue;
-                }
+        for (ServiceParticipant__c serviceParticipant : participants) {
+            ServiceSchedule__c schedule = schedules.get(
+                serviceParticipant.ServiceSchedule__c
+            );
 
-                if (schedule.ParticipantsEnrolled__c == null) {
-                    schedule.ParticipantsEnrolled__c = 0;
-                }
-                schedule.ParticipantsEnrolled__c++;
+            if (serviceParticipant.Status__c != ENROLLED) {
+                continue;
             }
-            serviceSchedules.add(schedule);
+
+            if (schedule.ParticipantsEnrolled__c == null) {
+                schedule.ParticipantsEnrolled__c = 0;
+            }
+
+            schedule.ParticipantsEnrolled__c++;
+
+            serviceSchedules.put(schedule.Id, schedule);
         }
 
         if (!serviceSchedules.isEmpty()) {
-            update serviceSchedules;
+            update serviceSchedules.values();
         }
     }
 
-    private List<ServiceSchedule__c> getServiceSchedules(Set<Id> scheduleIds) {
-        return new List<ServiceSchedule__c>(
+    public void processDeletedServiceSchedules(List<ServiceParticipant__c> participants) {
+        Set<Id> serviceScheduleIds = new Set<Id>();
+        Map<Id, ServiceSchedule__c> serviceSchedules = new Map<Id, ServiceSchedule__c>();
+
+        for (ServiceParticipant__c participant : participants) {
+            serviceScheduleIds.add(participant.ServiceSchedule__c);
+        }
+
+        Map<Id, ServiceSchedule__c> schedules = new Map<Id, ServiceSchedule__c>();
+
+        schedules = getServiceSchedules(serviceScheduleIds);
+
+        for (ServiceParticipant__c serviceParticipant : participants) {
+            ServiceSchedule__c schedule = schedules.get(
+                serviceParticipant.ServiceSchedule__c
+            );
+
+            if (serviceParticipant.Status__c != ENROLLED) {
+                continue;
+            }
+
+            schedule.ParticipantsEnrolled__c--;
+
+            serviceSchedules.put(schedule.Id, schedule);
+        }
+
+        if (!serviceSchedules.isEmpty()) {
+            update serviceSchedules.values();
+        }
+    }
+
+    private Map<Id, ServiceSchedule__c> getServiceSchedules(Set<Id> scheduleIds) {
+        return new Map<Id, ServiceSchedule__c>(
             [
-                SELECT
-                    Id,
-                    ParticipantsEnrolled__c,
-                    (SELECT Id, Status__c FROM ServiceParticipants__r)
+                SELECT Id, ParticipantsEnrolled__c
                 FROM ServiceSchedule__c
                 WHERE Id IN :scheduleIds
             ]

--- a/force-app/main/default/classes/ServiceParticipantRollupsService.cls
+++ b/force-app/main/default/classes/ServiceParticipantRollupsService.cls
@@ -35,7 +35,9 @@ public with sharing class ServiceParticipantRollupsService {
         }
     }
 
-    public void processDeletedServiceSchedules(List<ServiceParticipant__c> participants) {
+    public void processDeletedServiceParticipants(
+        List<ServiceParticipant__c> participants
+    ) {
         Set<Id> serviceScheduleIds = new Set<Id>();
         Map<Id, ServiceSchedule__c> serviceSchedules = new Map<Id, ServiceSchedule__c>();
 

--- a/force-app/main/default/classes/ServiceParticipantRollupsService.cls-meta.xml
+++ b/force-app/main/default/classes/ServiceParticipantRollupsService.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>54.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/ServiceParticipantRollupsService_TEST.cls
+++ b/force-app/main/default/classes/ServiceParticipantRollupsService_TEST.cls
@@ -1,0 +1,84 @@
+/*
+ *
+ *  * Copyright (c) 2022, salesforce.com, inc.
+ *  * All rights reserved.
+ *  * SPDX-License-Identifier: BSD-3-Clause
+ *  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ *
+ */
+@IsTest
+public with sharing class ServiceParticipantRollupsService_TEST {
+    private static Id mockContactId = TestUtil.mockId(Contact.sObjectType);
+    private static Id mockEngagementId = TestUtil.mockId(
+        ProgramEngagement__c.sObjectType
+    );
+    private static Id mockServiceId = TestUtil.mockId(Service__c.sObjectType);
+
+    @TestSetup
+    private static void createTestData() {
+        // By turning off none, we turn on all
+        TestUtil.turnOffFeatureGates(new Set<String>{});
+        TestDataFactory.generateAttendanceData('Monthly');
+    }
+
+    @IsTest
+    private static void shouldUpdateParticipantsEnrolled() {
+        ServiceParticipantRollupsService rollupService = new ServiceParticipantRollupsService();
+        createTestData();
+
+        Integer expectedEnrolledParticipants = 2;
+
+        List<ServiceParticipant__c> participants = new List<ServiceParticipant__c>(
+            [SELECT Id, ServiceSchedule__c FROM ServiceParticipant__c]
+        );
+
+        Test.startTest();
+        rollupService.processParticipantRollups(participants);
+        Test.stopTest();
+
+        ServiceSchedule__c schedule = [
+            SELECT Id, ParticipantsEnrolled__c
+            FROM serviceschedule__c
+            LIMIT 1
+        ];
+
+        System.assertEquals(
+            expectedEnrolledParticipants,
+            schedule.ParticipantsEnrolled__c
+        );
+    }
+
+    @IsTest
+    private static void shouldNotUpdateParticipantsEnrolledIfStatusIsNotEnrolled() {
+        ServiceParticipantRollupsService rollupService = new ServiceParticipantRollupsService();
+        createTestData();
+
+        Integer expectedEnrolledParticipants = 1;
+
+        List<ServiceParticipant__c> participants = new List<ServiceParticipant__c>(
+            [SELECT Id, ServiceSchedule__c FROM ServiceParticipant__c]
+        );
+
+        participants[0].Status__c = 'Withdrawn';
+        update participants[0];
+
+        List<ServiceParticipant__c> updatedParticipants = new List<ServiceParticipant__c>(
+            [SELECT Id, ServiceSchedule__c FROM ServiceParticipant__c]
+        );
+
+        Test.startTest();
+        rollupService.processParticipantRollups(updatedParticipants);
+        Test.stopTest();
+
+        ServiceSchedule__c schedule = [
+            SELECT Id, ParticipantsEnrolled__c
+            FROM serviceschedule__c
+            LIMIT 1
+        ];
+
+        System.assertEquals(
+            expectedEnrolledParticipants,
+            schedule.ParticipantsEnrolled__c
+        );
+    }
+}

--- a/force-app/main/default/classes/ServiceParticipantRollupsService_TEST.cls
+++ b/force-app/main/default/classes/ServiceParticipantRollupsService_TEST.cls
@@ -8,11 +8,7 @@
  */
 @IsTest
 public with sharing class ServiceParticipantRollupsService_TEST {
-    private static Id mockContactId = TestUtil.mockId(Contact.sObjectType);
-    private static Id mockEngagementId = TestUtil.mockId(
-        ProgramEngagement__c.sObjectType
-    );
-    private static Id mockServiceId = TestUtil.mockId(Service__c.sObjectType);
+    private static ServiceParticipantRollupsService rollupService = new ServiceParticipantRollupsService();
 
     @TestSetup
     private static void createTestData() {
@@ -23,62 +19,53 @@ public with sharing class ServiceParticipantRollupsService_TEST {
 
     @IsTest
     private static void shouldUpdateParticipantsEnrolled() {
-        ServiceParticipantRollupsService rollupService = new ServiceParticipantRollupsService();
         createTestData();
-
         Integer expectedEnrolledParticipants = 2;
+        ServiceParticipantRollupsService rollupService = new ServiceParticipantRollupsService();
+
+        List<ServiceSchedule__c> schedulesToReturn = new List<ServiceSchedule__c>(
+            [
+                SELECT
+                    Id,
+                    ParticipantsEnrolled__c,
+                    (
+                        SELECT Id, Status__c
+                        FROM ServiceParticipants__r
+                        WHERE status__c = 'Enrolled'
+                    )
+                FROM ServiceSchedule__c
+                LIMIT 1
+            ]
+        );
 
         List<ServiceParticipant__c> participants = new List<ServiceParticipant__c>(
-            [SELECT Id, ServiceSchedule__c FROM ServiceParticipant__c]
+            [
+                SELECT Id, Status__c, ServiceSchedule__c
+                FROM ServiceParticipant__c
+                WHERE ServiceSchedule__c = :schedulesToReturn[0].Id
+            ]
         );
+
+        TestStub serviceScheduleSelectorStub = new StubBuilder(
+                ServiceScheduleSelector.class
+            )
+            .when('getSchedulesWithParticipants', Set<Id>.class)
+            .calledWith(new Set<Id>{ schedulesToReturn[0].Id })
+            .thenReturn(schedulesToReturn)
+            .build();
+
+        rollupService.scheduleSelector = (ServiceScheduleSelector) serviceScheduleSelectorStub.create();
 
         Test.startTest();
         rollupService.processParticipantRollups(participants);
         Test.stopTest();
 
-        ServiceSchedule__c schedule = [
-            SELECT Id, ParticipantsEnrolled__c
-            FROM serviceschedule__c
-            LIMIT 1
-        ];
-
         System.assertEquals(
             expectedEnrolledParticipants,
-            schedule.ParticipantsEnrolled__c
-        );
-    }
-
-    @IsTest
-    private static void shouldNotUpdateParticipantsEnrolledIfStatusIsNotEnrolled() {
-        ServiceParticipantRollupsService rollupService = new ServiceParticipantRollupsService();
-        createTestData();
-
-        Integer expectedEnrolledParticipants = 1;
-
-        List<ServiceParticipant__c> participants = new List<ServiceParticipant__c>(
-            [SELECT Id, ServiceSchedule__c FROM ServiceParticipant__c]
+            schedulesToReturn[0].ParticipantsEnrolled__c,
+            'Expected the number of enrolled participants to be the same as what is returned from the selector'
         );
 
-        participants[0].Status__c = 'Withdrawn';
-        update participants[0];
-
-        List<ServiceParticipant__c> updatedParticipants = new List<ServiceParticipant__c>(
-            [SELECT Id, ServiceSchedule__c FROM ServiceParticipant__c]
-        );
-
-        Test.startTest();
-        rollupService.processParticipantRollups(updatedParticipants);
-        Test.stopTest();
-
-        ServiceSchedule__c schedule = [
-            SELECT Id, ParticipantsEnrolled__c
-            FROM serviceschedule__c
-            LIMIT 1
-        ];
-
-        System.assertEquals(
-            expectedEnrolledParticipants,
-            schedule.ParticipantsEnrolled__c
-        );
+        serviceScheduleSelectorStub.assertCalledAsExpected();
     }
 }

--- a/force-app/main/default/classes/ServiceParticipantRollupsService_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/ServiceParticipantRollupsService_TEST.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>54.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/ServiceParticipantTriggerHandler.cls
+++ b/force-app/main/default/classes/ServiceParticipantTriggerHandler.cls
@@ -19,7 +19,7 @@ public with sharing class ServiceParticipantTriggerHandler {
             // when AFTER_UPDATE {
             // }
             when AFTER_DELETE {
-                rollupsService.processDeletedServiceSchedules(Trigger.old);
+                rollupsService.processDeletedServiceParticipants(Trigger.old);
             }
             // when AFTER_UNDELETE {
             // }

--- a/force-app/main/default/classes/ServiceParticipantTriggerHandler.cls
+++ b/force-app/main/default/classes/ServiceParticipantTriggerHandler.cls
@@ -16,13 +16,15 @@ public with sharing class ServiceParticipantTriggerHandler {
             when AFTER_INSERT {
                 rollupsService.processInsertedParticipants(Trigger.new);
             }
-            // when AFTER_UPDATE {
-            // }
-            when AFTER_DELETE {
-                rollupsService.processDeletedServiceParticipants(Trigger.old);
+            when AFTER_UPDATE {
+                rollupsService.processInsertedParticipants(Trigger.new);
             }
-            // when AFTER_UNDELETE {
-            // }
+            when AFTER_DELETE {
+                rollupsService.processInsertedParticipants(Trigger.old);
+            }
+            when AFTER_UNDELETE {
+                rollupsService.processInsertedParticipants(Trigger.new);
+            }
             when else {
                 return;
             }

--- a/force-app/main/default/classes/ServiceParticipantTriggerHandler.cls
+++ b/force-app/main/default/classes/ServiceParticipantTriggerHandler.cls
@@ -18,8 +18,9 @@ public with sharing class ServiceParticipantTriggerHandler {
             }
             // when AFTER_UPDATE {
             // }
-            // when AFTER_DELETE {
-            // }
+            when AFTER_DELETE {
+                rollupsService.processDeletedServiceSchedules(Trigger.old);
+            }
             // when AFTER_UNDELETE {
             // }
             when else {

--- a/force-app/main/default/classes/ServiceParticipantTriggerHandler.cls
+++ b/force-app/main/default/classes/ServiceParticipantTriggerHandler.cls
@@ -1,3 +1,11 @@
+/*
+ *
+ *  * Copyright (c) 2022, salesforce.com, inc.
+ *  * All rights reserved.
+ *  * SPDX-License-Identifier: BSD-3-Clause
+ *  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ *
+ */
 public with sharing class ServiceParticipantTriggerHandler {
     @TestVisible
     private ServiceParticipantRollupsService rollupsService = new ServiceParticipantRollupsService();

--- a/force-app/main/default/classes/ServiceParticipantTriggerHandler.cls
+++ b/force-app/main/default/classes/ServiceParticipantTriggerHandler.cls
@@ -1,0 +1,30 @@
+public with sharing class ServiceParticipantTriggerHandler {
+    @TestVisible
+    private ServiceParticipantRollupsService rollupsService = new ServiceParticipantRollupsService();
+
+    public void execute() {
+        if (!Trigger.isExecuting) {
+            return;
+        }
+
+        delegate();
+    }
+
+    @TestVisible
+    private void delegate() {
+        switch on Trigger.operationType {
+            when AFTER_INSERT {
+                rollupsService.processInsertedParticipants(Trigger.new);
+            }
+            // when AFTER_UPDATE {
+            // }
+            // when AFTER_DELETE {
+            // }
+            // when AFTER_UNDELETE {
+            // }
+            when else {
+                return;
+            }
+        }
+    }
+}

--- a/force-app/main/default/classes/ServiceParticipantTriggerHandler.cls
+++ b/force-app/main/default/classes/ServiceParticipantTriggerHandler.cls
@@ -22,16 +22,16 @@ public with sharing class ServiceParticipantTriggerHandler {
     private void delegate() {
         switch on Trigger.operationType {
             when AFTER_INSERT {
-                rollupsService.processInsertedParticipants(Trigger.new);
+                rollupsService.processParticipantRollups(Trigger.new);
             }
             when AFTER_UPDATE {
-                rollupsService.processInsertedParticipants(Trigger.new);
+                rollupsService.processParticipantRollups(Trigger.new);
             }
             when AFTER_DELETE {
-                rollupsService.processInsertedParticipants(Trigger.old);
+                rollupsService.processParticipantRollups(Trigger.old);
             }
             when AFTER_UNDELETE {
-                rollupsService.processInsertedParticipants(Trigger.new);
+                rollupsService.processParticipantRollups(Trigger.new);
             }
             when else {
                 return;

--- a/force-app/main/default/classes/ServiceParticipantTriggerHandler.cls-meta.xml
+++ b/force-app/main/default/classes/ServiceParticipantTriggerHandler.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>54.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/ServiceParticipantTriggerHandler_TEST.cls
+++ b/force-app/main/default/classes/ServiceParticipantTriggerHandler_TEST.cls
@@ -1,0 +1,172 @@
+/*
+ *
+ *  * Copyright (c) 2022, salesforce.com, inc.
+ *  * All rights reserved.
+ *  * SPDX-License-Identifier: BSD-3-Clause
+ *  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ *
+ */
+
+@IsTest
+public with sharing class ServiceParticipantTriggerHandler_TEST {
+    private static Contact contactRecord;
+    private static Service__c service;
+    public static ProgramEngagement__c engagement;
+    private static List<ServiceParticipant__c> serviceParticipants;
+    private static List<ServiceSchedule__c> serviceSchedules;
+
+    @TestSetup
+    private static void createServiceData() {
+        // By turning off none, we turn on all
+        TestUtil.turnOffFeatureGates(new Set<String>{});
+        TestDataFactory.generateAttendanceData('Monthly');
+    }
+
+    // ////////// Functional Tests //////////
+    @IsTest
+    private static void shouldIncrementParticipantEnrolledCountOnInsert() {
+        setupTest(new Set<String>{});
+        requery();
+
+        // The participant records were inserted in the setupTest method
+        System.assertEquals(4, serviceSchedules[0].ParticipantsEnrolled__c);
+    }
+
+    @IsTest
+    private static void shouldDecrementParticipantEnrolledCountOnDelete() {
+        setupTest(new Set<String>{});
+
+        Test.startTest();
+        delete serviceParticipants[0];
+        Test.stopTest();
+
+        requery();
+
+        System.assertEquals(3, serviceSchedules[0].ParticipantsEnrolled__c);
+    }
+
+    @IsTest
+    private static void shouldIncrementParticipantEnrolledCountOnUnDelete() {
+        setupTest(new Set<String>{});
+        delete serviceParticipants[0];
+
+        Test.startTest();
+        undelete serviceParticipants[0];
+        Test.stopTest();
+
+        requery();
+        System.assertEquals(4, serviceSchedules[0].ParticipantsEnrolled__c);
+    }
+
+    @IsTest
+    private static void shouldIncrementParticipantEnrolledCountOnUpdate() {
+        setupTest(new Set<String>{});
+        System.assertEquals(2, serviceSchedules[0].ParticipantsEnrolled__c);
+
+        requery();
+
+        Test.startTest();
+        serviceParticipants[3].Status__c = 'Enrolled';
+        update serviceParticipants[3];
+        Test.stopTest();
+
+        requery();
+
+        System.assertEquals(5, serviceSchedules[0].ParticipantsEnrolled__c);
+    }
+
+    @IsTest
+    private static void shouldDecrementParticipantEnrolledCountOnUpdate() {
+        setupTest(new Set<String>{});
+        System.assertEquals(2, serviceSchedules[0].ParticipantsEnrolled__c);
+
+        requery();
+
+        Test.startTest();
+        serviceParticipants[0].Status__c = 'Withdrawn';
+        update serviceParticipants[0];
+        Test.stopTest();
+
+        requery();
+
+        System.assertEquals(3, serviceSchedules[0].ParticipantsEnrolled__c);
+    }
+
+    @IsTest
+    private static void shouldCallExecuteMethod() {
+        setupTest(new Set<String>{});
+
+        Test.startTest();
+        ServiceParticipantTriggerHandler triggerHandler = new ServiceParticipantTriggerHandler();
+        triggerHandler.execute();
+        Test.stopTest();
+
+        requery();
+
+        //assert that none of the records were updated
+        System.assertEquals(4, serviceSchedules[0].ParticipantsEnrolled__c);
+    }
+
+    @IsTest
+    private static void shouldPassInvalidOperationType() {
+        setupTest(new Set<String>{});
+
+        Test.startTest();
+        new ServiceParticipantTriggerHandler().delegate();
+        Test.stopTest();
+
+        requery();
+
+        //assert that none of the records were updated
+        System.assertEquals(4, serviceSchedules[0].ParticipantsEnrolled__c);
+    }
+
+    private static void setupTest(Set<String> featureGatesToDisable) {
+        TestUtil.turnOffFeatureGates(featureGatesToDisable);
+        requery();
+
+        System.assertEquals(2, serviceSchedules[0].ParticipantsEnrolled__c);
+
+        serviceParticipants = new List<ServiceParticipant__c>{
+            new ServiceParticipant__c(
+                Name = 'Test Participant 1',
+                Contact__c = contactRecord.Id,
+                ProgramEngagement__c = engagement.Id,
+                Service__c = service.Id,
+                ServiceSchedule__c = serviceSchedules[0].Id,
+                SignUpDate__c = System.today()
+            ),
+            new ServiceParticipant__c(
+                Name = 'Test Participant 2',
+                Contact__c = contactRecord.Id,
+                ProgramEngagement__c = engagement.Id,
+                Service__c = service.Id,
+                ServiceSchedule__c = serviceSchedules[0].Id,
+                SignUpDate__c = System.today(),
+                Status__c = 'Waitlisted'
+            ),
+            new ServiceParticipant__c(
+                Name = 'Test Participant 3',
+                Contact__c = contactRecord.Id,
+                ProgramEngagement__c = engagement.Id,
+                Service__c = service.Id,
+                ServiceSchedule__c = serviceSchedules[0].Id,
+                SignUpDate__c = System.today()
+            )
+        };
+
+        insert serviceParticipants;
+    }
+
+    private static void requery() {
+        contactRecord = [SELECT Id FROM Contact LIMIT 1];
+
+        service = [SELECT Id FROM Service__c LIMIT 1];
+
+        serviceSchedules = [SELECT Id, ParticipantsEnrolled__c FROM ServiceSchedule__c];
+
+        engagement = [SELECT Id FROM ProgramEngagement__c LIMIT 1];
+
+        serviceParticipants = [SELECT Id FROM ServiceParticipant__c];
+    }
+}

--- a/force-app/main/default/classes/ServiceParticipantTriggerHandler_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/ServiceParticipantTriggerHandler_TEST.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>54.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/ServiceScheduleSelector.cls
+++ b/force-app/main/default/classes/ServiceScheduleSelector.cls
@@ -8,6 +8,8 @@
  */
 
 public with sharing class ServiceScheduleSelector {
+    private static String ENROLLED = 'Enrolled';
+
     public ServiceSchedule__c getServiceScheduleFromId(Id serviceScheduleId) {
         List<ServiceSchedule__c> serviceSchedules = getServiceSchedulesFromId(
             new Set<Id>{ serviceScheduleId }
@@ -56,5 +58,36 @@ public with sharing class ServiceScheduleSelector {
 
         return Security.stripInaccessible(AccessType.READABLE, serviceSchedules)
             .getRecords();
+    }
+
+    public List<ServiceSchedule__c> getSchedulesWithParticipants(
+        Set<Id> serviceScheduleIds
+    ) {
+        List<ServiceSchedule__c> schedules = new List<ServiceSchedule__c>();
+
+        if (
+            !(PermissionValidator.getInstance()
+                .hasObjectAccess(
+                    ServiceSchedule__c.SObjectType,
+                    PermissionValidator.CRUDAccessType.READABLE
+                ))
+        ) {
+            return new List<ServiceSchedule__c>();
+        }
+
+        schedules = [
+            SELECT
+                Id,
+                ParticipantsEnrolled__c,
+                (
+                    SELECT Id, Status__c
+                    FROM ServiceParticipants__r
+                    WHERE status__c = :ENROLLED
+                )
+            FROM ServiceSchedule__c
+            WHERE Id IN :serviceScheduleIds
+        ];
+
+        return Security.stripInaccessible(AccessType.READABLE, schedules).getRecords();
     }
 }

--- a/force-app/main/default/classes/ServiceScheduleSelector_TEST.cls
+++ b/force-app/main/default/classes/ServiceScheduleSelector_TEST.cls
@@ -79,4 +79,76 @@ public with sharing class ServiceScheduleSelector_TEST {
             }
         );
     }
+
+    @IsTest
+    private static void testGetSchedulesWithParticipants() {
+        List<ServiceSchedule__c> expectedSchedule = [
+            SELECT
+                Id,
+                ParticipantsEnrolled__c,
+                (
+                    SELECT id, status__c
+                    FROM ServiceParticipants__r
+                    WHERE status__c = 'Enrolled'
+                )
+            FROM ServiceSchedule__c
+            LIMIT 1
+        ];
+
+        Test.startTest();
+        List<ServiceSchedule__c> actualSchedule = scheduleSelector.getSchedulesWithParticipants(
+            new Set<Id>{ expectedSchedule[0].Id }
+        );
+        Test.stopTest();
+
+        System.assertEquals(
+            expectedSchedule[0].ParticipantsEnrolled__c,
+            actualSchedule[0].ParticipantsEnrolled__c,
+            'The enrolled participant count of the returned record should match the record we requested'
+        );
+    }
+
+    @IsTest
+    private static void testGetSchedulesWithParticipantsNoAccess() {
+        ServiceSchedule__c expectedSchedule = [
+            SELECT
+                Id,
+                ParticipantsEnrolled__c,
+                (
+                    SELECT id, status__c
+                    FROM ServiceParticipants__r
+                    WHERE status__c = 'Enrolled'
+                )
+            FROM ServiceSchedule__c
+            LIMIT 1
+        ];
+
+        permissionValidatorStub.withReturnValue(
+            'hasObjectAccess',
+            new List<Type>{ SObjectType.class, PermissionValidator.CRUDAccessType.class },
+            false
+        );
+
+        Test.startTest();
+        PermissionValidator.instance = (PermissionValidator) permissionValidatorStub.createMock();
+        List<ServiceSchedule__c> actualSchedule = scheduleSelector.getSchedulesWithParticipants(
+            new Set<Id>{ expectedSchedule.Id }
+        );
+        Test.stopTest();
+
+        System.assertEquals(
+            0,
+            actualSchedule.size(),
+            'Expected no rows to be returned since the user does not have access to the object'
+        );
+
+        permissionValidatorStub.assertCalledWith(
+            'hasObjectAccess',
+            new List<Type>{ SObjectType.class, PermissionValidator.CRUDAccessType.class },
+            new List<Object>{
+                ServiceSchedule__c.SObjectType,
+                PermissionValidator.CRUDAccessType.READABLE
+            }
+        );
+    }
 }

--- a/force-app/main/default/classes/TestUtil.cls
+++ b/force-app/main/default/classes/TestUtil.cls
@@ -16,7 +16,8 @@ public with sharing class TestUtil {
         'ServiceDeliveriesToContact',
         'ServiceDeliveriesToService',
         'ServiceDeliveriesToServiceSession',
-        'ServiceDeliveriesToProgramEngagement'
+        'ServiceDeliveriesToProgramEngagement',
+        'ServiceParticipantsToServiceSchedule'
     };
 
     public static final String TEST_USER_EMAIL = 'temptestuser@caseplan.example.com';

--- a/force-app/main/default/customMetadata/FeatureGate.ServiceParticipantsToServiceSchedule.md-meta.xml
+++ b/force-app/main/default/customMetadata/FeatureGate.ServiceParticipantsToServiceSchedule.md-meta.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Rollup Svc Participants to Svc Schedule</label>
+    <protected>false</protected>
+    <values>
+        <field>IsActive__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+</CustomMetadata>

--- a/force-app/main/default/layouts/ServiceSchedule__c-Service Schedule Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/ServiceSchedule__c-Service Schedule Layout.layout-meta.xml
@@ -32,6 +32,10 @@
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
+                <field>ParticipantsEnrolled__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
                 <field>DefaultServiceQuantity__c</field>
             </layoutItems>
             <layoutItems>
@@ -176,7 +180,7 @@
     <showRunAssignmentRulesCheckbox>false</showRunAssignmentRulesCheckbox>
     <showSubmitAndAttachButton>false</showSubmitAndAttachButton>
     <summaryLayout>
-        <masterLabel>00hJ00000070z0s</masterLabel>
+        <masterLabel>00h3F000007fAdK</masterLabel>
         <sizeX>4</sizeX>
         <sizeY>0</sizeY>
         <summaryLayoutStyle>Default</summaryLayoutStyle>

--- a/force-app/main/default/objects/ServiceSchedule__c/fields/ParticipantsEnrolled__c.field-meta.xml
+++ b/force-app/main/default/objects/ServiceSchedule__c/fields/ParticipantsEnrolled__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>ParticipantsEnrolled__c</fullName>
+    <externalId>false</externalId>
+    <inlineHelpText>The total number of Service Participants with Status set to Enrolled linked to this Service Schedule</inlineHelpText>
+    <label>Participants Enrolled</label>
+    <precision>18</precision>
+    <required>false</required>
+    <scale>0</scale>
+    <trackTrending>false</trackTrending>
+    <type>Number</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/permissionsets/PMDM_Deliver.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/PMDM_Deliver.permissionset-meta.xml
@@ -13,11 +13,11 @@
         <enabled>true</enabled>
     </classAccesses>
     <classAccesses>
-        <apexClass>RecentServiceSessionController</apexClass>
+        <apexClass>ProgramController</apexClass>
         <enabled>true</enabled>
     </classAccesses>
     <classAccesses>
-        <apexClass>ProgramController</apexClass>
+        <apexClass>RecentServiceSessionController</apexClass>
         <enabled>true</enabled>
     </classAccesses>
     <classAccesses>
@@ -232,6 +232,11 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
+        <editable>false</editable>
+        <field>ServiceDelivery__c.ServiceSchedule__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
         <editable>true</editable>
         <field>ServiceDelivery__c.ServiceSession__c</field>
         <readable>true</readable>
@@ -244,11 +249,6 @@
     <fieldPermissions>
         <editable>false</editable>
         <field>ServiceDelivery__c.UnitOfMeasurement__c</field>
-        <readable>true</readable>
-    </fieldPermissions>
-    <fieldPermissions>
-        <editable>false</editable>
-        <field>ServiceDelivery__c.ServiceSchedule__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
@@ -363,6 +363,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>ServiceSchedule__c.ParticipantsEnrolled__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>ServiceSchedule__c.PrimaryServiceProvider__c</field>
         <readable>true</readable>
     </fieldPermissions>
@@ -438,6 +443,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Service__c.AttendanceFieldSet__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Service__c.AttendanceRate__c</field>
         <readable>true</readable>
     </fieldPermissions>
@@ -459,11 +469,6 @@
     <fieldPermissions>
         <editable>false</editable>
         <field>Service__c.NumPresentServiceDeliveries__c</field>
-        <readable>true</readable>
-    </fieldPermissions>
-    <fieldPermissions>
-        <editable>false</editable>
-        <field>Service__c.AttendanceFieldSet__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>

--- a/force-app/main/default/permissionsets/PMDM_Manage.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/PMDM_Manage.permissionset-meta.xml
@@ -13,11 +13,11 @@
         <enabled>true</enabled>
     </classAccesses>
     <classAccesses>
-        <apexClass>RecentServiceSessionController</apexClass>
+        <apexClass>ProgramController</apexClass>
         <enabled>true</enabled>
     </classAccesses>
     <classAccesses>
-        <apexClass>ProgramController</apexClass>
+        <apexClass>RecentServiceSessionController</apexClass>
         <enabled>true</enabled>
     </classAccesses>
     <classAccesses>
@@ -232,6 +232,11 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
+        <editable>false</editable>
+        <field>ServiceDelivery__c.ServiceSchedule__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
         <editable>true</editable>
         <field>ServiceDelivery__c.ServiceSession__c</field>
         <readable>true</readable>
@@ -244,11 +249,6 @@
     <fieldPermissions>
         <editable>false</editable>
         <field>ServiceDelivery__c.UnitOfMeasurement__c</field>
-        <readable>true</readable>
-    </fieldPermissions>
-    <fieldPermissions>
-        <editable>false</editable>
-        <field>ServiceDelivery__c.ServiceSchedule__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
@@ -362,6 +362,11 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
+        <editable>false</editable>
+        <field>ServiceSchedule__c.ParticipantsEnrolled__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
         <editable>true</editable>
         <field>ServiceSchedule__c.PrimaryServiceProvider__c</field>
         <readable>true</readable>
@@ -437,6 +442,11 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
+        <editable>true</editable>
+        <field>Service__c.AttendanceFieldSet__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
         <editable>false</editable>
         <field>Service__c.AttendanceRate__c</field>
         <readable>true</readable>
@@ -459,11 +469,6 @@
     <fieldPermissions>
         <editable>false</editable>
         <field>Service__c.NumPresentServiceDeliveries__c</field>
-        <readable>true</readable>
-    </fieldPermissions>
-    <fieldPermissions>
-        <editable>true</editable>
-        <field>Service__c.AttendanceFieldSet__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>

--- a/force-app/main/default/permissionsets/PMDM_View.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/PMDM_View.permissionset-meta.xml
@@ -208,6 +208,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>ServiceDelivery__c.ServiceSchedule__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>ServiceDelivery__c.ServiceSession__c</field>
         <readable>true</readable>
     </fieldPermissions>
@@ -219,11 +224,6 @@
     <fieldPermissions>
         <editable>false</editable>
         <field>ServiceDelivery__c.UnitOfMeasurement__c</field>
-        <readable>true</readable>
-    </fieldPermissions>
-    <fieldPermissions>
-        <editable>false</editable>
-        <field>ServiceDelivery__c.ServiceSchedule__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
@@ -338,6 +338,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>ServiceSchedule__c.ParticipantsEnrolled__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>ServiceSchedule__c.PrimaryServiceProvider__c</field>
         <readable>true</readable>
     </fieldPermissions>
@@ -413,6 +418,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Service__c.AttendanceFieldSet__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Service__c.AttendanceRate__c</field>
         <readable>true</readable>
     </fieldPermissions>
@@ -434,11 +444,6 @@
     <fieldPermissions>
         <editable>false</editable>
         <field>Service__c.NumPresentServiceDeliveries__c</field>
-        <readable>true</readable>
-    </fieldPermissions>
-    <fieldPermissions>
-        <editable>false</editable>
-        <field>Service__c.AttendanceFieldSet__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>

--- a/force-app/main/default/triggers/ServiceParticipantTrigger.trigger
+++ b/force-app/main/default/triggers/ServiceParticipantTrigger.trigger
@@ -1,0 +1,8 @@
+trigger ServiceParticipantTrigger on ServiceParticipant__c(
+    after insert,
+    after update,
+    after delete,
+    after undelete
+) {
+    new ServiceParticipantTriggerHandler().execute();
+}

--- a/force-app/main/default/triggers/ServiceParticipantTrigger.trigger-meta.xml
+++ b/force-app/main/default/triggers/ServiceParticipantTrigger.trigger-meta.xml
@@ -1,0 +1,5 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>54.0</apiVersion>
+  <status>Active</status>
+</ApexTrigger>


### PR DESCRIPTION
# Critical Changes

# Changes
Created a new field called ParticipantsEnrolled on ServiceSchedule object also added help text to the field
Created a new feature gate record which will be shipped as Inactive
Modified the permission sets so users cannot edit the field
Added this field to ServiceSchedule page layout just below Participant Capacity field
Added a new trigger on the Service Participant object to roll up the number of participants whose status is set to enrolled
# Issues Closed
[W-10999445](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000utl7LYAQ/view)
# New Metadata
Participants Enrolled field on Service Schedule object
# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
~~- [ ] Any net new LWC work has Sa11y tests & 50% or above lines JEST test coverage~~  
- [x] CRUD/FLS is enforced in Apex
- [x] Permission sets are updated to account for CRUD|FLS|Tab|Classes
~~- [ ] Field sets are updated to account for new fields~~
~~- [ ] UX approval or UX not necessary~~
- [x] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: W-0000000: Work Name (https://github.com/SalesforceFoundation/PMM/pull/303)
- [ ] All **acceptance criteria** have been met
    - [x] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [x] PR contains draft release notes
- [ ] QE story level testing completed