### PR TITLE
W-10311123: [Accessibility] The “Saved” and “Error” status alert notifications are not detected and announced by the assistive tech

### DIFF
--- a/force-app/main/default/labels/CustomLabels.labels-meta.xml
+++ b/force-app/main/default/labels/CustomLabels.labels-meta.xml
@@ -80,6 +80,22 @@
         <shortDescription>Service Field Message for BSDT</shortDescription>
         <value>The fields shown on this page depend on the Service you select.</value>
     </labels>
+        /**
+            "Attempted to save " +
+            this.currentSaveCount +
+            " new or modified rows. There were " +
+            this.savedCount +
+            " successful and " +
+            this.errorCount +
+            " errors. Consult invidivual rows for details.";
+        */    
+    <labels>
+        <fullName>BSDT_Saving_Complete_Message</fullName>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>Save Result Summary Message for BSDT</shortDescription>
+        <value>Attempted to save {0} new or modified rows, with {1} successful and {2} errors. Consult rows for details.</value>
+    </labels>
     <labels>
         <fullName>BSDT_Selected_Contacts</fullName>
         <language>en_US</language>

--- a/force-app/main/default/labels/CustomLabels.labels-meta.xml
+++ b/force-app/main/default/labels/CustomLabels.labels-meta.xml
@@ -81,12 +81,19 @@
         <value>The fields shown on this page depend on the Service you select.</value>
     </labels> 
     <labels>
-        <fullName>BSDT_Saving_Complete_Message</fullName>
+        <fullName>BSDT_Saving_Complete_Success_Message</fullName>
         <language>en_US</language>
         <protected>true</protected>
-        <shortDescription>Save Result Summary Message for BSDT</shortDescription>
-        <value>Attempted to save {0} new or modified rows, with {1} successful and {2} errors. Consult rows for details.</value>
+        <shortDescription>Save Success Summary Message for BSDT</shortDescription>
+        <value>{0} Service Deliveries were saved.</value>
     </labels>
+    <labels>
+        <fullName>BSDT_Saving_Complete_Failure_Message</fullName>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>Save Failure Summary Message for BSDT</shortDescription>
+        <value>{0} Service Deliveries have errors and weren&apos;t saved.</value>
+    </labels>    
     <labels>
         <fullName>BSDT_Selected_Contacts</fullName>
         <language>en_US</language>

--- a/force-app/main/default/labels/CustomLabels.labels-meta.xml
+++ b/force-app/main/default/labels/CustomLabels.labels-meta.xml
@@ -79,16 +79,7 @@
         <protected>true</protected>
         <shortDescription>Service Field Message for BSDT</shortDescription>
         <value>The fields shown on this page depend on the Service you select.</value>
-    </labels>
-        /**
-            "Attempted to save " +
-            this.currentSaveCount +
-            " new or modified rows. There were " +
-            this.savedCount +
-            " successful and " +
-            this.errorCount +
-            " errors. Consult invidivual rows for details.";
-        */    
+    </labels> 
     <labels>
         <fullName>BSDT_Saving_Complete_Message</fullName>
         <language>en_US</language>

--- a/force-app/main/default/lwc/bulkServiceDeliveryUI/bulkServiceDeliveryUI.html
+++ b/force-app/main/default/lwc/bulkServiceDeliveryUI/bulkServiceDeliveryUI.html
@@ -32,6 +32,7 @@
                                 index={delivery.index}
                                 onsuccess={handleRowSuccess}
                                 ondelete={handleRowDelete}
+                                onerror={handleRowError}
                                 row-count={rowCount}
                                 should-focus={delivery.shouldFocus}
                             ></c-service-delivery-row>

--- a/force-app/main/default/lwc/bulkServiceDeliveryUI/bulkServiceDeliveryUI.js
+++ b/force-app/main/default/lwc/bulkServiceDeliveryUI/bulkServiceDeliveryUI.js
@@ -153,10 +153,8 @@ export default class BulkServiceDeliveryUI extends NavigationMixin(LightningElem
     get savingCompleteToastVariant() {
         if (this.errorCount === 0) {
             return "success";
-        } else if (this.errorCount === this.currentSaveCount) {
-            return "error";
         }
-        return "warning";
+        return "error";
     }
 
     addDelivery() {

--- a/force-app/main/default/lwc/bulkServiceDeliveryUI/bulkServiceDeliveryUI.js
+++ b/force-app/main/default/lwc/bulkServiceDeliveryUI/bulkServiceDeliveryUI.js
@@ -9,7 +9,7 @@
 
 import { LightningElement, api, track, wire } from "lwc";
 import { NavigationMixin } from "lightning/navigation";
-import { handleError, showToast } from "c/util";
+import { format, handleError, showToast } from "c/util";
 import { loadStyle } from "lightning/platformResourceLoader";
 
 import { ServiceDeliveryFieldSets } from "./serviceDeliveryFieldSets";
@@ -22,6 +22,7 @@ import saving from "@salesforce/label/c.Saving";
 import success from "@salesforce/label/c.Success";
 import serviceDeliveriesAdded from "@salesforce/label/c.Service_Deliveries_Added";
 import serviceFieldMessage from "@salesforce/label/c.BSDT_Service_Fields_Message";
+import savingCompleteMessage from "@salesforce/label/c.BSDT_Saving_Complete_Message";
 import required from "@salesforce/label/c.Required";
 import rowsWithErrors from "@salesforce/label/c.Rows_With_Errors";
 
@@ -62,6 +63,7 @@ export default class BulkServiceDeliveryUI extends NavigationMixin(LightningElem
         success,
         serviceDeliveriesAdded,
         serviceFieldMessage,
+        savingCompleteMessage,
         rowsWithErrors,
         save,
     };
@@ -141,17 +143,11 @@ export default class BulkServiceDeliveryUI extends NavigationMixin(LightningElem
     }
 
     get savingCompleteMessage() {
-        let message = "text";
-        /**
-            "Attempted to save " +
-            this.currentSaveCount +
-            " new or modified rows. There were " +
-            this.savedCount +
-            " successful and " +
-            this.errorCount +
-            " errors. Consult invidivual rows for details.";
-        */
-        return message;
+        return format(this.labels.savingCompleteMessage, [
+            this.currentSaveCount,
+            this.savedCount,
+            this.errorCount,
+        ]);
     }
 
     addDelivery() {

--- a/force-app/main/default/lwc/bulkServiceDeliveryUI/bulkServiceDeliveryUI.js
+++ b/force-app/main/default/lwc/bulkServiceDeliveryUI/bulkServiceDeliveryUI.js
@@ -150,6 +150,15 @@ export default class BulkServiceDeliveryUI extends NavigationMixin(LightningElem
         ]);
     }
 
+    get savingCompleteToastVariant() {
+        if (this.errorCount === 0) {
+            return "success";
+        } else if (this.errorCount === this.currentSaveCount) {
+            return "error";
+        }
+        return "warning";
+    }
+
     addDelivery() {
         let serviceDelivery = {
             index: this._nextIndex,
@@ -184,11 +193,18 @@ export default class BulkServiceDeliveryUI extends NavigationMixin(LightningElem
     // eslint-disable-next-line no-unused-vars
     handleRowError(event) {
         this.errorCount++;
+
         if (this.savingComplete()) {
+            let toastVariant = this.savingCompleteToastVariant;
+            let toastTitle =
+                toastVariant === "success"
+                    ? this.labels.success
+                    : this.labels.rowsWithErrors;
+
             showToast(
-                this.labels.success,
+                toastTitle,
                 this.savingCompleteMessage,
-                "success",
+                toastVariant,
                 "dismissible"
             );
         }
@@ -222,16 +238,17 @@ export default class BulkServiceDeliveryUI extends NavigationMixin(LightningElem
         this.savedCount++;
 
         if (this.savingComplete()) {
+            let toastVariant = this.savingCompleteToastVariant;
+            let toastTitle =
+                toastVariant === "success"
+                    ? this.labels.success
+                    : this.labels.rowsWithErrors;
             showToast(
-                this.labels.success,
+                toastTitle,
                 this.savingCompleteMessage,
-                "success",
+                toastVariant,
                 "dismissible"
             );
-        }
-
-        if (!this.isModal) {
-            return;
         }
 
         if (this.savedCount === this.targetSaveCount) {

--- a/force-app/main/default/lwc/bulkServiceDeliveryUI/bulkServiceDeliveryUI.js
+++ b/force-app/main/default/lwc/bulkServiceDeliveryUI/bulkServiceDeliveryUI.js
@@ -188,23 +188,20 @@ export default class BulkServiceDeliveryUI extends NavigationMixin(LightningElem
         return false;
     }
 
+    showSaveSummaryToast() {
+        let toastVariant = this.savingCompleteToastVariant;
+        let toastTitle =
+            toastVariant === "success" ? this.labels.success : this.labels.rowsWithErrors;
+
+        showToast(toastTitle, this.savingCompleteMessage, toastVariant, "dismissible");
+    }
+
     // eslint-disable-next-line no-unused-vars
     handleRowError(event) {
         this.errorCount++;
 
         if (this.savingComplete()) {
-            let toastVariant = this.savingCompleteToastVariant;
-            let toastTitle =
-                toastVariant === "success"
-                    ? this.labels.success
-                    : this.labels.rowsWithErrors;
-
-            showToast(
-                toastTitle,
-                this.savingCompleteMessage,
-                toastVariant,
-                "dismissible"
-            );
+            this.showSaveSummaryToast();
         }
     }
 
@@ -236,17 +233,7 @@ export default class BulkServiceDeliveryUI extends NavigationMixin(LightningElem
         this.savedCount++;
 
         if (this.savingComplete()) {
-            let toastVariant = this.savingCompleteToastVariant;
-            let toastTitle =
-                toastVariant === "success"
-                    ? this.labels.success
-                    : this.labels.rowsWithErrors;
-            showToast(
-                toastTitle,
-                this.savingCompleteMessage,
-                toastVariant,
-                "dismissible"
-            );
+            this.showSaveSummaryToast();
         }
 
         if (this.savedCount === this.targetSaveCount) {

--- a/force-app/main/default/lwc/bulkServiceDeliveryUI/bulkServiceDeliveryUI.js
+++ b/force-app/main/default/lwc/bulkServiceDeliveryUI/bulkServiceDeliveryUI.js
@@ -22,7 +22,8 @@ import saving from "@salesforce/label/c.Saving";
 import success from "@salesforce/label/c.Success";
 import serviceDeliveriesAdded from "@salesforce/label/c.Service_Deliveries_Added";
 import serviceFieldMessage from "@salesforce/label/c.BSDT_Service_Fields_Message";
-import savingCompleteMessage from "@salesforce/label/c.BSDT_Saving_Complete_Message";
+import savingCompleteSuccessMessage from "@salesforce/label/c.BSDT_Saving_Complete_Success_Message";
+import savingCompleteFailureMessage from "@salesforce/label/c.BSDT_Saving_Complete_Failure_Message";
 import required from "@salesforce/label/c.Required";
 import rowsWithErrors from "@salesforce/label/c.Rows_With_Errors";
 
@@ -63,7 +64,8 @@ export default class BulkServiceDeliveryUI extends NavigationMixin(LightningElem
         success,
         serviceDeliveriesAdded,
         serviceFieldMessage,
-        savingCompleteMessage,
+        savingCompleteSuccessMessage,
+        savingCompleteFailureMessage,
         rowsWithErrors,
         save,
     };
@@ -143,11 +145,25 @@ export default class BulkServiceDeliveryUI extends NavigationMixin(LightningElem
     }
 
     get savingCompleteMessage() {
-        return format(this.labels.savingCompleteMessage, [
-            this.currentSaveCount,
-            this.savedCount,
-            this.errorCount,
-        ]);
+        let successSummary;
+        let failureSummary;
+        if (this.savedCount > 0) {
+            successSummary = format(this.labels.savingCompleteSuccessMessage, [
+                this.savedCount,
+            ]);
+        }
+
+        if (this.errorCount > 0) {
+            failureSummary = format(this.labels.savingCompleteFailureMessage, [
+                this.errorCount,
+            ]);
+        }
+        if (successSummary && failureSummary) {
+            return successSummary + " " + failureSummary;
+        } else if (successSummary) {
+            return successSummary;
+        }
+        return failureSummary;
     }
 
     get savingCompleteToastVariant() {
@@ -190,8 +206,7 @@ export default class BulkServiceDeliveryUI extends NavigationMixin(LightningElem
 
     showSaveSummaryToast() {
         let toastVariant = this.savingCompleteToastVariant;
-        let toastTitle =
-            toastVariant === "success" ? this.labels.success : this.labels.rowsWithErrors;
+        let toastTitle = toastVariant === "success" ? this.labels.success : ""; //this.labels.rowsWithErrors;
 
         showToast(toastTitle, this.savingCompleteMessage, toastVariant, "dismissible");
     }

--- a/force-app/main/default/lwc/bulkServiceDeliveryUI/bulkServiceDeliveryUI.js
+++ b/force-app/main/default/lwc/bulkServiceDeliveryUI/bulkServiceDeliveryUI.js
@@ -206,7 +206,7 @@ export default class BulkServiceDeliveryUI extends NavigationMixin(LightningElem
 
     showSaveSummaryToast() {
         let toastVariant = this.savingCompleteToastVariant;
-        let toastTitle = toastVariant === "success" ? this.labels.success : ""; //this.labels.rowsWithErrors;
+        let toastTitle = toastVariant === "success" ? this.labels.success : "";
 
         showToast(toastTitle, this.savingCompleteMessage, toastVariant, "dismissible");
     }

--- a/force-app/main/default/lwc/serviceDeliveryRow/serviceDeliveryRow.html
+++ b/force-app/main/default/lwc/serviceDeliveryRow/serviceDeliveryRow.html
@@ -143,7 +143,7 @@
                                     ></lightning-spinner>
                                 </div>
                             </template>
-                            <template if:true={showSavedIcon} role="alert">
+                            <div if:true={showSavedIcon} role="alert">
                                 <lightning-icon
                                     tabindex="0"
                                     icon-name="utility:success"
@@ -153,8 +153,8 @@
                                     title={labels.saved}
                                 ></lightning-icon>
                                 <span class="slds-var-p-left_small">{labels.saved}</span>
-                            </template>
-                            <template if:true={showModifiedIcon} role="alert">
+                            </div>
+                            <div if:true={showModifiedIcon} role="alert">
                                 <lightning-icon
                                     tabindex="0"
                                     icon-name="utility:warning"
@@ -164,8 +164,8 @@
                                     title={labels.edited}
                                 ></lightning-icon>
                                 <span class="slds-var-p-left_small">{labels.edited}</span>
-                            </template>
-                            <template if:true={isError} role="alert">
+                            </div>
+                            <div if:true={isError} role="alert">
                                 <lightning-icon
                                     tabindex="0"
                                     icon-name="utility:error"
@@ -175,7 +175,7 @@
                                     title={errorMessage}
                                 ></lightning-icon>
                                 <span class="slds-var-p-left_small">{labels.error}</span>
-                            </template>
+                            </div>
                         </lightning-layout-item>
                         <lightning-layout-item class="slds-text-align_right" size="4">
                             <lightning-button-icon

--- a/force-app/main/default/lwc/serviceDeliveryRow/serviceDeliveryRow.html
+++ b/force-app/main/default/lwc/serviceDeliveryRow/serviceDeliveryRow.html
@@ -144,19 +144,15 @@
                                 </div>
                             </template>
                             <template if:true={showSavedIcon}>
-                                <div role="alert">
-                                    <lightning-icon
-                                        tabindex="0"
-                                        icon-name="utility:success"
-                                        alternative-text={labels.saved}
-                                        size="x-small"
-                                        variant="success"
-                                        title={labels.saved}
-                                    ></lightning-icon>
-                                    <span class="slds-var-p-left_small"
-                                        >{labels.saved}</span
-                                    >
-                                </div>
+                                <lightning-icon
+                                    tabindex="0"
+                                    icon-name="utility:success"
+                                    alternative-text={labels.saved}
+                                    size="x-small"
+                                    variant="success"
+                                    title={labels.saved}
+                                ></lightning-icon>
+                                <span class="slds-var-p-left_small">{labels.saved}</span>
                             </template>
                             <template if:true={showModifiedIcon}>
                                 <div role="alert">
@@ -174,19 +170,15 @@
                                 </div>
                             </template>
                             <template if:true={isError}>
-                                <div role="alert">
-                                    <lightning-icon
-                                        tabindex="0"
-                                        icon-name="utility:error"
-                                        alternative-text={labels.error}
-                                        size="x-small"
-                                        variant="error"
-                                        title={errorMessage}
-                                    ></lightning-icon>
-                                    <span class="slds-var-p-left_small"
-                                        >{labels.error}</span
-                                    >
-                                </div>
+                                <lightning-icon
+                                    tabindex="0"
+                                    icon-name="utility:error"
+                                    alternative-text={labels.error}
+                                    size="x-small"
+                                    variant="error"
+                                    title={errorMessage}
+                                ></lightning-icon>
+                                <span class="slds-var-p-left_small">{labels.error}</span>
                             </template>
                         </lightning-layout-item>
                         <lightning-layout-item class="slds-text-align_right" size="4">

--- a/force-app/main/default/lwc/serviceDeliveryRow/serviceDeliveryRow.html
+++ b/force-app/main/default/lwc/serviceDeliveryRow/serviceDeliveryRow.html
@@ -155,19 +155,15 @@
                                 <span class="slds-var-p-left_small">{labels.saved}</span>
                             </template>
                             <template if:true={showModifiedIcon}>
-                                <div role="alert">
-                                    <lightning-icon
-                                        tabindex="0"
-                                        icon-name="utility:warning"
-                                        alternative-text={labels.edited}
-                                        size="x-small"
-                                        variant="warning"
-                                        title={labels.edited}
-                                    ></lightning-icon>
-                                    <span class="slds-var-p-left_small"
-                                        >{labels.edited}</span
-                                    >
-                                </div>
+                                <lightning-icon
+                                    tabindex="0"
+                                    icon-name="utility:warning"
+                                    alternative-text={labels.edited}
+                                    size="x-small"
+                                    variant="warning"
+                                    title={labels.edited}
+                                ></lightning-icon>
+                                <span class="slds-var-p-left_small">{labels.edited}</span>
                             </template>
                             <template if:true={isError}>
                                 <lightning-icon

--- a/force-app/main/default/lwc/serviceDeliveryRow/serviceDeliveryRow.html
+++ b/force-app/main/default/lwc/serviceDeliveryRow/serviceDeliveryRow.html
@@ -143,39 +143,51 @@
                                     ></lightning-spinner>
                                 </div>
                             </template>
-                            <div if:true={showSavedIcon} role="alert">
-                                <lightning-icon
-                                    tabindex="0"
-                                    icon-name="utility:success"
-                                    alternative-text={labels.saved}
-                                    size="x-small"
-                                    variant="success"
-                                    title={labels.saved}
-                                ></lightning-icon>
-                                <span class="slds-var-p-left_small">{labels.saved}</span>
-                            </div>
-                            <div if:true={showModifiedIcon} role="alert">
-                                <lightning-icon
-                                    tabindex="0"
-                                    icon-name="utility:warning"
-                                    alternative-text={labels.edited}
-                                    size="x-small"
-                                    variant="warning"
-                                    title={labels.edited}
-                                ></lightning-icon>
-                                <span class="slds-var-p-left_small">{labels.edited}</span>
-                            </div>
-                            <div if:true={isError} role="alert">
-                                <lightning-icon
-                                    tabindex="0"
-                                    icon-name="utility:error"
-                                    alternative-text={labels.error}
-                                    size="x-small"
-                                    variant="error"
-                                    title={errorMessage}
-                                ></lightning-icon>
-                                <span class="slds-var-p-left_small">{labels.error}</span>
-                            </div>
+                            <template if:true={showSavedIcon}>
+                                <div role="alert">
+                                    <lightning-icon
+                                        tabindex="0"
+                                        icon-name="utility:success"
+                                        alternative-text={labels.saved}
+                                        size="x-small"
+                                        variant="success"
+                                        title={labels.saved}
+                                    ></lightning-icon>
+                                    <span class="slds-var-p-left_small"
+                                        >{labels.saved}</span
+                                    >
+                                </div>
+                            </template>
+                            <template if:true={showModifiedIcon}>
+                                <div role="alert">
+                                    <lightning-icon
+                                        tabindex="0"
+                                        icon-name="utility:warning"
+                                        alternative-text={labels.edited}
+                                        size="x-small"
+                                        variant="warning"
+                                        title={labels.edited}
+                                    ></lightning-icon>
+                                    <span class="slds-var-p-left_small"
+                                        >{labels.edited}</span
+                                    >
+                                </div>
+                            </template>
+                            <template if:true={isError}>
+                                <div role="alert">
+                                    <lightning-icon
+                                        tabindex="0"
+                                        icon-name="utility:error"
+                                        alternative-text={labels.error}
+                                        size="x-small"
+                                        variant="error"
+                                        title={errorMessage}
+                                    ></lightning-icon>
+                                    <span class="slds-var-p-left_small"
+                                        >{labels.error}</span
+                                    >
+                                </div>
+                            </template>
                         </lightning-layout-item>
                         <lightning-layout-item class="slds-text-align_right" size="4">
                             <lightning-button-icon


### PR DESCRIPTION
Update markup to correctly announce save and error messages on row-level save of BSDT

# Critical Changes

# Changes

# Issues Closed
- [W-10311123](https://gus.lightning.force.com/a07EE00000XtqtTYAR)

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
- [ ] Any net new LWC work has Sa11y tests & 50% or above lines JEST test coverage  
- [ ] CRUD/FLS is enforced in Apex
- [ ] Permission sets are updated to account for CRUD|FLS|Tab|Classes
- [ ] Field sets are updated to account for new fields
- [ ] UX approval or UX not necessary
- [ ] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: W-0000000: Work Name (https://github.com/SalesforceFoundation/PMM/pull/303)
- [ ] All **acceptance criteria** have been met
    - [ ] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [ ] PR contains draft release notes
- [ ] QE story level testing completed