### PR TITLE
Announce error message via screen reader

### DIFF
--- a/force-app/main/default/lwc/serviceDeliveryRow/serviceDeliveryRow.html
+++ b/force-app/main/default/lwc/serviceDeliveryRow/serviceDeliveryRow.html
@@ -41,6 +41,7 @@
                                                     {field.label}
                                                 </div>
                                                 <lightning-combobox
+                                                    aria-label={field.label}
                                                     name={field.apiName}
                                                     onchange={handleComboChange}
                                                     placeholder={field.placeholder}
@@ -62,6 +63,7 @@
                                                         {unitOfMeasureValue}
                                                     </div>
                                                     <lightning-input-field
+                                                        aria-label={field.label}
                                                         data-name={field.apiName}
                                                         field-name={field.apiName}
                                                         onchange={handleInputChange}
@@ -83,6 +85,7 @@
                                                         {field.label}
                                                     </div>
                                                     <lightning-input-field
+                                                        aria-label={field.label}
                                                         data-name={field.apiName}
                                                         field-name={field.apiName}
                                                         onchange={handleInputChange}
@@ -97,6 +100,7 @@
                                             <div
                                                 class="slds-text-color_error"
                                                 if:false={field.isAccessible}
+                                                aria-live={labels.fieldAccessError}
                                             >
                                                 {labels.fieldAccessError}
                                             </div>
@@ -112,7 +116,11 @@
                                         size="12"
                                         padding="around-small"
                                     >
-                                        <div class="slds-text-color_error" key={error}>
+                                        <div
+                                            class="slds-text-color_error"
+                                            key={error}
+                                            aria-live={errorMessage}
+                                        >
                                             {errorMessage}
                                         </div>
                                     </lightning-layout-item>

--- a/force-app/main/default/lwc/serviceDeliveryRow/serviceDeliveryRow.js
+++ b/force-app/main/default/lwc/serviceDeliveryRow/serviceDeliveryRow.js
@@ -274,24 +274,26 @@ export default class ServiceDeliveryRow extends LightningElement {
     }
 
     handleSaveError(event) {
-        if (
-            JSON.stringify(event.detail).includes("UNABLE_TO_LOCK_ROW") &&
-            this.errorRetryCount < this.errorRetryMax
-        ) {
-            this.errorRetryCount++;
-            this.saveRow();
-            return;
+        if (!this.isError) {
+            if (
+                JSON.stringify(event.detail).includes("UNABLE_TO_LOCK_ROW") &&
+                this.errorRetryCount < this.errorRetryMax
+            ) {
+                this.errorRetryCount++;
+                this.saveRow();
+                return;
+            }
+
+            this.errorMessage = handleError(event, false, "dismissible", true);
+            this.errorRetryCount = 0;
+            this.isDirty = false;
+            this.isSaving = false;
+            this.isSaved = false;
+            this.isError = true;
+
+            event.detail.index = this.index;
+            this.dispatchEvent(new CustomEvent("error", { detail: event.detail }));
         }
-
-        this.errorMessage = handleError(event, false, "dismissible", true);
-        this.errorRetryCount = 0;
-        this.isDirty = false;
-        this.isSaving = false;
-        this.isSaved = false;
-        this.isError = true;
-
-        event.detail.index = this.index;
-        this.dispatchEvent(new CustomEvent("error", { detail: event.detail }));
     }
 
     handleSuccess(event) {
@@ -304,17 +306,29 @@ export default class ServiceDeliveryRow extends LightningElement {
     handleSubmit(event) {
         let fields = event.detail.fields;
 
-        if (this.programEngagementId) {
-            fields[PROGRAMENGAGEMENT_FIELD.fieldApiName] = this.programEngagementId;
+        if (this.hasProgramEngagementField && !this.programEngagementId) {
+            this.isError = true;
+            this.errorMessage = handleError(
+                this.labels.selectEngagement,
+                false,
+                "dismissible",
+                true
+            );
         }
 
-        if (this.serviceId) {
-            fields[SERVICE_FIELD.fieldApiName] = this.serviceId;
+        if (!this.isError) {
+            if (this.programEngagementId) {
+                fields[PROGRAMENGAGEMENT_FIELD.fieldApiName] = this.programEngagementId;
+            }
+
+            if (this.serviceId) {
+                fields[SERVICE_FIELD.fieldApiName] = this.serviceId;
+            }
+
+            this.template.querySelector("lightning-record-edit-form").submit(fields);
+
+            this.setSaving();
         }
-
-        this.template.querySelector("lightning-record-edit-form").submit(fields);
-
-        this.setSaving();
     }
 
     handleSaveNewPE(event) {


### PR DESCRIPTION

# Critical Changes

# Changes
Added aria label and aria live to service delivery row html file so when there is an error message, the message is announced to the user. We now will show an error message if program engagement field is not filled in.

# Issues Closed
[W-10241719](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000U1v8jYAB/view)
[W-10241720](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000U1v8kYAB/view)
# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
~~- [ ] Any net new LWC work has Sa11y tests & 50% or above lines JEST test coverage~~  
~~- [ ] CRUD/FLS is enforced in Apex~~
~~- [ ] Permission sets are updated to account for CRUD|FLS|Tab|Classes~~
~~- [ ] Field sets are updated to account for new fields~~
~~- [ ] UX approval or UX not necessary~~
- [x] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: W-0000000: Work Name (https://github.com/SalesforceFoundation/PMM/pull/303)
- [ ] All **acceptance criteria** have been met
    - [x] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [ ] PR contains draft release notes
- [ ] QE story level testing completed