### PR TITLE
Stage Filter for Participant Selector

### DIFF
--- a/force-app/main/default/classes/ProgramEngagementSelector.cls
+++ b/force-app/main/default/classes/ProgramEngagementSelector.cls
@@ -31,6 +31,39 @@ public with sharing class ProgramEngagementSelector {
             .getRecords();
     }
 
+    public ProgramEngagement__c getProgramEngagementById(Id peId) {
+        if (
+            !(Schema.SObjectType.ProgramEngagement__c.isAccessible() &&
+            PermissionValidator.getInstance()
+                .hasFieldReadAccess(ProgramEngagement__c.Contact__c.getDescribe()) &&
+            PermissionValidator.getInstance()
+                .hasFieldReadAccess(ProgramEngagement__c.Program__c.getDescribe()))
+        ) {
+            return null;
+        }
+
+        List<ProgramEngagement__c> queriedEngagements = [
+            SELECT
+                Id,
+                Name,
+                Program__c,
+                Program__r.Name,
+                ProgramCohort__c,
+                Stage__c,
+                Contact__c,
+                Contact__r.Name,
+                Contact__r.Email
+            FROM ProgramEngagement__c
+            WHERE Id = :peId
+        ];
+        List<ProgramEngagement__c> securityResult = Security.stripInaccessible(
+                AccessType.READABLE,
+                queriedEngagements
+            )
+            .getRecords();
+        return securityResult.isEmpty() ? null : securityResult[0];
+    }
+
     // Using strip inaccessible and performing access checks for
     // all fields involved in the query. Id, Name must be true if object
     // access is true.

--- a/force-app/main/default/classes/ProgramEngagementSelector_TEST.cls
+++ b/force-app/main/default/classes/ProgramEngagementSelector_TEST.cls
@@ -124,9 +124,9 @@ public with sharing class ProgramEngagementSelector_TEST {
                 SELECT Id, Contact__r.Name, Contact__r.Email, Stage__c, ProgramCohort__c
                 FROM ProgramEngagement__c
                 WHERE
-                    Stage__c IN :ACTIVE_ENGAGEMENT_STAGES
-                    AND Program__c = :program.Id
+                    Program__c = :program.Id
                     AND Contact__r.Name LIKE '%Contact%'
+                    AND Stage__c = 'Enrolled'
             ]
         );
 
@@ -151,7 +151,7 @@ public with sharing class ProgramEngagementSelector_TEST {
                 'Name',
                 String.valueOf(ProgramEngagement__c.ProgramCohort__c)
             },
-            ACTIVE_ENGAGEMENT_STAGES,
+            new Set<String>{ 'Enrolled' },
             'Test Contact',
             null
         );

--- a/force-app/main/default/classes/ProgramEngagementSelector_TEST.cls
+++ b/force-app/main/default/classes/ProgramEngagementSelector_TEST.cls
@@ -75,6 +75,54 @@ public with sharing class ProgramEngagementSelector_TEST {
     }
 
     @IsTest
+    private static void testGetProgramEngagementsById() {
+        ProgramEngagement__c expected = [
+            SELECT Id, Name
+            FROM ProgramEngagement__c
+            LIMIT 1
+        ][0];
+
+        Test.startTest();
+        ProgramEngagementSelector selector = new ProgramEngagementSelector();
+        ProgramEngagement__c actual = selector.getProgramEngagementById(expected.Id);
+        Test.stopTest();
+        System.assertEquals(expected.Id, actual.Id);
+    }
+
+    @IsTest
+    private static void testGetProgramEngagementsByIdNoAccess() {
+        Profile p = [SELECT Id FROM Profile WHERE Name = 'Standard User'];
+        Integer random = Integer.valueOf(math.rint(math.random() * 1000000));
+        User u = new User(
+            Alias = 'stand',
+            Email = 'standarduser2@' + random + '.example.com',
+            EmailEncodingKey = 'UTF-8',
+            LastName = 'StandardUser',
+            LanguageLocaleKey = 'en_US',
+            LocaleSidKey = 'en_US',
+            ProfileId = p.Id,
+            TimeZoneSidKey = 'America/Los_Angeles',
+            UserName = 'standarduser2@' + random + '.example.com'
+        );
+
+        ProgramEngagement__c engagement = [
+            SELECT Id, Name
+            FROM ProgramEngagement__c
+            LIMIT 1
+        ][0];
+
+        Test.startTest();
+        System.runAs(u) {
+            ProgramEngagementSelector selector = new ProgramEngagementSelector();
+            ProgramEngagement__c actual = selector.getProgramEngagementById(
+                engagement.Id
+            );
+            System.assertEquals(null, actual);
+        }
+        Test.stopTest();
+    }
+
+    @IsTest
     private static void testGetProgramEngagementsByProgramId() {
         Program__c program = [SELECT Id, Name FROM Program__c LIMIT 1];
 

--- a/force-app/main/default/classes/ProgramEngagementService.cls
+++ b/force-app/main/default/classes/ProgramEngagementService.cls
@@ -43,4 +43,17 @@ public with sharing class ProgramEngagementService {
 
         return activeStages;
     }
+
+    public Map<String, String> getActiveStagesWithLabels() {
+        Set<String> apiNames = activeStages;
+        Map<String, String> result = new Map<String, String>();
+        Schema.DescribeFieldResult fieldResult = ProgramEngagement__c.Stage__c.getDescribe();
+        List<Schema.PicklistEntry> ple = fieldResult.getPicklistValues();
+        for (Schema.PicklistEntry f : ple) {
+            if (apiNames.contains(f.getValue())) {
+                result.put(f.getValue(), f.getLabel());
+            }
+        }
+        return result;
+    }
 }

--- a/force-app/main/default/classes/ProgramEngagementService.cls
+++ b/force-app/main/default/classes/ProgramEngagementService.cls
@@ -44,7 +44,7 @@ public with sharing class ProgramEngagementService {
         return activeStages;
     }
 
-    public Map<String, String> getActiveStagesWithLabels() {
+    public Map<String, String> getActiveStagesByValue() {
         Set<String> apiNames = activeStages;
         Map<String, String> result = new Map<String, String>();
         Schema.DescribeFieldResult fieldResult = ProgramEngagement__c.Stage__c.getDescribe();

--- a/force-app/main/default/classes/ProgramEngagementService.cls
+++ b/force-app/main/default/classes/ProgramEngagementService.cls
@@ -10,6 +10,8 @@
 public with sharing class ProgramEngagementService {
     @TestVisible
     private FieldBucketSelector bucketSelector = new FieldBucketSelector();
+    @TestVisible
+    private ProgramEngagementSelector selector = new ProgramEngagementSelector();
 
     @TestVisible
     private Set<String> activeStages {
@@ -55,5 +57,9 @@ public with sharing class ProgramEngagementService {
             }
         }
         return result;
+    }
+
+    public ProgramEngagement__c getProgramEngagementById(Id peId) {
+        return selector.getProgramEngagementById(peId);
     }
 }

--- a/force-app/main/default/classes/ProgramEngagementService_TEST.cls
+++ b/force-app/main/default/classes/ProgramEngagementService_TEST.cls
@@ -10,6 +10,7 @@
 @IsTest
 public with sharing class ProgramEngagementService_TEST {
     private static TestStub bucketSelectorStub;
+    private static TestStub peSelectorStub;
 
     private static ProgramEngagementService service = new ProgramEngagementService();
 
@@ -68,6 +69,30 @@ public with sharing class ProgramEngagementService_TEST {
             expectedStageMap.size(),
             actualStageMap.size(),
             'Returned incorrect number of mappings'
+        );
+    }
+
+    @IsTest
+    private static void shouldGetProgramEngagementById() {
+        Id peId = TestUtil.mockId(ProgramEngagement__c.SObjectType);
+        ProgramEngagement__c expected = new ProgramEngagement__c();
+        expected.Id = peId;
+
+        peSelectorStub = new StubBuilder(ProgramEngagementSelector.class)
+            .when('getProgramEngagementById', Id.class)
+            .calledWith(peId)
+            .thenReturn(expected)
+            .build();
+        service.selector = (ProgramEngagementSelector) peSelectorStub.create();
+
+        Test.startTest();
+        ProgramEngagement__c actual = service.getProgramEngagementById(peId);
+        Test.stopTest();
+
+        System.assertEquals(
+            expected,
+            actual,
+            'Did not return the expected Program Engagement'
         );
     }
 

--- a/force-app/main/default/classes/ProgramEngagementService_TEST.cls
+++ b/force-app/main/default/classes/ProgramEngagementService_TEST.cls
@@ -53,33 +53,16 @@ public with sharing class ProgramEngagementService_TEST {
     }
 
     @IsTest
-    private static void shouldGetActiveStagesWithLabels() {
-        List<String> bucketNames = new List<String>{ 'Active' };
-
+    private static void shouldGetActiveStagesByValue() {
         Schema.SObjectType programEngagementSObjType = ProgramEngagement__c.SObjectType;
         Schema.SObjectField stageField = ProgramEngagement__c.Stage__c;
-
-        List<Bucket__mdt> stageBuckets = createBuckets();
-
-        bucketSelectorStub = new StubBuilder(FieldBucketSelector.class)
-            .when(
-                'getBuckets',
-                List<String>.class,
-                Schema.SObjectType.class,
-                Schema.SObjectField.class
-            )
-            .calledWith(bucketNames, programEngagementSObjType, stageField)
-            .thenReturn(stageBuckets)
-            .build();
-
-        service.bucketSelector = (FieldBucketSelector) bucketSelectorStub.create();
 
         Map<String, String> expectedStageMap = new Map<String, String>();
         expectedStageMap.put('Active', 'Active');
         expectedStageMap.put('Enrolled', 'Enrolled');
 
         Test.startTest();
-        Map<String, String> actualStageMap = service.getActiveStagesWithLabels();
+        Map<String, String> actualStageMap = service.getActiveStagesByValue();
         Test.stopTest();
         System.assertEquals(
             expectedStageMap.size(),

--- a/force-app/main/default/classes/ProgramEngagementService_TEST.cls
+++ b/force-app/main/default/classes/ProgramEngagementService_TEST.cls
@@ -52,6 +52,42 @@ public with sharing class ProgramEngagementService_TEST {
         bucketSelectorStub.assertCalledAsExpected();
     }
 
+    @IsTest
+    private static void shouldGetActiveStagesWithLabels() {
+        List<String> bucketNames = new List<String>{ 'Active' };
+
+        Schema.SObjectType programEngagementSObjType = ProgramEngagement__c.SObjectType;
+        Schema.SObjectField stageField = ProgramEngagement__c.Stage__c;
+
+        List<Bucket__mdt> stageBuckets = createBuckets();
+
+        bucketSelectorStub = new StubBuilder(FieldBucketSelector.class)
+            .when(
+                'getBuckets',
+                List<String>.class,
+                Schema.SObjectType.class,
+                Schema.SObjectField.class
+            )
+            .calledWith(bucketNames, programEngagementSObjType, stageField)
+            .thenReturn(stageBuckets)
+            .build();
+
+        service.bucketSelector = (FieldBucketSelector) bucketSelectorStub.create();
+
+        Map<String, String> expectedStageMap = new Map<String, String>();
+        expectedStageMap.put('Active', 'Active');
+        expectedStageMap.put('Enrolled', 'Enrolled');
+
+        Test.startTest();
+        Map<String, String> actualStageMap = service.getActiveStagesWithLabels();
+        Test.stopTest();
+        System.assertEquals(
+            expectedStageMap.size(),
+            actualStageMap.size(),
+            'Returned incorrect number of mappings'
+        );
+    }
+
     private static List<Bucket__mdt> createBuckets() {
         BucketedField__mdt bucketedField = (BucketedField__mdt) new TestUtil.BucketedFieldBuilder()
             .withDeveloperName('ProgramEngagementStage')

--- a/force-app/main/default/classes/SelectParticipantModel.cls
+++ b/force-app/main/default/classes/SelectParticipantModel.cls
@@ -29,9 +29,6 @@ public with sharing class SelectParticipantModel {
         ),
         'programCohort' => fieldSetService.getFieldForLWC(
             Schema.ProgramEngagement__c.ProgramCohort__c.getDescribe()
-        ),
-        'stage' => fieldSetService.getFieldForLWC(
-            Schema.ProgramEngagement__c.Stage__c.getDescribe()
         )
     };
     private Map<String, Map<String, Object>> scheduleFields = new Map<String, Map<String, Object>>{

--- a/force-app/main/default/classes/SelectParticipantModel.cls
+++ b/force-app/main/default/classes/SelectParticipantModel.cls
@@ -29,6 +29,9 @@ public with sharing class SelectParticipantModel {
         ),
         'programCohort' => fieldSetService.getFieldForLWC(
             Schema.ProgramEngagement__c.ProgramCohort__c.getDescribe()
+        ),
+        'stage' => fieldSetService.getFieldForLWC(
+            Schema.ProgramEngagement__c.Stage__c.getDescribe()
         )
     };
     private Map<String, Map<String, Object>> scheduleFields = new Map<String, Map<String, Object>>{

--- a/force-app/main/default/classes/ServiceScheduleCreatorController.cls
+++ b/force-app/main/default/classes/ServiceScheduleCreatorController.cls
@@ -51,7 +51,7 @@ public with sharing class ServiceScheduleCreatorController {
     @AuraEnabled(cacheable=true)
     public static Map<String, String> getActiveStages() {
         try {
-            return peService.getActiveStagesWithLabels();
+            return peService.getActiveStagesByValue();
         } catch (Exception ex) {
             throw Util.getAuraHandledException(ex);
         }

--- a/force-app/main/default/classes/ServiceScheduleCreatorController.cls
+++ b/force-app/main/default/classes/ServiceScheduleCreatorController.cls
@@ -10,6 +10,8 @@
 public with sharing class ServiceScheduleCreatorController {
     @TestVisible
     private static ServiceScheduleService service = new ServiceScheduleService();
+    @TestVisible
+    private static ProgramEngagementService peService = new ProgramEngagementService();
 
     @AuraEnabled(cacheable=true)
     public static ServiceScheduleModel getServiceScheduleModel(
@@ -47,16 +49,31 @@ public with sharing class ServiceScheduleCreatorController {
     }
 
     @AuraEnabled(cacheable=true)
+    public static Map<String, String> getActiveStages() {
+        try {
+            return peService.getActiveStagesWithLabels();
+        } catch (Exception ex) {
+            throw Util.getAuraHandledException(ex);
+        }
+    }
+
+    @AuraEnabled(cacheable=true)
     public static SelectParticipantModel getSelectParticipantModel(
         Id serviceId,
         String searchText,
+        String stage,
         String cohortId
     ) {
         if (cohortId == '') {
             cohortId = null;
         }
         try {
-            return service.getSelectParticipantModel(serviceId, searchText, cohortId);
+            return service.getSelectParticipantModel(
+                serviceId,
+                searchText,
+                stage,
+                cohortId
+            );
         } catch (Exception ex) {
             throw Util.getAuraHandledException(ex);
         }

--- a/force-app/main/default/classes/ServiceScheduleCreatorController.cls
+++ b/force-app/main/default/classes/ServiceScheduleCreatorController.cls
@@ -35,6 +35,15 @@ public with sharing class ServiceScheduleCreatorController {
     }
 
     @AuraEnabled
+    public static ProgramEngagement__c getProgramEngagementById(Id peId) {
+        try {
+            return peService.getProgramEngagementById(peId);
+        } catch (Exception ex) {
+            throw Util.getAuraHandledException(ex);
+        }
+    }
+
+    @AuraEnabled
     // Doing fls checks in the validateCreateAccess method in the domain
     /* sfca-disable-stack ApexFlsViolationRule */
     public static void addParticipants(

--- a/force-app/main/default/classes/ServiceScheduleCreatorController_TEST.cls
+++ b/force-app/main/default/classes/ServiceScheduleCreatorController_TEST.cls
@@ -10,6 +10,56 @@
 @IsTest
 public with sharing class ServiceScheduleCreatorController_TEST {
     private static BasicStub serviceStub = new BasicStub(ServiceScheduleService.class);
+    private static BasicStub peServiceStub = new BasicStub(
+        ProgramEngagementService.class
+    );
+
+    @IsTest
+    private static void shouldGetActiveStages() {
+        String methodName = 'getActiveStagesWithLabels';
+        Map<String, String> expectedStageMap = new Map<String, String>{
+            'Active' => 'Active',
+            'Enrolled' => 'Enrolled'
+        };
+
+        peServiceStub.withReturnValue(methodName, expectedStageMap);
+        ServiceScheduleCreatorController.peService = (ProgramEngagementService) peServiceStub.createMock();
+
+        Test.startTest();
+        Map<String, String> actualStageMap = ServiceScheduleCreatorController.getActiveStages();
+        Test.stopTest();
+
+        System.assertEquals(
+            expectedStageMap,
+            actualStageMap,
+            'Expected stage map was not returned'
+        );
+        peServiceStub.assertCalled(methodName);
+    }
+
+    @IsTest
+    private static void shouldGetActiveStagesException() {
+        String methodName = 'getActiveStagesWithLabels';
+        peServiceStub.withThrowException(methodName);
+        Exception actualException;
+
+        ServiceScheduleCreatorController.peService = (ProgramEngagementService) peServiceStub.createMock();
+        Map<String, String> actualStageMap;
+        Test.startTest();
+        try {
+            actualStageMap = ServiceScheduleCreatorController.getActiveStages();
+        } catch (Exception ex) {
+            actualException = ex;
+        }
+        Test.stopTest();
+
+        System.assertEquals(
+            peServiceStub.testExceptionMessage,
+            actualException.getMessage(),
+            'Expected the controller to rethrow the exception from the service.'
+        );
+        peServiceStub.assertCalled(methodName);
+    }
 
     @IsTest
     private static void shouldGetModelFromService() {
@@ -493,7 +543,7 @@ public with sharing class ServiceScheduleCreatorController_TEST {
 
         serviceStub.withReturnValue(
             methodName,
-            new List<Type>{ Id.class, String.class, Id.class },
+            new List<Type>{ Id.class, String.class, String.class, Id.class },
             modelToReturn
         );
 
@@ -503,6 +553,7 @@ public with sharing class ServiceScheduleCreatorController_TEST {
 
         SelectParticipantModel actual = ServiceScheduleCreatorController.getSelectParticipantModel(
             serviceId,
+            null,
             null,
             null
         );
@@ -522,8 +573,8 @@ public with sharing class ServiceScheduleCreatorController_TEST {
 
         serviceStub.assertCalledWith(
             methodName,
-            new List<Type>{ Id.class, String.class, Id.class },
-            new List<Object>{ serviceId, null, null }
+            new List<Type>{ Id.class, String.class, String.class, Id.class },
+            new List<Object>{ serviceId, null, null, null }
         );
     }
 
@@ -531,12 +582,13 @@ public with sharing class ServiceScheduleCreatorController_TEST {
     private static void testGetSelectParticipantModelWithEmptyCohort() {
         Id serviceId = TestUtil.mockId(Service__c.SObjectType);
         String searchString = 'Test';
+        String stageString = '';
         SelectParticipantModel modelToReturn = new SelectParticipantModel();
         String methodName = 'getSelectParticipantModel';
 
         serviceStub.withReturnValue(
             methodName,
-            new List<Type>{ Id.class, String.class, Id.class },
+            new List<Type>{ Id.class, String.class, String.class, Id.class },
             modelToReturn
         );
 
@@ -547,6 +599,7 @@ public with sharing class ServiceScheduleCreatorController_TEST {
         SelectParticipantModel actual = ServiceScheduleCreatorController.getSelectParticipantModel(
             serviceId,
             searchString,
+            stageString,
             ''
         );
 
@@ -565,8 +618,8 @@ public with sharing class ServiceScheduleCreatorController_TEST {
 
         serviceStub.assertCalledWith(
             methodName,
-            new List<Type>{ Id.class, String.class, Id.class },
-            new List<Object>{ serviceId, searchString, null }
+            new List<Type>{ Id.class, String.class, String.class, Id.class },
+            new List<Object>{ serviceId, searchString, null, null }
         );
     }
 
@@ -575,12 +628,13 @@ public with sharing class ServiceScheduleCreatorController_TEST {
         Id serviceId = TestUtil.mockId(Service__c.SObjectType);
         Id cohortId = TestUtil.mockId(ProgramCohort__c.SObjectType);
         String searchString = 'Test';
+        String stageString = '';
         SelectParticipantModel modelToReturn = new SelectParticipantModel();
         String methodName = 'getSelectParticipantModel';
 
         serviceStub.withReturnValue(
             methodName,
-            new List<Type>{ Id.class, String.class, Id.class },
+            new List<Type>{ Id.class, String.class, String.class, Id.class },
             modelToReturn
         );
 
@@ -591,6 +645,7 @@ public with sharing class ServiceScheduleCreatorController_TEST {
         SelectParticipantModel actual = ServiceScheduleCreatorController.getSelectParticipantModel(
             serviceId,
             searchString,
+            stageString,
             cohortId
         );
 
@@ -609,8 +664,8 @@ public with sharing class ServiceScheduleCreatorController_TEST {
 
         serviceStub.assertCalledWith(
             methodName,
-            new List<Type>{ Id.class, String.class, Id.class },
-            new List<Object>{ serviceId, searchString, cohortId }
+            new List<Type>{ Id.class, String.class, String.class, Id.class },
+            new List<Object>{ serviceId, searchString, stageString, cohortId }
         );
     }
 
@@ -623,7 +678,7 @@ public with sharing class ServiceScheduleCreatorController_TEST {
 
         serviceStub.withThrowException(
             methodName,
-            new List<Type>{ Id.class, String.class, Id.class }
+            new List<Type>{ Id.class, String.class, String.class, Id.class }
         );
         ServiceScheduleCreatorController.service = (ServiceScheduleService) serviceStub.createMock();
 
@@ -631,6 +686,7 @@ public with sharing class ServiceScheduleCreatorController_TEST {
         try {
             actual = ServiceScheduleCreatorController.getSelectParticipantModel(
                 serviceId,
+                null,
                 null,
                 null
             );
@@ -649,8 +705,8 @@ public with sharing class ServiceScheduleCreatorController_TEST {
 
         serviceStub.assertCalledWith(
             methodName,
-            new List<Type>{ Id.class, String.class, Id.class },
-            new List<Object>{ serviceId, null, null }
+            new List<Type>{ Id.class, String.class, String.class, Id.class },
+            new List<Object>{ serviceId, null, null, null }
         );
     }
 

--- a/force-app/main/default/classes/ServiceScheduleCreatorController_TEST.cls
+++ b/force-app/main/default/classes/ServiceScheduleCreatorController_TEST.cls
@@ -16,7 +16,7 @@ public with sharing class ServiceScheduleCreatorController_TEST {
 
     @IsTest
     private static void shouldGetActiveStages() {
-        String methodName = 'getActiveStagesWithLabels';
+        String methodName = 'getActiveStagesByValue';
         Map<String, String> expectedStageMap = new Map<String, String>{
             'Active' => 'Active',
             'Enrolled' => 'Enrolled'
@@ -39,7 +39,7 @@ public with sharing class ServiceScheduleCreatorController_TEST {
 
     @IsTest
     private static void shouldGetActiveStagesException() {
-        String methodName = 'getActiveStagesWithLabels';
+        String methodName = 'getActiveStagesByValue';
         peServiceStub.withThrowException(methodName);
         Exception actualException;
 

--- a/force-app/main/default/classes/ServiceScheduleCreatorController_TEST.cls
+++ b/force-app/main/default/classes/ServiceScheduleCreatorController_TEST.cls
@@ -62,6 +62,55 @@ public with sharing class ServiceScheduleCreatorController_TEST {
     }
 
     @IsTest
+    private static void shouldGetProgramEngagementById() {
+        String methodName = 'getProgramEngagementById';
+        Id peId = TestUtil.mockId(ProgramEngagement__c.SObjectType);
+        ProgramEngagement__c expected = new ProgramEngagement__c();
+        expected.Id = peId;
+
+        peServiceStub.withReturnValue(methodName, new List<Type>{ Id.class }, expected);
+        ServiceScheduleCreatorController.peService = (ProgramEngagementService) peServiceStub.createMock();
+
+        Test.startTest();
+        ProgramEngagement__c actual = ServiceScheduleCreatorController.getProgramEngagementById(
+            peId
+        );
+        Test.stopTest();
+
+        System.assertEquals(
+            expected,
+            actual,
+            'Expected Program Engagement was not returned'
+        );
+        peServiceStub.assertCalled(methodName, new List<Type>{ Id.class });
+    }
+
+    @IsTest
+    private static void shouldGetProgramEngagementByIdException() {
+        String methodName = 'getProgramEngagementById';
+        peServiceStub.withThrowException(methodName, new List<Type>{ Id.class });
+        Exception actualException;
+        Id peId = TestUtil.mockId(ProgramEngagement__c.SObjectType);
+        ProgramEngagement__c actual;
+        ServiceScheduleCreatorController.peService = (ProgramEngagementService) peServiceStub.createMock();
+
+        Test.startTest();
+        try {
+            actual = ServiceScheduleCreatorController.getProgramEngagementById(peId);
+        } catch (Exception ex) {
+            actualException = ex;
+        }
+        Test.stopTest();
+
+        System.assertEquals(
+            peServiceStub.testExceptionMessage,
+            actualException.getMessage(),
+            'Expected the controller to rethrow the exception from the service.'
+        );
+        peServiceStub.assertCalled(methodName, new List<Type>{ Id.class });
+    }
+
+    @IsTest
     private static void shouldGetModelFromService() {
         String methodName = 'getServiceScheduleModel';
         ServiceScheduleModel modelToReturn = new ServiceScheduleModel();

--- a/force-app/main/default/classes/ServiceScheduleService.cls
+++ b/force-app/main/default/classes/ServiceScheduleService.cls
@@ -101,10 +101,11 @@ public with sharing class ServiceScheduleService {
     public SelectParticipantModel getSelectParticipantModel(
         Id serviceId,
         String searchText,
+        String stage,
         Id cohortId
     ) {
         SelectParticipantModel model = new SelectParticipantModel();
-        loadAndPopulateParticipantRecords(serviceId, model, searchText, cohortId);
+        loadAndPopulateParticipantRecords(serviceId, model, searchText, stage, cohortId);
         return model;
     }
 
@@ -254,8 +255,14 @@ public with sharing class ServiceScheduleService {
         Id serviceId,
         SelectParticipantModel model,
         String searchText,
+        String stage,
         Id cohortId
     ) {
+        Set<String> stages;
+        stages = String.isEmpty(stage)
+            ? progEngagementService.getActiveStages()
+            : new Set<String>{ stage };
+
         model.program = programEngagementSelector.getProgramByServiceId(serviceId);
         if (model.program == null) {
             return;
@@ -268,7 +275,7 @@ public with sharing class ServiceScheduleService {
         model.programEngagements = programEngagementSelector.getProgramEngagementsByProgramId(
             model.program.Id,
             getSelectFieldsWithToLabel(model),
-            progEngagementService.getActiveStages(),
+            stages,
             searchText,
             cohortId
         );

--- a/force-app/main/default/classes/ServiceScheduleService_TEST.cls
+++ b/force-app/main/default/classes/ServiceScheduleService_TEST.cls
@@ -929,6 +929,7 @@ public with sharing class ServiceScheduleService_TEST {
         SelectParticipantModel actual = service.getSelectParticipantModel(
             serviceId,
             null,
+            null,
             null
         );
         Test.stopTest();
@@ -1003,6 +1004,7 @@ public with sharing class ServiceScheduleService_TEST {
         SelectParticipantModel actualModel = service.getSelectParticipantModel(
             TestUtil.mockId(Service__c.SObjectType),
             null,
+            'Active',
             null
         );
         Test.stopTest();
@@ -1072,6 +1074,7 @@ public with sharing class ServiceScheduleService_TEST {
         // Step 3
         SelectParticipantModel participantModel = service.getSelectParticipantModel(
             serviceId,
+            null,
             null,
             null
         );

--- a/force-app/main/default/labels/CustomLabels.labels-meta.xml
+++ b/force-app/main/default/labels/CustomLabels.labels-meta.xml
@@ -417,6 +417,13 @@
         <value>Filter by {0}</value>
     </labels>
     <labels>
+        <fullName>Filter_by_Stage</fullName>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>Filter by Stage</shortDescription>
+        <value>Filter by Stage</value>
+    </labels>
+    <labels>
         <fullName>Finish</fullName>
         <language>en_US</language>
         <protected>true</protected>

--- a/force-app/main/default/labels/CustomLabels.labels-meta.xml
+++ b/force-app/main/default/labels/CustomLabels.labels-meta.xml
@@ -413,8 +413,8 @@
         <fullName>Filter_by_Record</fullName>
         <language>en_US</language>
         <protected>true</protected>
-        <shortDescription>Filter by {SObject Label}</shortDescription>
-        <value>Filter by {0}</value>
+        <shortDescription>Filter by: {SObject Label}</shortDescription>
+        <value>Filter by: {0}</value>
     </labels>
     <labels>
         <fullName>Filter_by_Stage</fullName>

--- a/force-app/main/default/lwc/participantSelector/participantSelector.html
+++ b/force-app/main/default/lwc/participantSelector/participantSelector.html
@@ -28,7 +28,10 @@
                     class="slds-var-p-right_small slds-var-p-top_xx-small"
                 >
                     <lightning-layout multiple-rows="true">
-                        <lightning-layout-item size="6" class="slds-var-p-bottom_small">
+                        <lightning-layout-item
+                            size={controlSize}
+                            class="slds-var-p-bottom_small"
+                        >
                             <lightning-input
                                 type="String"
                                 label={objectLabels.program.objectLabel}
@@ -37,12 +40,20 @@
                                 disabled
                             ></lightning-input>
                         </lightning-layout-item>
-                        <lightning-layout-item size="6">
+                        <lightning-layout-item size={controlSize}>
                             <lightning-combobox
                                 label={labels.filterByCohort}
                                 options={searchOptions}
                                 onchange={handleCohortChange}
-                                value={selectedCohortId}
+                                placeholder={labels.none}
+                                class="slds-var-p-right_medium"
+                            ></lightning-combobox>
+                        </lightning-layout-item>
+                        <lightning-layout-item size="2" if:true={showStageInput}>
+                            <lightning-combobox
+                                label={labels.filterByStage}
+                                options={stageOptions}
+                                onchange={handleStageChange}
                                 placeholder={labels.none}
                             ></lightning-combobox>
                         </lightning-layout-item>

--- a/force-app/main/default/lwc/participantSelector/participantSelector.js
+++ b/force-app/main/default/lwc/participantSelector/participantSelector.js
@@ -27,7 +27,6 @@ import none from "@salesforce/label/c.None";
 import noRecordsFound from "@salesforce/label/c.No_Records_Found";
 import noRecordsSelected from "@salesforce/label/c.No_Records_Selected";
 import filterByRecord from "@salesforce/label/c.Filter_By_Record";
-import filterByStage from "@salesforce/label/c.Filter_By_Stage";
 import noContactsSelected from "@salesforce/label/c.No_Service_Participants_Created_Warning";
 import add from "@salesforce/label/c.Add";
 import addAll from "@salesforce/label/c.Add_All";
@@ -100,7 +99,6 @@ export default class ParticipantSelector extends LightningElement {
         removeLabel,
         loading,
         tooManyResults,
-        filterByStage,
     };
 
     @api
@@ -238,6 +236,7 @@ export default class ParticipantSelector extends LightningElement {
         this.labels.filterByCohort = format(filterByRecord, [
             this.objectLabels.programCohort.objectLabel,
         ]);
+        this.labels.filterByStage = format(filterByRecord, [this.fields.stage.label]);
     }
 
     loadTableRows(data) {


### PR DESCRIPTION
# Critical Changes

# Changes
Adds a Stage Filter to the Participant Selector component

# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
- [ ] Any net new LWC work has Sa11y tests & 50% or above lines JEST test coverage  
- [ ] CRUD/FLS is enforced in Apex
- [ ] Permission sets are updated to account for CRUD|FLS|Tab|Classes
- [ ] Field sets are updated to account for new fields
- [ ] UX approval or UX not necessary
- [x] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: W-0000000: Work Name (https://github.com/SalesforceFoundation/PMM/pull/303)
- [ ] All **acceptance criteria** have been met
    - [x] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [x] PR contains draft release notes
- [ ] QE story level testing completed