### PR TITLE
Screen readers announcing the day of the week selected

### DIFF
--- a/force-app/main/default/lwc/picklist/picklist.html
+++ b/force-app/main/default/lwc/picklist/picklist.html
@@ -9,26 +9,38 @@
 
 <template>
     <div class="slds-var-p-bottom_small slds-var-p-left_xxx-small" if:true={options}>
-        <div class="slds-form-element" if:true={multiSelect}>
-            <label
-                class="slds-form-element__legend slds-form-element__label"
-                for="buttons"
-            >
-                {label}
-            </label>
-            <div class="slds-form-element__control">
-                <lightning-button-group id="buttons">
-                    <template for:each={options} for:item="option" if:true={options}>
-                        <lightning-button
-                            key={option.value}
-                            name={option.value}
-                            label={option.label}
-                            variant={option.variant}
-                            onclick={handleMultiSelectClick}
-                        ></lightning-button>
-                    </template>
-                </lightning-button-group>
-            </div>
+        <div if:true={multiSelect}>
+            <fieldset class="slds-form-element">
+                <legend class="slds-form-element__legend slds-form-element__label">
+                    {label}
+                </legend>
+                <div class="slds-form-element__control">
+                    <div class="slds-checkbox_button-group">
+                        <template for:each={options} for:item="option" if:true={options}>
+                            <span
+                                class="slds-button slds-checkbox_button"
+                                key={option.value}
+                            >
+                                <input
+                                    type="checkbox"
+                                    value={option.value}
+                                    id={option.value}
+                                    name={option.value}
+                                    onclick={handleMultiSelectClick}
+                                />
+                                <label
+                                    class="slds-checkbox_button__label"
+                                    for={option.value}
+                                >
+                                    <span class="slds-checkbox_faux"
+                                        >{option.label}</span
+                                    ></label
+                                >
+                            </span>
+                        </template>
+                    </div>
+                </div>
+            </fieldset>
         </div>
         <lightning-radio-group
             if:false={multiSelect}

--- a/force-app/main/default/lwc/picklist/picklist.js
+++ b/force-app/main/default/lwc/picklist/picklist.js
@@ -76,9 +76,6 @@ export default class Picklist extends LightningElement {
         this.options.forEach(option => {
             if (option.value === event.target.name) {
                 option.isSelected = !option.isSelected;
-                option.variant = option.isSelected
-                    ? SELECTED_VARIANT
-                    : UNSELECTED_VARIANT;
             }
         });
 


### PR DESCRIPTION
# Critical Changes

# Changes
With this change now the screen reader announces which day of the week is selected.
# Issues Closed
[W-10311101](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000Xtqt7YAB/view)
# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
~~- [ ] Any net new LWC work has Sa11y tests & 50% or above lines JEST test coverage~~  
~~- [ ] CRUD/FLS is enforced in Apex~~
~~- [ ] Permission sets are updated to account for CRUD|FLS|Tab|Classes~~
~~- [ ] Field sets are updated to account for new fields~~
~~- [ ] UX approval or UX not necessary~~
- [x] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: W-0000000: Work Name (https://github.com/SalesforceFoundation/PMM/pull/303)
- [ ] All **acceptance criteria** have been met
    - [x] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [x] PR contains draft release notes
- [ ] QE story level testing completed