### PR TITLE
W-10999493: Option to delete all service deliveries on a service session

### DIFF
--- a/force-app/main/default/aura/deleteServiceDeliveries/deleteServiceDeliveries.cmp
+++ b/force-app/main/default/aura/deleteServiceDeliveries/deleteServiceDeliveries.cmp
@@ -8,7 +8,11 @@
   -->
 
 <aura:component implements="force:lightningQuickActionWithoutHeader, force:hasRecordId">
-    <c:serviceDeliveryDeleter onclose="{!c.handleClose}" recordId="{!v.recordId}" />
+    <c:serviceDeliveryDeleter
+        oncancel="{!c.handleCancel}"
+        onclose="{!c.handleClose}"
+        recordId="{!v.recordId}"
+    />
     <aura:html tag="style">
         .cuf-content { padding: 0 0rem !important; } .slds-p-around--medium { padding:
         0rem !important; } .slds-modal__content{ overflow-y:hidden !important;

--- a/force-app/main/default/aura/deleteServiceDeliveries/deleteServiceDeliveries.cmp
+++ b/force-app/main/default/aura/deleteServiceDeliveries/deleteServiceDeliveries.cmp
@@ -8,7 +8,7 @@
   -->
 
 <aura:component implements="force:lightningQuickActionWithoutHeader, force:hasRecordId">
-    <h2>Delete Service Deliveries</h2>
+    <c:serviceDeliveryDeleter onclose="{!c.handleClose}" recordId="{!v.recordId}" />
     <aura:html tag="style">
         .cuf-content { padding: 0 0rem !important; } .slds-p-around--medium { padding:
         0rem !important; } .slds-modal__content{ overflow-y:hidden !important;

--- a/force-app/main/default/aura/deleteServiceDeliveries/deleteServiceDeliveries.cmp
+++ b/force-app/main/default/aura/deleteServiceDeliveries/deleteServiceDeliveries.cmp
@@ -1,0 +1,17 @@
+<!--
+  - /*
+  -  * Copyright (c) 2020, salesforce.com, inc.
+  -  * All rights reserved.
+  -  * SPDX-License-Identifier: BSD-3-Clause
+  -  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+  -  */
+  -->
+
+<aura:component implements="force:lightningQuickActionWithoutHeader, force:hasRecordId">
+    <h2>Delete Service Deliveries</h2>
+    <aura:html tag="style">
+        .cuf-content { padding: 0 0rem !important; } .slds-p-around--medium { padding:
+        0rem !important; } .slds-modal__content{ overflow-y:hidden !important;
+        height:unset !important; max-height:unset !important; }
+    </aura:html>
+</aura:component>

--- a/force-app/main/default/aura/deleteServiceDeliveries/deleteServiceDeliveries.cmp
+++ b/force-app/main/default/aura/deleteServiceDeliveries/deleteServiceDeliveries.cmp
@@ -1,6 +1,6 @@
 <!--
   - /*
-  -  * Copyright (c) 2020, salesforce.com, inc.
+  -  * Copyright (c) 2022, salesforce.com, inc.
   -  * All rights reserved.
   -  * SPDX-License-Identifier: BSD-3-Clause
   -  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause

--- a/force-app/main/default/aura/deleteServiceDeliveries/deleteServiceDeliveries.cmp-meta.xml
+++ b/force-app/main/default/aura/deleteServiceDeliveries/deleteServiceDeliveries.cmp-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>54.0</apiVersion>
+    <description>Support Quick Action to delete Service Deliveries</description>
+</AuraDefinitionBundle>

--- a/force-app/main/default/aura/deleteServiceDeliveries/deleteServiceDeliveriesController.js
+++ b/force-app/main/default/aura/deleteServiceDeliveries/deleteServiceDeliveriesController.js
@@ -9,6 +9,10 @@
 ({
     handleClose: function(component, event, helper) {
         $A.get("e.force:closeQuickAction").fire();
-        $A.get("e.force:refreshView").fire();
+        window.location.reload();
+    },
+
+    handleCancel: function(component, event, helper) {
+        $A.get("e.force:closeQuickAction").fire();
     }
 });

--- a/force-app/main/default/aura/deleteServiceDeliveries/deleteServiceDeliveriesController.js
+++ b/force-app/main/default/aura/deleteServiceDeliveries/deleteServiceDeliveriesController.js
@@ -1,0 +1,14 @@
+/*
+ *  * Copyright (c) 2022, salesforce.com, inc.
+ *  * All rights reserved.
+ *  * SPDX-License-Identifier: BSD-3-Clause
+ *  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ *
+ */
+
+({
+    handleClose: function(component, event, helper) {
+        $A.get("e.force:closeQuickAction").fire();
+        $A.get("e.force:refreshView").fire();
+    }
+});

--- a/force-app/main/default/classes/ServiceDeliveryController.cls
+++ b/force-app/main/default/classes/ServiceDeliveryController.cls
@@ -15,6 +15,24 @@ public with sharing class ServiceDeliveryController {
     @TestVisible
     private static ServiceDeliveryDomain deliveryDomain = new ServiceDeliveryDomain();
 
+    @AuraEnabled(cacheable=true)
+    public static Boolean canDeleteServiceDeliveries() {
+        try {
+            if (
+                !(PermissionValidator.getInstance()
+                    .hasObjectAccess(
+                        ServiceDelivery__c.SObjectType,
+                        PermissionValidator.CRUDAccessType.DELETEABLE
+                    ))
+            ) {
+                return false;
+            }
+        } catch (Exception e) {
+            throw Util.getAuraHandledException(e);
+        }
+        return true;
+    }
+
     @AuraEnabled
     public static Integer deleteServiceDeliveriesForSession(Id sessionId) {
         try {

--- a/force-app/main/default/classes/ServiceDeliveryController.cls
+++ b/force-app/main/default/classes/ServiceDeliveryController.cls
@@ -12,7 +12,24 @@ public with sharing class ServiceDeliveryController {
     @TestVisible
     private static ServiceDeliverySelector deliverySelector = new ServiceDeliverySelector();
 
+    @TestVisible
+    private static ServiceDeliveryDomain deliveryDomain = new ServiceDeliveryDomain();
+
     @AuraEnabled
+    public static Integer deleteServiceDeliveriesForSession(Id sessionId) {
+        try {
+            List<ServiceDelivery__c> deliveries = deliverySelector.getServiceDeliveriesForSession(
+                sessionId
+            );
+
+            deliveryDomain.deleteServiceDeliveries(deliveries);
+            return deliveries.size();
+        } catch (Exception e) {
+            throw Util.getAuraHandledException(e);
+        }
+    }
+
+    @AuraEnabled(cacheable=true)
     public static Integer getNumberOfServiceDeliveriesForSession(Id sessionId) {
         try {
             return deliverySelector.getNumberOfServiceDeliveriesForSession(sessionId);
@@ -20,6 +37,7 @@ public with sharing class ServiceDeliveryController {
             throw Util.getAuraHandledException(e);
         }
     }
+
     //removed cacheable = true so the picklist values will be rendered when
     //a new program engagement record is created
     @AuraEnabled

--- a/force-app/main/default/classes/ServiceDeliveryController.cls
+++ b/force-app/main/default/classes/ServiceDeliveryController.cls
@@ -9,7 +9,17 @@
 
 public with sharing class ServiceDeliveryController {
     public static ServiceService service = new ServiceService();
+    @TestVisible
+    private static ServiceDeliverySelector deliverySelector = new ServiceDeliverySelector();
 
+    @AuraEnabled
+    public static Integer getNumberOfServiceDeliveriesForSession(Id sessionId) {
+        try {
+            return deliverySelector.getNumberOfServiceDeliveriesForSession(sessionId);
+        } catch (Exception e) {
+            throw Util.getAuraHandledException(e);
+        }
+    }
     //removed cacheable = true so the picklist values will be rendered when
     //a new program engagement record is created
     @AuraEnabled

--- a/force-app/main/default/classes/ServiceDeliveryController_TEST.cls
+++ b/force-app/main/default/classes/ServiceDeliveryController_TEST.cls
@@ -12,6 +12,96 @@ public with sharing class ServiceDeliveryController_TEST {
     private static BasicStub serviceStub = new BasicStub(ServiceService.class);
     private static BasicStub selectorStub = new BasicStub(ServiceDeliverySelector.class);
     private static BasicStub domainStub = new BasicStub(ServiceDeliveryDomain.class);
+    private static BasicStub validatorStub = new BasicStub(PermissionValidator.class);
+
+    @IsTest
+    private static void testCanDeleteServiceDeliveriesWithAccess() {
+        validatorStub.withReturnValue(
+            'hasObjectAccess',
+            new List<Type>{ SObjectType.class, PermissionValidator.CRUDAccessType.class },
+            true
+        );
+
+        Test.startTest();
+        PermissionValidator.instance = (PermissionValidator) validatorStub.createMock();
+        Boolean hasAccess = ServiceDeliveryController.canDeleteServiceDeliveries();
+        Test.stopTest();
+
+        System.assert(
+            hasAccess,
+            'Controller should allow delete when user has delete access on object.'
+        );
+
+        validatorStub.assertCalledWith(
+            'hasObjectAccess',
+            new List<Type>{ SObjectType.class, PermissionValidator.CRUDAccessType.class },
+            new List<Object>{
+                ServiceDelivery__c.SObjectType,
+                PermissionValidator.CRUDAccessType.DELETEABLE
+            }
+        );
+    }
+
+    @IsTest
+    private static void testCanDeleteServiceDeliveriesNoAccess() {
+        validatorStub.withReturnValue(
+            'hasObjectAccess',
+            new List<Type>{ SObjectType.class, PermissionValidator.CRUDAccessType.class },
+            false
+        );
+
+        Test.startTest();
+        PermissionValidator.instance = (PermissionValidator) validatorStub.createMock();
+        Boolean hasAccess = ServiceDeliveryController.canDeleteServiceDeliveries();
+        Test.stopTest();
+
+        System.assert(
+            !hasAccess,
+            'Controller should NOT allow delete when user lacks delete access on object.'
+        );
+
+        validatorStub.assertCalledWith(
+            'hasObjectAccess',
+            new List<Type>{ SObjectType.class, PermissionValidator.CRUDAccessType.class },
+            new List<Object>{
+                ServiceDelivery__c.SObjectType,
+                PermissionValidator.CRUDAccessType.DELETEABLE
+            }
+        );
+    }
+
+    @IsTest
+    private static void testCanDeleteServiceDeliveriesException() {
+        validatorStub.withThrowException(
+            'hasObjectAccess',
+            new List<Type>{ SObjectType.class, PermissionValidator.CRUDAccessType.class }
+        );
+
+        Test.startTest();
+        PermissionValidator.instance = (PermissionValidator) validatorStub.createMock();
+        Exception actualException;
+        try {
+            Boolean hasAccess = ServiceDeliveryController.canDeleteServiceDeliveries();
+        } catch (Exception e) {
+            actualException = e;
+        }
+        Test.stopTest();
+
+        System.assertEquals(
+            validatorStub.testExceptionMessage,
+            actualException.getMessage(),
+            'Expected the controller to rethrow the exception from the validator.'
+        );
+
+        validatorStub.assertCalledWith(
+            'hasObjectAccess',
+            new List<Type>{ SObjectType.class, PermissionValidator.CRUDAccessType.class },
+            new List<Object>{
+                ServiceDelivery__c.SObjectType,
+                PermissionValidator.CRUDAccessType.DELETEABLE
+            }
+        );
+    }
 
     @IsTest
     private static void testDeleteServiceDeliveriesForSessionException() {

--- a/force-app/main/default/classes/ServiceDeliveryController_TEST.cls
+++ b/force-app/main/default/classes/ServiceDeliveryController_TEST.cls
@@ -145,7 +145,7 @@ public with sharing class ServiceDeliveryController_TEST {
         System.assertEquals(
             expectedServiceDeliveries.size(),
             actualNumberDeleted,
-            'The controller should return that the expected count of deliveries were deleted'
+            'The controller should return the expected count of deliveries that were deleted'
         );
         domainStub.assertCalledWith(
             'deleteServiceDeliveries',

--- a/force-app/main/default/classes/ServiceDeliveryController_TEST.cls
+++ b/force-app/main/default/classes/ServiceDeliveryController_TEST.cls
@@ -10,6 +10,178 @@
 @IsTest
 public with sharing class ServiceDeliveryController_TEST {
     private static BasicStub serviceStub = new BasicStub(ServiceService.class);
+    private static BasicStub selectorStub = new BasicStub(ServiceDeliverySelector.class);
+    private static BasicStub domainStub = new BasicStub(ServiceDeliveryDomain.class);
+
+    @IsTest
+    private static void testDeleteServiceDeliveriesForSessionException() {
+        List<ServiceDelivery__c> expectedServiceDeliveries = new List<ServiceDelivery__c>{
+            new ServiceDelivery__c(
+                Name = 'Test1',
+                Id = TestUtil.mockId(ServiceDelivery__c.SObjectType)
+            ),
+            new ServiceDelivery__c(
+                Name = 'Test2',
+                Id = TestUtil.mockId(ServiceDelivery__c.SObjectType)
+            ),
+            new ServiceDelivery__c(
+                Name = 'Test3',
+                Id = TestUtil.mockId(ServiceDelivery__c.SObjectType)
+            )
+        };
+        Id sessionId = TestUtil.mockId(ServiceSession__c.SObjectType);
+        selectorStub.withReturnValue(
+            'getServiceDeliveriesForSession',
+            Id.class,
+            expectedServiceDeliveries
+        );
+
+        domainStub.withThrowException(
+            'deleteServiceDeliveries',
+            List<ServiceDelivery__c>.class
+        );
+
+        Test.startTest();
+        ServiceDeliveryController.deliverySelector = (ServiceDeliverySelector) selectorStub.createMock();
+        ServiceDeliveryController.deliveryDomain = (ServiceDeliveryDomain) domainStub.createMock();
+
+        Exception actualException;
+        try {
+            final Integer actualNumberDeleted = ServiceDeliveryController.deleteServiceDeliveriesForSession(
+                sessionId
+            );
+        } catch (Exception e) {
+            actualException = e;
+        }
+        Test.stopTest();
+
+        System.assertEquals(
+            domainStub.testExceptionMessage,
+            actualException.getMessage(),
+            'Expected the controller to rethrow the exception from the domain.'
+        );
+        domainStub.assertCalledWith(
+            'deleteServiceDeliveries',
+            List<ServiceDelivery__c>.class,
+            expectedServiceDeliveries
+        );
+        selectorStub.assertCalledWith(
+            'getServiceDeliveriesForSession',
+            Id.class,
+            sessionId
+        );
+    }
+
+    @IsTest
+    private static void testGetNumberOfServiceDeliveriesForSessionException() {
+        Id sessionId = TestUtil.mockId(ServiceSession__c.SObjectType);
+        selectorStub.withThrowException(
+            'getNumberOfServiceDeliveriesForSession',
+            Id.class
+        );
+
+        Test.startTest();
+        ServiceDeliveryController.deliverySelector = (ServiceDeliverySelector) selectorStub.createMock();
+        Exception actualException;
+        try {
+            final Integer actualNumberOfDeliveries = ServiceDeliveryController.getNumberOfServiceDeliveriesForSession(
+                sessionId
+            );
+        } catch (Exception e) {
+            actualException = e;
+        }
+        Test.stopTest();
+
+        System.assertEquals(
+            selectorStub.testExceptionMessage,
+            actualException.getMessage(),
+            'Expected the controller to rethrow the exception from the selector.'
+        );
+
+        selectorStub.assertCalledWith(
+            'getNumberOfServiceDeliveriesForSession',
+            Id.class,
+            sessionId
+        );
+    }
+
+    @IsTest
+    private static void testDeleteServiceDeliveriesForSession() {
+        List<ServiceDelivery__c> expectedServiceDeliveries = new List<ServiceDelivery__c>{
+            new ServiceDelivery__c(
+                Name = 'Test1',
+                Id = TestUtil.mockId(ServiceDelivery__c.SObjectType)
+            ),
+            new ServiceDelivery__c(
+                Name = 'Test2',
+                Id = TestUtil.mockId(ServiceDelivery__c.SObjectType)
+            ),
+            new ServiceDelivery__c(
+                Name = 'Test3',
+                Id = TestUtil.mockId(ServiceDelivery__c.SObjectType)
+            )
+        };
+        Id sessionId = TestUtil.mockId(ServiceSession__c.SObjectType);
+        selectorStub.withReturnValue(
+            'getServiceDeliveriesForSession',
+            Id.class,
+            expectedServiceDeliveries
+        );
+
+        domainStub.withReturnValue(
+            'deleteServiceDeliveries',
+            List<ServiceDelivery__c>.class,
+            null
+        );
+
+        Test.startTest();
+        ServiceDeliveryController.deliverySelector = (ServiceDeliverySelector) selectorStub.createMock();
+        ServiceDeliveryController.deliveryDomain = (ServiceDeliveryDomain) domainStub.createMock();
+        final Integer actualNumberDeleted = ServiceDeliveryController.deleteServiceDeliveriesForSession(
+            sessionId
+        );
+        Test.stopTest();
+
+        System.assertEquals(
+            expectedServiceDeliveries.size(),
+            actualNumberDeleted,
+            'The controller should return that the expected count of deliveries were deleted'
+        );
+        domainStub.assertCalledWith(
+            'deleteServiceDeliveries',
+            List<ServiceDelivery__c>.class,
+            expectedServiceDeliveries
+        );
+        selectorStub.assertCalledWith(
+            'getServiceDeliveriesForSession',
+            Id.class,
+            sessionId
+        );
+    }
+
+    @IsTest
+    private static void testGetNumberOfServiceDeliveriesForSession() {
+        Integer expectedNumberOfDeliveries = 5;
+        Id sessionId = TestUtil.mockId(ServiceSession__c.SObjectType);
+        selectorStub.withReturnValue(
+            'getNumberOfServiceDeliveriesForSession',
+            Id.class,
+            expectedNumberOfDeliveries
+        );
+
+        Test.startTest();
+        ServiceDeliveryController.deliverySelector = (ServiceDeliverySelector) selectorStub.createMock();
+        final Integer actualNumberOfDeliveries = ServiceDeliveryController.getNumberOfServiceDeliveriesForSession(
+            sessionId
+        );
+        Test.stopTest();
+
+        System.assertEquals(
+            expectedNumberOfDeliveries,
+            actualNumberOfDeliveries,
+            'The controller should return the expected count of deliveries'
+        );
+    }
 
     @IsTest
     private static void testGetServicesAndEngagements() {

--- a/force-app/main/default/classes/ServiceDeliveryDomain.cls
+++ b/force-app/main/default/classes/ServiceDeliveryDomain.cls
@@ -28,6 +28,24 @@ public with sharing class ServiceDeliveryDomain {
         updateServiceDeliveries(deliveriesToUpdate);
     }
 
+    public void deleteServiceDeliveries(List<ServiceDelivery__c> serviceDeliveries) {
+        if (serviceDeliveries.isEmpty()) {
+            return;
+        }
+
+        if (
+            !PermissionValidator.getInstance()
+                .hasObjectAccess(
+                    ServiceDelivery__c.SObjectType,
+                    PermissionValidator.CRUDAccessType.DELETEABLE
+                )
+        ) {
+            throw new ServiceDeliveryDomainException(Label.Delete_Operation_Exception);
+        }
+
+        delete serviceDeliveries;
+    }
+
     public void insertServiceDeliveries(List<ServiceDelivery__c> serviceDeliveries) {
         if (serviceDeliveries.isEmpty()) {
             return;

--- a/force-app/main/default/classes/ServiceDeliveryDomain_TEST.cls
+++ b/force-app/main/default/classes/ServiceDeliveryDomain_TEST.cls
@@ -12,6 +12,107 @@ private with sharing class ServiceDeliveryDomain_TEST {
     private static BasicStub validatorStub = new BasicStub(PermissionValidator.class);
 
     @IsTest
+    private static void shouldNotThrowExceptionWithoutDeletePermissionsOnEmptyList() {
+        String methodName = 'hasObjectAccess';
+        Integer dmlLimitAfter;
+        Exception actualException;
+
+        validatorStub.withReturnValue(
+            methodName,
+            new List<Type>{ SObjectType.class, PermissionValidator.CRUDAccessType.class },
+            false
+        );
+
+        PermissionValidator.instance = (PermissionValidator) validatorStub.createMock();
+        List<ServiceDelivery__c> serviceDeliveriesToDelete = new List<ServiceDelivery__c>();
+
+        Test.startTest();
+        try {
+            new ServiceDeliveryDomain()
+                .deleteServiceDeliveries(serviceDeliveriesToDelete);
+            dmlLimitAfter = System.Limits.getDmlStatements();
+        } catch (Exception ex) {
+            actualException = ex;
+        }
+        Test.stopTest();
+
+        System.assertEquals(
+            null,
+            actualException,
+            'Did not expect the domain to throw the exception for an empty list.'
+        );
+
+        System.assertEquals(
+            0,
+            dmlLimitAfter,
+            'Did not expect any dml statements for an empty list.'
+        );
+    }
+
+    @IsTest
+    private static void shouldDeleteServiceDeliveries() {
+        TestDataFactory.generateServiceData();
+
+        List<ServiceDelivery__c> existingServiceDeliveries = [
+            SELECT Id, Name
+            FROM ServiceDelivery__c
+        ];
+
+        Test.startTest();
+        new ServiceDeliveryDomain().deleteServiceDeliveries(existingServiceDeliveries);
+        Test.stopTest();
+
+        List<ServiceDelivery__c> serviceDeliveriesAfter = [
+            SELECT Id, Name
+            FROM ServiceDelivery__c
+        ];
+        System.assertEquals(
+            0,
+            serviceDeliveriesAfter.size(),
+            'Service Delivery reocords should have been deleted.'
+        );
+    }
+
+    @IsTest
+    private static void shouldThrowExceptionWhenDeletePermissionCheckFails() {
+        String methodName = 'hasObjectAccess';
+        Integer dmlLimitAfter;
+        Exception actualException;
+
+        validatorStub.withReturnValue(
+            methodName,
+            new List<Type>{ SObjectType.class, PermissionValidator.CRUDAccessType.class },
+            false
+        );
+
+        PermissionValidator.instance = (PermissionValidator) validatorStub.createMock();
+        List<ServiceDelivery__c> serviceDeliveriesToDelete = new List<ServiceDelivery__c>{
+            new ServiceDelivery__c(Name = 'Test Upsert Failure.')
+        };
+
+        Test.startTest();
+        try {
+            new ServiceDeliveryDomain()
+                .deleteServiceDeliveries(serviceDeliveriesToDelete);
+        } catch (Exception ex) {
+            dmlLimitAfter = System.Limits.getDmlStatements();
+            actualException = ex;
+        }
+        Test.stopTest();
+
+        System.assert(
+            actualException instanceof ServiceDeliveryDomain.ServiceDeliveryDomainException,
+            'Expected the domain to throw the exception.'
+        );
+
+        System.assertEquals(
+            0,
+            dmlLimitAfter,
+            'Expected the exception to be thrown before any dml statements.'
+        );
+    }
+
+    @IsTest
     private static void shouldUpsertServiceDeliveries() {
         TestDataFactory.generateServiceData();
         Service__c service = [SELECT Id FROM Service__c LIMIT 1];

--- a/force-app/main/default/classes/ServiceDeliverySelector.cls
+++ b/force-app/main/default/classes/ServiceDeliverySelector.cls
@@ -10,6 +10,14 @@
 public with sharing class ServiceDeliverySelector {
     private QueryBuilder queryBuilder = new QueryBuilder();
 
+    public Integer getNumberOfServiceDeliveriesForSession(Id sessionId) {
+        return [
+            SELECT COUNT()
+            FROM ServiceDelivery__c
+            WHERE ServiceSession__c = :sessionId
+        ];
+    }
+
     public String getAttendanceFieldSetName(Id scheduleId) {
         // We want to bypass FLS because this is a system field that drives our UI
         List<ServiceSchedule__c> schedules = [

--- a/force-app/main/default/classes/ServiceDeliverySelector.cls
+++ b/force-app/main/default/classes/ServiceDeliverySelector.cls
@@ -11,7 +11,13 @@ public with sharing class ServiceDeliverySelector {
     private QueryBuilder queryBuilder = new QueryBuilder();
 
     public Integer getNumberOfServiceDeliveriesForSession(Id sessionId) {
-        if (!Schema.SObjectType.ServiceDelivery__c.isAccessible()) {
+        if (
+            !(PermissionValidator.getInstance()
+                .hasObjectAccess(
+                    ServiceDelivery__c.SObjectType,
+                    PermissionValidator.CRUDAccessType.READABLE
+                ))
+        ) {
             return 0;
         }
 
@@ -23,7 +29,13 @@ public with sharing class ServiceDeliverySelector {
     }
 
     public List<ServiceDelivery__c> getServiceDeliveriesForSession(Id sessionId) {
-        if (!Schema.SObjectType.ServiceDelivery__c.isAccessible()) {
+        if (
+            !(PermissionValidator.getInstance()
+                .hasObjectAccess(
+                    ServiceDelivery__c.SObjectType,
+                    PermissionValidator.CRUDAccessType.READABLE
+                ))
+        ) {
             return new List<ServiceDelivery__c>();
         }
 

--- a/force-app/main/default/classes/ServiceDeliverySelector.cls
+++ b/force-app/main/default/classes/ServiceDeliverySelector.cls
@@ -18,6 +18,10 @@ public with sharing class ServiceDeliverySelector {
         ];
     }
 
+    public List<ServiceDelivery__c> getServiceDeliveriesForSession(Id sessionId) {
+        return [SELECT Id FROM ServiceDelivery__c WHERE ServiceSession__c = :sessionId];
+    }
+
     public String getAttendanceFieldSetName(Id scheduleId) {
         // We want to bypass FLS because this is a system field that drives our UI
         List<ServiceSchedule__c> schedules = [

--- a/force-app/main/default/classes/ServiceDeliverySelector.cls
+++ b/force-app/main/default/classes/ServiceDeliverySelector.cls
@@ -11,6 +11,10 @@ public with sharing class ServiceDeliverySelector {
     private QueryBuilder queryBuilder = new QueryBuilder();
 
     public Integer getNumberOfServiceDeliveriesForSession(Id sessionId) {
+        if (!Schema.SObjectType.ServiceDelivery__c.isAccessible()) {
+            return 0;
+        }
+
         return [
             SELECT COUNT()
             FROM ServiceDelivery__c
@@ -19,6 +23,10 @@ public with sharing class ServiceDeliverySelector {
     }
 
     public List<ServiceDelivery__c> getServiceDeliveriesForSession(Id sessionId) {
+        if (!Schema.SObjectType.ServiceDelivery__c.isAccessible()) {
+            return new List<ServiceDelivery__c>();
+        }
+
         return [SELECT Id FROM ServiceDelivery__c WHERE ServiceSession__c = :sessionId];
     }
 

--- a/force-app/main/default/classes/ServiceDeliverySelector_TEST.cls
+++ b/force-app/main/default/classes/ServiceDeliverySelector_TEST.cls
@@ -19,6 +19,135 @@ public with sharing class ServiceDeliverySelector_TEST {
     }
 
     @IsTest
+    private static void testGetNumberOfServiceDeliveriesForSessionNoAccess() {
+        Id sessionId = [SELECT Id FROM ServiceSession__c LIMIT 1].Id;
+
+        validatorStub.withReturnValue(
+            'hasObjectAccess',
+            new List<Type>{ SObjectType.class, PermissionValidator.CRUDAccessType.class },
+            false
+        );
+
+        Test.startTest();
+        PermissionValidator.instance = (PermissionValidator) validatorStub.createMock();
+        Integer actualNumberOfDeliveries = selector.getNumberOfServiceDeliveriesForSession(
+            sessionId
+        );
+        Test.stopTest();
+
+        System.assertEquals(
+            0,
+            actualNumberOfDeliveries,
+            'Expected 0 count of service deliveries since the user does not have access to the object'
+        );
+
+        validatorStub.assertCalledWith(
+            'hasObjectAccess',
+            new List<Type>{ SObjectType.class, PermissionValidator.CRUDAccessType.class },
+            new List<Object>{
+                ServiceDelivery__c.SObjectType,
+                PermissionValidator.CRUDAccessType.READABLE
+            }
+        );
+    }
+
+    @IsTest
+    private static void testGetServiceDeliveriesForSessionNoAccess() {
+        Id sessionId = [SELECT Id FROM ServiceSession__c LIMIT 1].Id;
+
+        validatorStub.withReturnValue(
+            'hasObjectAccess',
+            new List<Type>{ SObjectType.class, PermissionValidator.CRUDAccessType.class },
+            false
+        );
+
+        Test.startTest();
+        PermissionValidator.instance = (PermissionValidator) validatorStub.createMock();
+        List<ServiceDelivery__c> actualDeliveries = selector.getServiceDeliveriesForSession(
+            sessionId
+        );
+        Test.stopTest();
+
+        System.assertEquals(
+            0,
+            actualDeliveries.size(),
+            'Expected empty list of service deliveries since the user does not have access to the object'
+        );
+
+        validatorStub.assertCalledWith(
+            'hasObjectAccess',
+            new List<Type>{ SObjectType.class, PermissionValidator.CRUDAccessType.class },
+            new List<Object>{
+                ServiceDelivery__c.SObjectType,
+                PermissionValidator.CRUDAccessType.READABLE
+            }
+        );
+    }
+
+    @IsTest
+    private static void testGetNumberOfServiceDeliveriesForSession() {
+        Id sessionId = [SELECT Id FROM ServiceSession__c LIMIT 1].Id;
+
+        Integer expectedNumberOfDeliveries = ([
+                SELECT Id
+                FROM ServiceDelivery__c
+                WHERE ServiceSession__c = :sessionId
+            ])
+            .size();
+        Test.startTest();
+        Integer actualNumberOfDeliveries = selector.getNumberOfServiceDeliveriesForSession(
+            sessionId
+        );
+        Test.stopTest();
+
+        System.assertNotEquals(
+            0,
+            actualNumberOfDeliveries,
+            'There should be more than 0 matching service deliveries for a valid test'
+        );
+
+        System.assertEquals(
+            expectedNumberOfDeliveries,
+            actualNumberOfDeliveries,
+            'The selector should have returned the expected count of service deliveries'
+        );
+    }
+
+    @IsTest
+    private static void testGetServiceDeliveriesForSession() {
+        Id sessionId = [SELECT Id FROM ServiceSession__c LIMIT 1].Id;
+
+        List<ServiceDelivery__c> expectedDeliveries = [
+            SELECT Id
+            FROM ServiceDelivery__c
+            WHERE ServiceSession__c = :sessionId
+        ];
+        Test.startTest();
+        List<ServiceDelivery__c> actualDeliveries = selector.getServiceDeliveriesForSession(
+            sessionId
+        );
+        Test.stopTest();
+
+        System.assertNotEquals(
+            0,
+            actualDeliveries.size(),
+            'There should be more than 0 matching service deliveries for a valid test'
+        );
+
+        System.assertEquals(
+            expectedDeliveries.size(),
+            actualDeliveries.size(),
+            'The selector should have returned the expected count of service deliveries'
+        );
+
+        Set<Id> expectedDeliveryIds = new Map<Id, ServiceDelivery__c>(expectedDeliveries)
+            .keySet();
+        for (ServiceDelivery__c delivery : actualDeliveries) {
+            System.assert(expectedDeliveryIds.contains(delivery.Id));
+        }
+    }
+
+    @IsTest
     private static void getServiceDeliveriesFiltersWithClient() {
         List<ServiceDelivery__c> actualDeliveries;
         Id sessionId = [SELECT Id FROM ServiceSession__c LIMIT 1].Id;

--- a/force-app/main/default/flexipages/Service_Schedule_Record_Page.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/Service_Schedule_Record_Page.flexipage-meta.xml
@@ -17,7 +17,7 @@
                 </componentInstanceProperties>
                 <componentInstanceProperties>
                     <name>numVisibleActions</name>
-                    <value>3</value>
+                    <value>4</value>
                 </componentInstanceProperties>
                 <componentName>force:highlightsPanel</componentName>
             </componentInstance>

--- a/force-app/main/default/labels/CustomLabels.labels-meta.xml
+++ b/force-app/main/default/labels/CustomLabels.labels-meta.xml
@@ -288,7 +288,7 @@
         <language>en_US</language>
         <protected>true</protected>
         <shortDescription>Delete related Service Deliveries?</shortDescription>
-        <value>Delete Related Service Deliveries</value>
+        <value>Delete Related Service Deliveries?</value>
     </labels>
         <labels>
         <fullName>Delete_Service_Deliveries_Confirm</fullName>

--- a/force-app/main/default/labels/CustomLabels.labels-meta.xml
+++ b/force-app/main/default/labels/CustomLabels.labels-meta.xml
@@ -282,7 +282,7 @@
         <protected>true</protected>
         <shortDescription>Delete Future Service Sessions</shortDescription>
         <value>Delete Future Service Sessions</value>
-    </labels>
+    </labels>  
     <labels>
         <fullName>Delete_Service_Deliveries</fullName>
         <language>en_US</language>

--- a/force-app/main/default/labels/CustomLabels.labels-meta.xml
+++ b/force-app/main/default/labels/CustomLabels.labels-meta.xml
@@ -284,6 +284,20 @@
         <value>Delete Future Service Sessions</value>
     </labels>
     <labels>
+        <fullName>Delete_Service_Deliveries</fullName>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>Delete Related Service Deliveries</shortDescription>
+        <value>Delete Related Service Deliveries</value>
+    </labels>
+        <labels>
+        <fullName>Delete_Service_Deliveries_Confirm</fullName>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>Delete Related Service Deliveries Confirmation</shortDescription>
+        <value>Are you sure you want to delete all {0} service deliveries associated with this session? You will no longer be able to view or report on these service deliveries.</value>
+    </labels>
+    <labels>
         <fullName>Delete_Sessions_Success</fullName>
         <language>en_US</language>
         <protected>true</protected>

--- a/force-app/main/default/labels/CustomLabels.labels-meta.xml
+++ b/force-app/main/default/labels/CustomLabels.labels-meta.xml
@@ -287,7 +287,7 @@
         <fullName>Delete_Service_Deliveries</fullName>
         <language>en_US</language>
         <protected>true</protected>
-        <shortDescription>Delete Related Service Deliveries</shortDescription>
+        <shortDescription>Delete related Service Deliveries?</shortDescription>
         <value>Delete Related Service Deliveries</value>
     </labels>
         <labels>
@@ -295,7 +295,7 @@
         <language>en_US</language>
         <protected>true</protected>
         <shortDescription>Delete Related Service Deliveries Confirmation</shortDescription>
-        <value>Are you sure you want to delete all {0} service deliveries associated with this session? You will no longer be able to view or report on these service deliveries.</value>
+        <value>You are about to delete {0} Service Deliveries associated with this Service Session. You won&apos;t be able to view or report on the Service Deliveries later.</value>
     </labels>
     <labels>
         <fullName>Delete_Sessions_Success</fullName>

--- a/force-app/main/default/layouts/ServiceSession__c-Service Session Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/ServiceSession__c-Service Session Layout.layout-meta.xml
@@ -90,6 +90,11 @@
             <actionType>StandardButton</actionType>
             <sortOrder>1</sortOrder>
         </platformActionListItems>
+        <platformActionListItems>
+            <actionName>ServiceSession__c.Delete_All_Service_Deliveries</actionName>
+            <actionType>QuickAction</actionType>
+            <sortOrder>2</sortOrder>
+        </platformActionListItems>        
     </platformActionList>
     <relatedLists>
         <excludeButtons>MassChangeOwner</excludeButtons>

--- a/force-app/main/default/lwc/serviceDeliveryDeleter/serviceDeliveryDeleter.html
+++ b/force-app/main/default/lwc/serviceDeliveryDeleter/serviceDeliveryDeleter.html
@@ -1,0 +1,43 @@
+<!--
+  - /*
+  -  * Copyright (c) 2022, salesforce.com, inc.
+  -  * All rights reserved.
+  -  * SPDX-License-Identifier: BSD-3-Clause
+  -  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+  -  */
+  -->
+
+<template>
+    <header class="slds-modal__header">
+        <h2 id="modal-heading-01" class="slds-modal__title slds-hyphenate">
+            {labels.header}
+        </h2>
+    </header>
+    <div class="slds-modal__content slds-p-around_medium" id="modal-content-id-1">
+        <p>{numberOfDeliveries}</p>
+        <p>{labels.message}</p>
+        <template if:true={errorMessage}>
+            <c-scoped-notification
+                theme="error"
+                title={errorMessage}
+                class="slds-var-p-around_small"
+            ></c-scoped-notification
+        ></template>
+    </div>
+    <footer class="slds-modal__footer">
+        <lightning-button
+            onclick={handleCancel}
+            label={labels.cancel}
+            title={labels.cancel}
+        ></lightning-button>
+        <lightning-button
+            label={labels.delete}
+            title={labels.delete}
+            variant="brand"
+            onclick={handleDelete}
+            class="slds-m-left_x-small"
+            disabled={isDisabled}
+        >
+        </lightning-button>
+    </footer>
+</template>

--- a/force-app/main/default/lwc/serviceDeliveryDeleter/serviceDeliveryDeleter.html
+++ b/force-app/main/default/lwc/serviceDeliveryDeleter/serviceDeliveryDeleter.html
@@ -14,7 +14,6 @@
         </h2>
     </header>
     <div class="slds-modal__content slds-p-around_medium" id="modal-content-id-1">
-        <p>{confirmationMessage}</p>
         <template if:true={errorMessage}>
             <c-scoped-notification
                 theme="error"
@@ -22,6 +21,7 @@
                 class="slds-var-p-around_small"
             ></c-scoped-notification
         ></template>
+        {confirmationMessage}
     </div>
     <footer class="slds-modal__footer">
         <lightning-button

--- a/force-app/main/default/lwc/serviceDeliveryDeleter/serviceDeliveryDeleter.html
+++ b/force-app/main/default/lwc/serviceDeliveryDeleter/serviceDeliveryDeleter.html
@@ -13,16 +13,20 @@
             {labels.header}
         </h2>
     </header>
-    <div class="slds-modal__content slds-p-around_medium" id="modal-content-id-1">
-        <template if:true={errorMessage}>
-            <c-scoped-notification
-                theme="error"
-                title={errorMessage}
-                class="slds-var-p-around_small"
-            ></c-scoped-notification
-        ></template>
-        {confirmationMessage}
-    </div>
+    <template if:true={isLoadingComplete}>
+        <div class="slds-modal__content slds-p-around_medium" id="modal-content-id-1">
+            <template if:true={errorMessage}>
+                <c-scoped-notification
+                    theme="error"
+                    title={errorMessage}
+                    class="slds-var-p-around_small"
+                ></c-scoped-notification
+            ></template>
+            <template if:true={hasAccessToDelete}>
+                {confirmationMessage}
+            </template>
+        </div>
+    </template>
     <footer class="slds-modal__footer">
         <lightning-button
             onclick={handleCancel}
@@ -30,6 +34,7 @@
             title={labels.cancel}
         ></lightning-button>
         <lightning-button
+            if:true={hasAccessToDelete}
             label={labels.delete}
             title={labels.delete}
             variant="brand"

--- a/force-app/main/default/lwc/serviceDeliveryDeleter/serviceDeliveryDeleter.html
+++ b/force-app/main/default/lwc/serviceDeliveryDeleter/serviceDeliveryDeleter.html
@@ -14,8 +14,7 @@
         </h2>
     </header>
     <div class="slds-modal__content slds-p-around_medium" id="modal-content-id-1">
-        <p>{numberOfDeliveries}</p>
-        <p>{labels.message}</p>
+        <p>{confirmationMessage}</p>
         <template if:true={errorMessage}>
             <c-scoped-notification
                 theme="error"

--- a/force-app/main/default/lwc/serviceDeliveryDeleter/serviceDeliveryDeleter.js
+++ b/force-app/main/default/lwc/serviceDeliveryDeleter/serviceDeliveryDeleter.js
@@ -97,7 +97,7 @@ export default class ServiceDeliveryDeleter extends LightningElement {
     }
 
     handleCancel() {
-        this.dispatchEvent(new CustomEvent("close"));
+        this.dispatchEvent(new CustomEvent("cancel"));
     }
 
     showSuccessToast(numDeleted) {

--- a/force-app/main/default/lwc/serviceDeliveryDeleter/serviceDeliveryDeleter.js
+++ b/force-app/main/default/lwc/serviceDeliveryDeleter/serviceDeliveryDeleter.js
@@ -10,7 +10,7 @@
 import { LightningElement, api, wire } from "lwc";
 import { format, handleError } from "c/util";
 import { ShowToastEvent } from "lightning/platformShowToastEvent";
-import deleteSessionsAfter from "@salesforce/apex/ServiceScheduleCreatorController.deleteSessionsAfter";
+import deleteServiceDeliveries from "@salesforce/apex/ServiceDeliveryController.deleteServiceDeliveriesForSession";
 import getNumberOfDeliveries from "@salesforce/apex/ServiceDeliveryController.getNumberOfServiceDeliveriesForSession";
 
 import HEADER_LABEL from "@salesforce/label/c.Delete_Service_Deliveries";
@@ -35,6 +35,10 @@ export default class ServiceDeliveryDeleter extends LightningElement {
         successMessage: DELETE_SUCCESS,
     };
 
+    get confirmationMessage() {
+        return format(MESSAGE_LABEL, [this.numberOfDeliveries]);
+    }
+
     @wire(getNumberOfDeliveries, { sessionId: "$recordId" })
     wiredNumberOfDeliveries(result) {
         if (!result) {
@@ -50,7 +54,7 @@ export default class ServiceDeliveryDeleter extends LightningElement {
 
     handleDelete() {
         if (this.isValid) {
-            deleteSessionsAfter({ scheduleId: this.recordId, startDate: null })
+            deleteServiceDeliveries({ sessionId: this.recordId })
                 .then(result => {
                     this.showSuccessToast(result);
                     this.dispatchEvent(new CustomEvent("close"));

--- a/force-app/main/default/lwc/serviceDeliveryDeleter/serviceDeliveryDeleter.js
+++ b/force-app/main/default/lwc/serviceDeliveryDeleter/serviceDeliveryDeleter.js
@@ -13,6 +13,7 @@ import { ShowToastEvent } from "lightning/platformShowToastEvent";
 import { refreshApex } from "@salesforce/apex";
 import deleteServiceDeliveries from "@salesforce/apex/ServiceDeliveryController.deleteServiceDeliveriesForSession";
 import getNumberOfDeliveries from "@salesforce/apex/ServiceDeliveryController.getNumberOfServiceDeliveriesForSession";
+import canDeleteServiceDeliveries from "@salesforce/apex/ServiceDeliveryController.canDeleteServiceDeliveries";
 
 import HEADER_LABEL from "@salesforce/label/c.Delete_Service_Deliveries";
 import MESSAGE_LABEL from "@salesforce/label/c.Delete_Service_Deliveries_Confirm";
@@ -20,12 +21,16 @@ import DELETE from "@salesforce/label/c.Delete";
 import CANCEL from "@salesforce/label/c.Cancel";
 import SUCCESS_LABEL from "@salesforce/label/c.Success";
 import DELETE_SUCCESS from "@salesforce/label/c.Delete_Sessions_Success";
+import NO_DELETE_PERMS from "@salesforce/label/c.Delete_Operation_Exception";
 
 export default class ServiceDeliveryDeleter extends LightningElement {
     @api recordId;
     errorMessage;
     numberOfDeliveries = 0;
+    hasAccessToDelete = false;
     wiredNumberOfDeliveriesResult;
+    permsLoaded = false;
+    numberOfDeliveriesLoaded = false;
 
     labels = {
         header: HEADER_LABEL,
@@ -34,14 +39,36 @@ export default class ServiceDeliveryDeleter extends LightningElement {
         delete: DELETE,
         cancel: CANCEL,
         successMessage: DELETE_SUCCESS,
+        noDeleteAccessMessage: NO_DELETE_PERMS,
     };
 
     get confirmationMessage() {
         return format(MESSAGE_LABEL, [this.numberOfDeliveries]);
     }
 
+    @wire(canDeleteServiceDeliveries)
+    wiredCanDeleteServiceDeliveries(result) {
+        this.permsLoaded = false;
+        if (!result) {
+            return;
+        }
+
+        if (result.data !== undefined) {
+            this.hasAccessToDelete = result.data;
+            if (this.hasAccessToDelete !== true) {
+                this.errorMessage = this.labels.noDeleteAccessMessage;
+            }
+        } else if (result.error && result.error.body) {
+            this.errorMessage = result.error.body;
+        } else if (result.error) {
+            console.log(result.error);
+        }
+        this.permsLoaded = true;
+    }
+
     @wire(getNumberOfDeliveries, { sessionId: "$recordId" })
     wiredNumberOfDeliveries(result) {
+        this.numberOfDeliveriesLoaded = false;
         if (!result) {
             return;
         }
@@ -52,6 +79,7 @@ export default class ServiceDeliveryDeleter extends LightningElement {
         } else if (result.error) {
             console.log(result.error);
         }
+        this.numberOfDeliveriesLoaded = true;
     }
 
     handleDelete() {
@@ -86,6 +114,10 @@ export default class ServiceDeliveryDeleter extends LightningElement {
     }
 
     get isDisabled() {
-        return !this.hasServiceDeliveries;
+        return !this.isLoadingComplete || !this.hasServiceDeliveries;
+    }
+
+    get isLoadingComplete() {
+        return this.permsLoaded && this.numberOfDeliveriesLoaded;
     }
 }

--- a/force-app/main/default/lwc/serviceDeliveryDeleter/serviceDeliveryDeleter.js
+++ b/force-app/main/default/lwc/serviceDeliveryDeleter/serviceDeliveryDeleter.js
@@ -1,0 +1,90 @@
+/*
+ *
+ *  * Copyright (c) 2022, salesforce.com, inc.
+ *  * All rights reserved.
+ *  * SPDX-License-Identifier: BSD-3-Clause
+ *  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ *
+ */
+
+import { LightningElement, api, wire } from "lwc";
+import { format, handleError } from "c/util";
+import { ShowToastEvent } from "lightning/platformShowToastEvent";
+import deleteSessionsAfter from "@salesforce/apex/ServiceScheduleCreatorController.deleteSessionsAfter";
+import getNumberOfDeliveries from "@salesforce/apex/ServiceDeliveryController.getNumberOfServiceDeliveriesForSession";
+
+import HEADER_LABEL from "@salesforce/label/c.Delete_Service_Deliveries";
+import MESSAGE_LABEL from "@salesforce/label/c.Delete_Service_Deliveries_Confirm";
+import DELETE from "@salesforce/label/c.Delete";
+import CANCEL from "@salesforce/label/c.Cancel";
+import SUCCESS_LABEL from "@salesforce/label/c.Success";
+import DELETE_SUCCESS from "@salesforce/label/c.Delete_Sessions_Success";
+
+export default class ServiceDeliveryDeleter extends LightningElement {
+    @api recordId;
+    errorMessage;
+    isValid = true;
+    numberOfDeliveries;
+
+    labels = {
+        header: HEADER_LABEL,
+        success: SUCCESS_LABEL,
+        message: MESSAGE_LABEL,
+        delete: DELETE,
+        cancel: CANCEL,
+        successMessage: DELETE_SUCCESS,
+    };
+
+    @wire(getNumberOfDeliveries, { sessionId: "$recordId" })
+    wiredNumberOfDeliveries(result) {
+        if (!result) {
+            return;
+        }
+
+        if (result.data) {
+            this.numberOfDeliveries = result.data;
+        } else if (result.error) {
+            console.log(result.error);
+        }
+    }
+
+    handleDelete() {
+        if (this.isValid) {
+            deleteSessionsAfter({ scheduleId: this.recordId, startDate: null })
+                .then(result => {
+                    this.showSuccessToast(result);
+                    this.dispatchEvent(new CustomEvent("close"));
+                })
+                .catch(error => {
+                    handleError(error);
+                });
+        }
+    }
+
+    checkValidity() {
+        this.isValid = true;
+
+        if (this.isValid) {
+            this.errorMessage = undefined;
+        } else {
+            this.errorMessage = "error"; //this.labels.invalidDate;
+        }
+    }
+
+    handleCancel() {
+        this.dispatchEvent(new CustomEvent("close"));
+    }
+
+    showSuccessToast(numDeleted) {
+        const event = new ShowToastEvent({
+            title: this.labels.success,
+            variant: "success",
+            message: format(this.labels.successMessage, [numDeleted]),
+        });
+        this.dispatchEvent(event);
+    }
+
+    get isDisabled() {
+        return !this.isValid;
+    }
+}

--- a/force-app/main/default/lwc/serviceDeliveryDeleter/serviceDeliveryDeleter.js
+++ b/force-app/main/default/lwc/serviceDeliveryDeleter/serviceDeliveryDeleter.js
@@ -58,8 +58,8 @@ export default class ServiceDeliveryDeleter extends LightningElement {
             if (this.hasAccessToDelete !== true) {
                 this.errorMessage = this.labels.noDeleteAccessMessage;
             }
-        } else if (result.error && result.error.body) {
-            this.errorMessage = result.error.body;
+        } else if (result.error && result.error.body && result.error.body.message) {
+            this.errorMessage = result.error.body.message;
         } else if (result.error) {
             console.log(result.error);
         }

--- a/force-app/main/default/lwc/serviceDeliveryDeleter/serviceDeliveryDeleter.js-meta.xml
+++ b/force-app/main/default/lwc/serviceDeliveryDeleter/serviceDeliveryDeleter.js-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>54.0</apiVersion>
+    <isExposed>false</isExposed>
+</LightningComponentBundle>

--- a/force-app/main/default/quickActions/ServiceSession__c.Delete_All_Service_Deliveries.quickAction-meta.xml
+++ b/force-app/main/default/quickActions/ServiceSession__c.Delete_All_Service_Deliveries.quickAction-meta.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<QuickAction xmlns="http://soap.sforce.com/2006/04/metadata">
+    <height>250</height>
+    <label>Delete Service Deliveries</label>
+    <lightningComponent>deleteServiceDeliveries</lightningComponent>
+    <optionsCreateFeedItem>false</optionsCreateFeedItem>
+    <type>LightningComponent</type>
+    <width>-100</width>
+</QuickAction>


### PR DESCRIPTION
# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
- [ ] Any net new LWC work has Sa11y tests & 50% or above lines JEST test coverage  
- [ ] CRUD/FLS is enforced in Apex
- [ ] Permission sets are updated to account for CRUD|FLS|Tab|Classes
- [ ] Field sets are updated to account for new fields
- [ ] UX approval or UX not necessary
- [ ] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: W-0000000: Work Name (https://github.com/SalesforceFoundation/PMM/pull/303)
- [ ] All **acceptance criteria** have been met
    - [ ] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [ ] PR contains draft release notes
- [ ] QE story level testing completed