### PR TITLE
Fix Monthly Schedule

### DIFF
--- a/force-app/main/default/lwc/newServiceSchedule/newServiceSchedule.js
+++ b/force-app/main/default/lwc/newServiceSchedule/newServiceSchedule.js
@@ -357,6 +357,7 @@ export default class NewServiceSchedule extends LightningElement {
                     initialStartDate.setMonth(today.getMonth());
                     initialStartDate.setDate(today.getDate());
                     initialStartDate.setFullYear(today.getFullYear());
+                    this.handleMonthlyRecurrenceOptions(initialStartDate);
                 }
                 if (this.useMinimumStartAfterLastSession) {
                     let minimumStartDateValue = new Date(

--- a/force-app/main/default/lwc/newServiceSchedule/newServiceSchedule.js
+++ b/force-app/main/default/lwc/newServiceSchedule/newServiceSchedule.js
@@ -357,7 +357,9 @@ export default class NewServiceSchedule extends LightningElement {
                     initialStartDate.setMonth(today.getMonth());
                     initialStartDate.setDate(today.getDate());
                     initialStartDate.setFullYear(today.getFullYear());
-                    this.handleMonthlyRecurrenceOptions(initialStartDate);
+                    if (this.isMonthly) {
+                        this.handleMonthlyRecurrenceOptions(initialStartDate);
+                    }
                 }
                 if (this.useMinimumStartAfterLastSession) {
                     let minimumStartDateValue = new Date(


### PR DESCRIPTION
// When the Add More Sessions button is clicked on an existing session, and the monthly option is selected, the picklist defaults to the start date. This feature has not yet been released so no release notes are needed.

# Critical Changes

# Changes

# Issues Closed
[W-11418571](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000011ILZ0YAO/view)
# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
~~- [ ] Any net new LWC work has Sa11y tests & 50% or above lines JEST test coverage~~  
~~- [ ] CRUD/FLS is enforced in Apex~~
~~- [ ] Permission sets are updated to account for CRUD|FLS|Tab|Classes~~
~~- [ ] Field sets are updated to account for new fields~~
~~- [ ] UX approval or UX not necessary~~
- [x] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: W-0000000: Work Name (https://github.com/SalesforceFoundation/PMM/pull/303)
- [ ] All **acceptance criteria** have been met
    - [x] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [x] PR contains draft release notes
- [ ] QE story level testing completed