### PR TITLE
Display Capacity warning

### DIFF
--- a/force-app/main/default/lwc/participantAdder/participantAdder.js
+++ b/force-app/main/default/lwc/participantAdder/participantAdder.js
@@ -66,7 +66,7 @@ export default class ParticipantAdder extends LightningElement {
         }
     }
 
-    @wire(getServiceScheduleModel, { recordTypeId: null })
+    @wire(getServiceScheduleModel, { serviceScheduleId: "$recordId", recordTypeId: null })
     wireServiceScheduleModel(result) {
         if (!result) {
             return;


### PR DESCRIPTION
# Critical Changes

# Changes
When the user clicks the Add participants quick action on the service schedule page layout and if the number of participants added is more than the Participant Capacity then the user sees a warning on the Add Selector screen.

# Issues Closed
[W-11195802](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000xjAMvYAM/view)
# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
~~- [ ] Any net new LWC work has Sa11y tests & 50% or above lines JEST test coverage~~  
~~- [ ] CRUD/FLS is enforced in Apex~~
~~- [ ] Permission sets are updated to account for CRUD|FLS|Tab|Classes~~
~~- [ ] Field sets are updated to account for new fields~~
~~- [ ] UX approval or UX not necessary~~
- [x] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: W-0000000: Work Name (https://github.com/SalesforceFoundation/PMM/pull/303)
- [ ] All **acceptance criteria** have been met
    - [x] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [x] PR contains draft release notes
- [ ] QE story level testing completed