### PR TITLE
Changing recent sessions header tag

### DIFF
--- a/force-app/main/default/lwc/recentSessions/recentSessions.html
+++ b/force-app/main/default/lwc/recentSessions/recentSessions.html
@@ -11,9 +11,9 @@
     <lightning-card class="sessions">
         <!-- Lightning Card Header -->
         <div class="slds-border_bottom slds-var-p-left_small slds-var-p-bottom_small">
-            <h1 slot="title" class="header-title-container slds-text-title_bold">
+            <h2 slot="title" class="header-title-container slds-text-title_bold">
                 <span class="slds-card__header-title">{labels.recentSessions}</span>
-            </h1>
+            </h2>
             <lightning-layout class="slds-var-p-top_small">
                 <lightning-layout-item>
                     <c-list-view-selector


### PR DESCRIPTION
# Critical Changes

# Changes
Changed recent sessions header  from h1 to h2
# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
~~- [ ] Any net new LWC work has Sa11y tests & 50% or above lines JEST test coverage~~  
~~- [ ] CRUD/FLS is enforced in Apex~~
~~- [ ] Permission sets are updated to account for CRUD|FLS|Tab|Classes~~
~~- [ ] Field sets are updated to account for new fields~~
-~~ [ ] UX approval or UX not necessary~~
- [x] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: W-0000000: Work Name (https://github.com/SalesforceFoundation/PMM/pull/303)
- [ ] All **acceptance criteria** have been met
    - [x] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [x] PR contains draft release notes
- [ ] QE story level testing completed