### PR TITLE
Fix issue with days of week selection

### DIFF
--- a/force-app/main/default/lwc/picklist/picklist.html
+++ b/force-app/main/default/lwc/picklist/picklist.html
@@ -5,8 +5,7 @@
   -  * SPDX-License-Identifier: BSD-3-Clause
   -  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
   -  */
-  -->
-
+-->
 <template>
     <div class="slds-var-p-bottom_small slds-var-p-left_xxx-small" if:true={options}>
         <div if:true={multiSelect}>
@@ -26,7 +25,9 @@
                                     value={option.value}
                                     id={option.value}
                                     name={option.value}
+                                    label={option.label}
                                     onclick={handleMultiSelectClick}
+                                    checked={option.isChecked}
                                 />
                                 <label
                                     class="slds-checkbox_button__label"

--- a/force-app/main/default/lwc/picklist/picklist.js
+++ b/force-app/main/default/lwc/picklist/picklist.js
@@ -9,8 +9,6 @@
 
 import { LightningElement, api, track } from "lwc";
 
-const UNSELECTED_VARIANT = "neutral";
-const SELECTED_VARIANT = "brand";
 const MULTI_SELECT_DELIM = ";";
 
 export default class Picklist extends LightningElement {
@@ -59,7 +57,7 @@ export default class Picklist extends LightningElement {
                 value: picklistValue.value,
                 label: picklistValue.label,
                 isSelected: isSelected,
-                variant: isSelected ? SELECTED_VARIANT : UNSELECTED_VARIANT,
+                isChecked: isSelected,
             };
         });
     }
@@ -76,6 +74,7 @@ export default class Picklist extends LightningElement {
         this.options.forEach(option => {
             if (option.value === event.target.name) {
                 option.isSelected = !option.isSelected;
+                option.isChecked = true;
             }
         });
 


### PR DESCRIPTION
# Critical Changes

# Changes
If for a Service Schedule if the user has selected the Weekly frequency with days of the week, now when the user clicks on Add More Sessions button, the days of the week stored on the service schedule record is pre selected.
# Issues Closed
[W-11418570](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000011IS2XYAW/view)
# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
~~- [ ] Any net new LWC work has Sa11y tests & 50% or above lines JEST test coverage~~  
~~- [ ] CRUD/FLS is enforced in Apex~~
~~- [ ] Permission sets are updated to account for CRUD|FLS|Tab|Classes~~
~~- [ ] Field sets are updated to account for new fields~~
~~- [ ] UX approval or UX not necessary~~
- [x] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: W-0000000: Work Name (https://github.com/SalesforceFoundation/PMM/pull/303)
- [ ] All **acceptance criteria** have been met
    - [x] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [x ] PR contains draft release notes
- [ ] QE story level testing completed