### PR TITLE
Give Modal Heading Default Focus on Open

### DIFF
--- a/force-app/main/default/lwc/modal/modal.html
+++ b/force-app/main/default/lwc/modal/modal.html
@@ -30,22 +30,22 @@
                         size="large"
                     ></lightning-button-icon>
 
-                    <template if:true={hasHeaderString}>
-                        <h2
-                            tabindex="-1"
-                            class="slds-text-heading_medium slds-hyphenate header-string"
-                        >
-                            {header}
-                        </h2>
-                    </template>
-                    <template if:false={hasHeaderString}>
-                        <h2
-                            tabindex="-1"
-                            class="slds-text-heading_medium slds-hyphenate header-slot"
-                        >
-                            <slot name="header"></slot>
-                        </h2>
-                    </template>
+                    <h2 data-id="modal-heading-01" tabindex="-1">
+                        <template if:true={hasHeaderString}>
+                            <span
+                                class="slds-text-heading_medium slds-hyphenate header-string"
+                            >
+                                {header}
+                            </span>
+                        </template>
+                        <template if:false={hasHeaderString}>
+                            <span
+                                class="slds-text-heading_medium slds-hyphenate header-slot"
+                            >
+                                <slot name="header"></slot>
+                            </span>
+                        </template>
+                    </h2>
 
                     <p class="slds-m-top_x-small modal-hidden">
                         <slot name="tagline" onslotchange={handeSlotTaglineChange}></slot>

--- a/force-app/main/default/lwc/modal/modal.html
+++ b/force-app/main/default/lwc/modal/modal.html
@@ -31,12 +31,18 @@
                     ></lightning-button-icon>
 
                     <template if:true={hasHeaderString}>
-                        <h2 class="slds-text-heading_medium slds-hyphenate header-string">
+                        <h2
+                            tabindex="-1"
+                            class="slds-text-heading_medium slds-hyphenate header-string"
+                        >
                             {header}
                         </h2>
                     </template>
                     <template if:false={hasHeaderString}>
-                        <h2 class="slds-text-heading_medium slds-hyphenate header-slot">
+                        <h2
+                            tabindex="-1"
+                            class="slds-text-heading_medium slds-hyphenate header-slot"
+                        >
                             <slot name="header"></slot>
                         </h2>
                     </template>

--- a/force-app/main/default/lwc/modal/modal.js
+++ b/force-app/main/default/lwc/modal/modal.js
@@ -45,10 +45,10 @@ export default class Modal extends LightningElement {
 
     renderedCallback() {
         if (!this._rendered && this.defaultVisible) {
-            // eslint-disable-next-line @lwc/lwc/no-async-operation
-            this.focus(); // The focus will be reset to the first element on the page on page refresh and will
+            // The focus will be reset to the first element on the page on page refresh and will
             // take focus away from the header. Page Loads and Refreshes:
             // https://www.lightningdesignsystem.com/accessibility/guidelines/global-focus/#page-loads-refreshes
+            this.focus();
             return;
         }
         this._rendered = true;

--- a/force-app/main/default/lwc/modal/modal.js
+++ b/force-app/main/default/lwc/modal/modal.js
@@ -46,11 +46,9 @@ export default class Modal extends LightningElement {
     renderedCallback() {
         if (!this._rendered && this.defaultVisible) {
             // eslint-disable-next-line @lwc/lwc/no-async-operation
-            setTimeout(() => {
-                this.focus();
-            }, 250); // Setting a time out for when the modal is being used
-            // as a page override. After the component loads something
-            // outside of the component is taking focus.
+            this.focus(); // The focus will be reset to the first element on the page on page refresh and will
+            // take focus away from the header. Page Loads and Refreshes:
+            // https://www.lightningdesignsystem.com/accessibility/guidelines/global-focus/#page-loads-refreshes
             return;
         }
         this._rendered = true;

--- a/force-app/main/default/lwc/modal/modal.js
+++ b/force-app/main/default/lwc/modal/modal.js
@@ -43,6 +43,17 @@ export default class Modal extends LightningElement {
         return this._headerPrivate;
     }
 
+    renderedCallback() {
+        if (!this._rendered && this.defaultVisible) {
+            // eslint-disable-next-line @lwc/lwc/no-async-operation
+            setTimeout(() => {
+                this.focus();
+            }, 1000);
+            return;
+        }
+        this._rendered = true;
+    }
+
     get modalCss() {
         return (
             "slds-modal slds-fade-in-open slds-align_absolute-center" +
@@ -71,8 +82,7 @@ export default class Modal extends LightningElement {
     @api show() {
         const outerDivEl = this.template.querySelector("div");
         outerDivEl.classList.remove(MODAL_HIDDEN);
-        const header = this.template.querySelector(".slds-text-heading_medium");
-        header.focus();
+        this.focus();
     }
 
     @api hide() {
@@ -93,5 +103,14 @@ export default class Modal extends LightningElement {
     handleSlotFooterChange() {
         const footerEl = this.template.querySelector("footer");
         footerEl.classList.remove(MODAL_HIDDEN);
+    }
+
+    focus() {
+        const header = this.template.querySelector("h2");
+        if (!header) {
+            return;
+        }
+
+        header.focus();
     }
 }

--- a/force-app/main/default/lwc/modal/modal.js
+++ b/force-app/main/default/lwc/modal/modal.js
@@ -48,7 +48,9 @@ export default class Modal extends LightningElement {
             // eslint-disable-next-line @lwc/lwc/no-async-operation
             setTimeout(() => {
                 this.focus();
-            }, 1000);
+            }, 250); // Setting a time out for when the modal is being used
+            // as a page override. After the component loads something
+            // outside of the component is taking focus.
             return;
         }
         this._rendered = true;

--- a/force-app/main/default/lwc/modal/modal.js
+++ b/force-app/main/default/lwc/modal/modal.js
@@ -71,6 +71,8 @@ export default class Modal extends LightningElement {
     @api show() {
         const outerDivEl = this.template.querySelector("div");
         outerDivEl.classList.remove(MODAL_HIDDEN);
+        const header = this.template.querySelector(".slds-text-heading_medium");
+        header.focus();
     }
 
     @api hide() {


### PR DESCRIPTION
# Critical Changes

# Changes
- When a custom component opens a modal, the focus will default to the modal header. In situations where the modal is used to override new like in Service Schedules and the user refreshes the page the focus will be reset to the very beginning of the page see [Page Loads and Refreshes](https://www.lightningdesignsystem.com/accessibility/guidelines/global-focus/#page-loads-refreshes).

# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
~~Any net new LWC work has Sa11y tests & 50% or above lines JEST test coverage~~
~~CRUD/FLS is enforced in Apex~~
~~Permission sets are updated to account for CRUD|FLS|Tab|Classes~~
~~Field sets are updated to account for new fields~~
~~UX approval or UX not necessary~~
- [x] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: W-0000000: Work Name (https://github.com/SalesforceFoundation/PMM/pull/303)
- [ ] All **acceptance criteria** have been met
    - [x] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [x] PR contains draft release notes
- [ ] QE story level testing completed