### PR TITLE
WIP: Added error banner for Service Delivery Defaults in BSDT

### DIFF
--- a/force-app/main/default/labels/CustomLabels.labels-meta.xml
+++ b/force-app/main/default/labels/CustomLabels.labels-meta.xml
@@ -151,6 +151,13 @@
         <value>Select at least one Contact to continue.</value>
     </labels>
     <labels>
+        <fullName>BSDT_DSDV_Error_Banner_Msg</fullName>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>Error message when there are field level errors on Default Service Delivery Value screen.</shortDescription>
+        <value>Please correct the field-level errors before continuing.</value>
+    </labels>
+    <labels>
         <fullName>Cant_Find_Participant</fullName>
         <language>en_US</language>
         <protected>true</protected>

--- a/force-app/main/default/labels/CustomLabels.labels-meta.xml
+++ b/force-app/main/default/labels/CustomLabels.labels-meta.xml
@@ -154,8 +154,8 @@
         <fullName>BSDT_Error_Banner_Msg</fullName>
         <language>en_US</language>
         <protected>true</protected>
-        <shortDescription>Error message when there are field level errors on DSDV screen.</shortDescription>
-        <value>Please correct the field-level errors before continuing.</value>
+        <shortDescription>Service delivery default error banner message.</shortDescription>
+        <value>Something went wrong. Review the errors on this page.</value>
     </labels>
     <labels>
         <fullName>Cant_Find_Participant</fullName>

--- a/force-app/main/default/labels/CustomLabels.labels-meta.xml
+++ b/force-app/main/default/labels/CustomLabels.labels-meta.xml
@@ -151,10 +151,10 @@
         <value>Select at least one Contact to continue.</value>
     </labels>
     <labels>
-        <fullName>BSDT_DSDV_Error_Banner_Msg</fullName>
+        <fullName>BSDT_Error_Banner_Msg</fullName>
         <language>en_US</language>
         <protected>true</protected>
-        <shortDescription>Error message when there are field level errors on Default Service Delivery Value screen.</shortDescription>
+        <shortDescription>Error message when there are field level errors on DSDV screen.</shortDescription>
         <value>Please correct the field-level errors before continuing.</value>
     </labels>
     <labels>

--- a/force-app/main/default/lwc/serviceDeliveryDefaults/serviceDeliveryDefaults.html
+++ b/force-app/main/default/lwc/serviceDeliveryDefaults/serviceDeliveryDefaults.html
@@ -1,6 +1,16 @@
 <template>
     <lightning-record-edit-form object-api-name={objectApiName} density="comfy">
         <lightning-layout multiple-rows="true">
+            <lightning-layout-item
+                size="12"
+                class="slds-var-p-bottom_small"
+                if:true={errorMessage}
+            >
+                <c-scoped-notification
+                    theme="error"
+                    title={errorMessage}
+                ></c-scoped-notification>
+            </lightning-layout-item>
             <lightning-layout-item size="12" class="slds-var-p-bottom_small">
                 <c-section title={labels.selectService}></c-section>
             </lightning-layout-item>

--- a/force-app/main/default/lwc/serviceDeliveryDefaults/serviceDeliveryDefaults.js
+++ b/force-app/main/default/lwc/serviceDeliveryDefaults/serviceDeliveryDefaults.js
@@ -93,14 +93,9 @@ export default class ServiceDeliveryDefaults extends LightningElement {
     @api
     getFields() {
         let fields = {};
-        let errorFields = [];
         let valid = true;
         this.template.querySelectorAll("lightning-input-field").forEach(inputField => {
-            let isFieldValid = inputField.reportValidity();
-            valid = valid && isFieldValid;
-            if (!isFieldValid) {
-                errorFields.push(inputField.fieldName);
-            }
+            valid = valid && inputField.reportValidity();
             fields[inputField.fieldName] = inputField.value;
         });
 

--- a/force-app/main/default/lwc/serviceDeliveryDefaults/serviceDeliveryDefaults.js
+++ b/force-app/main/default/lwc/serviceDeliveryDefaults/serviceDeliveryDefaults.js
@@ -1,7 +1,7 @@
 import { api, LightningElement, track, wire } from "lwc";
 import { getRecord } from "lightning/uiRecordApi";
 
-import BSDT_DSDV_ERROR_MSG from "@salesforce/label/c.BSDT_DSDV_Error_Banner_Msg";
+import BSDT_ERROR_MSG from "@salesforce/label/c.BSDT_Error_Banner_Msg";
 import SERVICE_DELIVERY_OBJECT from "@salesforce/schema/ServiceDelivery__c";
 import SERVICE_FIELD from "@salesforce/schema/ServiceDelivery__c.Service__c";
 import CONTACT_FIELD from "@salesforce/schema/ServiceDelivery__c.Contact__c";
@@ -105,7 +105,7 @@ export default class ServiceDeliveryDefaults extends LightningElement {
         });
 
         if (!valid) {
-            this.errorMessage = BSDT_DSDV_ERROR_MSG;
+            this.errorMessage = BSDT_ERROR_MSG;
             throw new Error(ERROR_MESSAGE);
         }
 

--- a/force-app/main/default/lwc/serviceDeliveryDefaults/serviceDeliveryDefaults.js
+++ b/force-app/main/default/lwc/serviceDeliveryDefaults/serviceDeliveryDefaults.js
@@ -1,6 +1,7 @@
 import { api, LightningElement, track, wire } from "lwc";
 import { getRecord } from "lightning/uiRecordApi";
 
+import ERROR_MSG from "@salesforce/label/c.Error";
 import SERVICE_DELIVERY_OBJECT from "@salesforce/schema/ServiceDelivery__c";
 import SERVICE_FIELD from "@salesforce/schema/ServiceDelivery__c.Service__c";
 import CONTACT_FIELD from "@salesforce/schema/ServiceDelivery__c.Contact__c";
@@ -21,6 +22,7 @@ export default class ServiceDeliveryDefaults extends LightningElement {
     @track fieldSet;
 
     serviceId;
+    errorMessage;
     objectApiName = SERVICE_DELIVERY_OBJECT.objectApiName;
     fieldSetName = DEFAULT_FIELD_SET;
     serviceFieldName = SERVICE_FIELD.fieldApiName;
@@ -91,18 +93,24 @@ export default class ServiceDeliveryDefaults extends LightningElement {
     @api
     getFields() {
         let fields = {};
+        let errorFields = [];
         let valid = true;
         this.template.querySelectorAll("lightning-input-field").forEach(inputField => {
-            valid = valid && inputField.reportValidity();
+            let isFieldValid = inputField.reportValidity();
+            valid = valid && isFieldValid;
+            if(!isFieldValid) {
+                errorFields.push(inputField.fieldName);
+            }
             fields[inputField.fieldName] = inputField.value;
         });
 
         if (!valid) {
+            this.errorMessage = ERROR_MSG;
+            console.log(errorFields);
             throw new Error(ERROR_MESSAGE);
         }
 
         fields[SERVICE_DELIVERY_FIELD_SET_FIELD.fieldApiName] = this.fieldSetName;
-
         return fields;
     }
 

--- a/force-app/main/default/lwc/serviceDeliveryDefaults/serviceDeliveryDefaults.js
+++ b/force-app/main/default/lwc/serviceDeliveryDefaults/serviceDeliveryDefaults.js
@@ -1,7 +1,7 @@
 import { api, LightningElement, track, wire } from "lwc";
 import { getRecord } from "lightning/uiRecordApi";
 
-import ERROR_MSG from "@salesforce/label/c.Error";
+import BSDT_DSDV_ERROR_MSG from "@salesforce/label/c.BSDT_DSDV_Error_Banner_Msg";
 import SERVICE_DELIVERY_OBJECT from "@salesforce/schema/ServiceDelivery__c";
 import SERVICE_FIELD from "@salesforce/schema/ServiceDelivery__c.Service__c";
 import CONTACT_FIELD from "@salesforce/schema/ServiceDelivery__c.Contact__c";
@@ -98,15 +98,14 @@ export default class ServiceDeliveryDefaults extends LightningElement {
         this.template.querySelectorAll("lightning-input-field").forEach(inputField => {
             let isFieldValid = inputField.reportValidity();
             valid = valid && isFieldValid;
-            if(!isFieldValid) {
+            if (!isFieldValid) {
                 errorFields.push(inputField.fieldName);
             }
             fields[inputField.fieldName] = inputField.value;
         });
 
         if (!valid) {
-            this.errorMessage = ERROR_MSG;
-            console.log(errorFields);
+            this.errorMessage = BSDT_DSDV_ERROR_MSG;
             throw new Error(ERROR_MESSAGE);
         }
 


### PR DESCRIPTION
# Critical Changes

# Changes
- Added error banner for Service Delivery Defaults in Group Option of Bulk Service Delivery Tool

# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
~~Any net new LWC work has Sa11y tests & 50% or above lines JEST test coverage~~
~~CRUD/FLS is enforced in Apex~~
~~Permission sets are updated to account for CRUD|FLS|Tab|Classes~~
~~Field sets are updated to account for new fields~~
- [x] UX approval or UX not necessary
- [x] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: W-0000000: Work Name (https://github.com/SalesforceFoundation/PMM/pull/303)
- [ ] All **acceptance criteria** have been met
    - [x] Developer
    - [x] Code Reviewer
    - [ ] QA
- [x] PR contains draft release notes
- [x] QE story level testing completed