### PR TITLE
Focus first input on new BSDT row

### DIFF
--- a/force-app/main/default/lwc/bulkServiceDeliveryUI/bulkServiceDeliveryUI.html
+++ b/force-app/main/default/lwc/bulkServiceDeliveryUI/bulkServiceDeliveryUI.html
@@ -30,6 +30,7 @@
                                 onsuccess={handleRowSuccess}
                                 ondelete={handleRowDelete}
                                 row-count={rowCount}
+                                should-focus={delivery.shouldFocus}
                             ></c-service-delivery-row>
                         </div>
                     </template>

--- a/force-app/main/default/lwc/bulkServiceDeliveryUI/bulkServiceDeliveryUI.js
+++ b/force-app/main/default/lwc/bulkServiceDeliveryUI/bulkServiceDeliveryUI.js
@@ -137,7 +137,11 @@ export default class BulkServiceDeliveryUI extends NavigationMixin(LightningElem
     }
 
     addDelivery() {
-        let serviceDelivery = { index: this._nextIndex, isDirty: false };
+        let serviceDelivery = {
+            index: this._nextIndex,
+            isDirty: false,
+            shouldFocus: true,
+        };
         if (this.applyDefaults || this.isModal) {
             Object.assign(serviceDelivery, this.defaultValues);
             serviceDelivery.Id = null;

--- a/force-app/main/default/lwc/serviceDeliveryRow/serviceDeliveryRow.js
+++ b/force-app/main/default/lwc/serviceDeliveryRow/serviceDeliveryRow.js
@@ -75,6 +75,7 @@ export default class ServiceDeliveryRow extends LightningElement {
     @api rowCount;
     @api isDirty = false;
     @api isError;
+    @api shouldFocus = false;
 
     @track fieldSet;
 
@@ -202,6 +203,27 @@ export default class ServiceDeliveryRow extends LightningElement {
             : this.serviceDeliveryFieldSets.currentFieldSetName;
         this.setCurrentFieldSet(fieldSetName);
         this.setDefaults();
+        this.handleFocus();
+    }
+
+    handleFocus() {
+        if (this.shouldFocus) {
+            // eslint-disable-next-line @lwc/lwc/no-async-operation
+            setTimeout(
+                function() {
+                    this.focusFirstInput();
+                }.bind(this),
+                50
+            );
+            this.shouldFocus = false;
+        }
+    }
+
+    focusFirstInput() {
+        let firstInput = this.template.querySelector("lightning-input-field");
+        if (firstInput) {
+            firstInput.focus();
+        }
     }
 
     // Called by lightning input field; when selections are filtered they


### PR DESCRIPTION
# Critical Changes

# Changes
Focus first input when a new BSDT row is added to improve screenreader experience.

# Issues Closed
[W-10241706](https://gus.lightning.force.com/a07EE00000U1v8WYAR)

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
- [ ] Any net new LWC work has Sa11y tests & 50% or above lines JEST test coverage  
- [ ] CRUD/FLS is enforced in Apex
- [ ] Permission sets are updated to account for CRUD|FLS|Tab|Classes
- [ ] Field sets are updated to account for new fields
- [ ] UX approval or UX not necessary
- [ ] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: W-0000000: Work Name (https://github.com/SalesforceFoundation/PMM/pull/303)
- [ ] All **acceptance criteria** have been met
    - [ ] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [ ] PR contains draft release notes
- [ ] QE story level testing completed