### PR TITLE
Action Column Labels for DataTable

### DIFF
--- a/force-app/main/default/labels/CustomLabels.labels-meta.xml
+++ b/force-app/main/default/labels/CustomLabels.labels-meta.xml
@@ -1054,4 +1054,11 @@
         <shortDescription>Warning</shortDescription>
         <value>Warning</value>
     </labels>
+    <labels>
+        <fullName>Action</fullName>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>Action</shortDescription>
+        <value>Action</value>
+    </labels>
 </CustomLabels>

--- a/force-app/main/default/lwc/participantSelector/participantSelector.js
+++ b/force-app/main/default/lwc/participantSelector/participantSelector.js
@@ -33,6 +33,7 @@ import save from "@salesforce/label/c.Save";
 import saveAndNew from "@salesforce/label/c.Save_New";
 import cantFind from "@salesforce/label/c.Cant_Find_Participant";
 import newLabel from "@salesforce/label/c.New";
+import actionLabel from "@salesforce/label/c.Action";
 
 const TIME = "TIME";
 
@@ -82,6 +83,7 @@ export default class ParticipantSelector extends LightningElement {
         cancel,
         cantFind,
         newLabel,
+        actionLabel,
     };
 
     @api
@@ -320,7 +322,7 @@ export default class ParticipantSelector extends LightningElement {
             this.selectorColumns = [...this.columns];
 
             this.selectorColumns.push({
-                fieldName: "",
+                label: this.labels.actionLabel,
                 type: "button",
                 hideDefaultActions: true,
                 typeAttributes: {

--- a/force-app/main/default/lwc/participantSelector/participantSelector.js
+++ b/force-app/main/default/lwc/participantSelector/participantSelector.js
@@ -34,6 +34,7 @@ import saveAndNew from "@salesforce/label/c.Save_New";
 import cantFind from "@salesforce/label/c.Cant_Find_Participant";
 import newLabel from "@salesforce/label/c.New";
 import actionLabel from "@salesforce/label/c.Action";
+import removeLabel from "@salesforce/label/c.Remove";
 
 const TIME = "TIME";
 
@@ -84,6 +85,7 @@ export default class ParticipantSelector extends LightningElement {
         cantFind,
         newLabel,
         actionLabel,
+        removeLabel,
     };
 
     @api
@@ -341,7 +343,7 @@ export default class ParticipantSelector extends LightningElement {
 
         this.selectedColumns = this.columns.slice(0, min);
         this.selectedColumns.push({
-            fieldName: "",
+            label: this.labels.actionLabel,
             type: "button-icon",
             hideDefaultActions: true,
             typeAttributes: {
@@ -349,6 +351,7 @@ export default class ParticipantSelector extends LightningElement {
                 variant: "bare",
                 iconPosition: "left",
                 disabled: { fieldName: "disableDeselect" },
+                alternativeText: this.labels.removeLabel,
             },
         });
     }

--- a/force-app/main/default/lwc/reviewSessions/reviewSessions.js
+++ b/force-app/main/default/lwc/reviewSessions/reviewSessions.js
@@ -21,6 +21,8 @@ import START_BEFORE_END_LABEL from "@salesforce/label/c.End_Date_After_Start_Dat
 import CREATE_SESSIONS_WARNING_LABEL from "@salesforce/label/c.Select_Create_Service_Session_Warning";
 import MAX_SESSIONS_WARNING_LABEL from "@salesforce/label/c.Creating_Service_Session_Warning";
 import ONLY_SHOWING_FUTURE_SESSIONS_MESSAGE from "@salesforce/label/c.Only_Showing_Future_Sessions";
+import REMOVE_LABEL from "@salesforce/label/c.Remove";
+import ACTION_LABEL from "@salesforce/label/c.Action";
 import TIME_ZONE from "@salesforce/i18n/timeZone";
 
 export default class ReviewSessions extends LightningElement {
@@ -124,6 +126,8 @@ export default class ReviewSessions extends LightningElement {
         cancel: CANCEL_LABEL,
         save: SAVE_LABEL,
         saveNew: SAVE_NEW_LABEL,
+        remove: REMOVE_LABEL,
+        action: ACTION_LABEL,
     };
 
     getSessions() {
@@ -221,7 +225,7 @@ export default class ReviewSessions extends LightningElement {
                 },
             },
             {
-                label: "",
+                label: this.labels.action,
                 cellAttributes: { class: { fieldName: "alreadyCreatedCSSClass" } },
                 name: "delete",
                 type: "button-icon",
@@ -231,6 +235,8 @@ export default class ReviewSessions extends LightningElement {
                     variant: "bare",
                     iconPosition: "left",
                     disabled: { fieldName: "disableDeselect" },
+                    alternativeText: this.labels.remove,
+                    tabIndex: 0,
                 },
             },
         ];

--- a/force-app/main/default/lwc/reviewSessions/reviewSessions.js
+++ b/force-app/main/default/lwc/reviewSessions/reviewSessions.js
@@ -236,7 +236,6 @@ export default class ReviewSessions extends LightningElement {
                     iconPosition: "left",
                     disabled: { fieldName: "disableDeselect" },
                     alternativeText: this.labels.remove,
-                    tabIndex: 0,
                 },
             },
         ];


### PR DESCRIPTION
# Critical Changes

# Changes
Adds labels to the previously empty datatable column headings

# Issues Closed
[W-10311059](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000XtelEYAR/view)

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
- [ ] Any net new LWC work has Sa11y tests & 50% or above lines JEST test coverage  
- [ ] CRUD/FLS is enforced in Apex
- [ ] Permission sets are updated to account for CRUD|FLS|Tab|Classes
- [ ] Field sets are updated to account for new fields
- [ ] UX approval or UX not necessary
- [x] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: W-0000000: Work Name (https://github.com/SalesforceFoundation/PMM/pull/303)
- [ ] All **acceptance criteria** have been met
    - [x] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [x] PR contains draft release notes
- [ ] QE story level testing completed