### PR TITLE
Improving Initial Load for Participant Selector in BSDT

### DIFF
--- a/force-app/main/default/classes/ProgramEngagementSelector.cls
+++ b/force-app/main/default/classes/ProgramEngagementSelector.cls
@@ -72,7 +72,8 @@ public with sharing class ProgramEngagementSelector {
     public List<ProgramEngagement__c> getProgramEngagementsByProgramId(
         Id programId,
         Set<String> fields,
-        Set<String> stages
+        Set<String> stages,
+        Integer engagementLimit
     ) {
         if (
             !(Schema.SObjectType.ProgramEngagement__c.isAccessible() &&
@@ -84,8 +85,8 @@ public with sharing class ProgramEngagementSelector {
             return new List<ProgramEngagement__c>();
         }
 
-        Integer limitTo =
-            System.Limits.getLimitQueryRows() - System.Limits.getQueryRows();
+        // Integer limitTo =
+        //     System.Limits.getLimitQueryRows() - System.Limits.getQueryRows();
 
         queryBuilder
             .reset()
@@ -95,7 +96,7 @@ public with sharing class ProgramEngagementSelector {
                 String.valueOf(ProgramEngagement__c.Program__c) + ' = :programId'
             )
             .addCondition(String.valueOf(ProgramEngagement__c.Stage__c) + ' IN :stages')
-            .withLimit(limitTo);
+            .withLimit(engagementLimit);
 
         List<ProgramEngagement__c> programEngagements = Database.query(
             queryBuilder.buildSoqlQuery()

--- a/force-app/main/default/classes/ServiceScheduleCreatorController.cls
+++ b/force-app/main/default/classes/ServiceScheduleCreatorController.cls
@@ -47,9 +47,9 @@ public with sharing class ServiceScheduleCreatorController {
     }
 
     @AuraEnabled(cacheable=true)
-    public static SelectParticipantModel getSelectParticipantModel(Id serviceId) {
+    public static SelectParticipantModel getSelectParticipantModel(Id serviceId, Integer engagementLimit) {
         try {
-            return service.getSelectParticipantModel(serviceId);
+            return service.getSelectParticipantModel(serviceId, engagementLimit);
         } catch (Exception ex) {
             throw Util.getAuraHandledException(ex);
         }

--- a/force-app/main/default/classes/ServiceScheduleService.cls
+++ b/force-app/main/default/classes/ServiceScheduleService.cls
@@ -98,9 +98,9 @@ public with sharing class ServiceScheduleService {
         domain.insertParticipants(engagements, schedule);
     }
 
-    public SelectParticipantModel getSelectParticipantModel(Id serviceId) {
+    public SelectParticipantModel getSelectParticipantModel(Id serviceId, Integer engagementLimit) {
         SelectParticipantModel model = new SelectParticipantModel();
-        loadAndPopulateParticipantRecords(serviceId, model);
+        loadAndPopulateParticipantRecords(serviceId, model, engagementLimit);
         return model;
     }
 
@@ -248,7 +248,8 @@ public with sharing class ServiceScheduleService {
 
     private void loadAndPopulateParticipantRecords(
         Id serviceId,
-        SelectParticipantModel model
+        SelectParticipantModel model,
+        Integer engagementLimit
     ) {
         model.program = programEngagementSelector.getProgramByServiceId(serviceId);
         if (model.program == null) {
@@ -262,7 +263,8 @@ public with sharing class ServiceScheduleService {
         model.programEngagements = programEngagementSelector.getProgramEngagementsByProgramId(
             model.program.Id,
             getSelectFieldsWithToLabel(model),
-            progEngagementService.getActiveStages()
+            progEngagementService.getActiveStages(), 
+            engagementLimit
         );
     }
 

--- a/force-app/main/default/lwc/participantSelector/participantSelector.html
+++ b/force-app/main/default/lwc/participantSelector/participantSelector.html
@@ -78,6 +78,16 @@
                                     </lightning-layout-item>
                                     <lightning-layout-item
                                         size="12"
+                                        class="slds-var-p-bottom_small"
+                                        if:true={showLimitInfo}
+                                    >
+                                        <c-scoped-notification
+                                            theme="info"
+                                            title={none}
+                                        ></c-scoped-notification>
+                                    </lightning-layout-item>
+                                    <lightning-layout-item
+                                        size="12"
                                         if:false={noRecordsFound}
                                     >
                                         <div

--- a/force-app/main/default/lwc/participantSelector/participantSelector.js
+++ b/force-app/main/default/lwc/participantSelector/participantSelector.js
@@ -39,6 +39,7 @@ import removeLabel from "@salesforce/label/c.Remove";
 
 const TIME = "TIME";
 const SEARCH_DELAY = 1000;
+const ENGAGEMENT_LIMIT = 10;
 
 export default class ParticipantSelector extends LightningElement {
     @api serviceId;
@@ -69,6 +70,7 @@ export default class ParticipantSelector extends LightningElement {
     offsetRows = 50;
     offset = this.offsetRows;
     showSpinner = false;
+    showLimitInfo = false;
 
     _searchTimeout;
 
@@ -161,7 +163,7 @@ export default class ParticipantSelector extends LightningElement {
         return `${name} (${this.participantCount}/${this.capacity})`;
     }
 
-    @wire(getSelectParticipantModel, { serviceId: "$serviceId" })
+    @wire(getSelectParticipantModel, { serviceId: "$serviceId", engagementLimit: (ENGAGEMENT_LIMIT + 1)})
     dataSetup(result) {
         this.wiredData = result;
         if (!(result.data || result.error)) {
@@ -169,6 +171,7 @@ export default class ParticipantSelector extends LightningElement {
         }
 
         if (result.data) {
+            this.showLimitInfo = (result.data.programEngagements.length > ENGAGEMENT_LIMIT);
             this.loadTable(result.data);
             this.loadTableRows(result.data);
             this.loadPreviousSelections();
@@ -207,7 +210,7 @@ export default class ParticipantSelector extends LightningElement {
 
     loadTableRows(data) {
         let selectedIds = this.selectedEngagements.map(engagement => engagement.Id);
-        this.allEngagements = data.programEngagements.slice(0);
+        this.allEngagements = data.programEngagements.slice(0, ENGAGEMENT_LIMIT);
 
         this.availableEngagementRows = this.allEngagements
             .filter(engagement => !selectedIds.includes(engagement.Id))


### PR DESCRIPTION
…o scoped notification to show when limit is exceeded

# Critical Changes

# Changes
- Added info scoped notification to show when there are too many records to show
- Added limit for the number of program engagements to show (set to 1000)
# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
- [ ] Any net new LWC work has Sa11y tests & 50% or above lines JEST test coverage  
- [ ] CRUD/FLS is enforced in Apex
- [ ] Permission sets are updated to account for CRUD|FLS|Tab|Classes
- [ ] Field sets are updated to account for new fields
- [ ] UX approval or UX not necessary
- [ ] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: W-0000000: Work Name (https://github.com/SalesforceFoundation/PMM/pull/303)
- [ ] All **acceptance criteria** have been met
    - [ ] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [ ] PR contains draft release notes
- [ ] QE story level testing completed