### PR TITLE
Sort order for BSDT Comboboxes

### DIFF
--- a/force-app/main/default/classes/ProgramEngagementSelector.cls
+++ b/force-app/main/default/classes/ProgramEngagementSelector.cls
@@ -25,6 +25,7 @@ public with sharing class ProgramEngagementSelector {
             SELECT Id, Name, Program__c, Program__r.Name
             FROM ProgramEngagement__c
             WHERE Contact__c = :contactId
+            ORDER BY Name
         ];
 
         return Security.stripInaccessible(AccessType.READABLE, queriedEngagements)

--- a/force-app/main/default/classes/ProgramEngagementSelector.cls
+++ b/force-app/main/default/classes/ProgramEngagementSelector.cls
@@ -25,9 +25,8 @@ public with sharing class ProgramEngagementSelector {
             SELECT Id, Name, Program__c, Program__r.Name
             FROM ProgramEngagement__c
             WHERE Contact__c = :contactId
-            ORDER BY Name
         ];
-
+        queriedEngagements.sort();
         return Security.stripInaccessible(AccessType.READABLE, queriedEngagements)
             .getRecords();
     }

--- a/force-app/main/default/classes/ProgramSelector.cls
+++ b/force-app/main/default/classes/ProgramSelector.cls
@@ -41,7 +41,7 @@ public with sharing class ProgramSelector {
                 ' IN :allowedProgramCohortStatuses'
             );
         }
-
+        queryBuilder.withOrderBy(String.valueOf(ProgramCohort__c.Name));
         programCohorts = Database.query(queryBuilder.buildSoqlQuery());
 
         return Security.stripInaccessible(AccessType.READABLE, programCohorts)

--- a/force-app/main/default/classes/ProgramSelector.cls
+++ b/force-app/main/default/classes/ProgramSelector.cls
@@ -41,9 +41,8 @@ public with sharing class ProgramSelector {
                 ' IN :allowedProgramCohortStatuses'
             );
         }
-        queryBuilder.withOrderBy(String.valueOf(ProgramCohort__c.Name));
         programCohorts = Database.query(queryBuilder.buildSoqlQuery());
-
+        programCohorts.sort();
         return Security.stripInaccessible(AccessType.READABLE, programCohorts)
             .getRecords();
     }

--- a/force-app/main/default/classes/ServiceSelector.cls
+++ b/force-app/main/default/classes/ServiceSelector.cls
@@ -19,6 +19,7 @@ public with sharing class ServiceSelector {
             SELECT Id, Name, Program__c
             FROM Service__c
             WHERE Program__c IN :programIds
+            ORDER BY Name
         ];
 
         return Security.stripInaccessible(AccessType.READABLE, queriedServices)
@@ -39,6 +40,7 @@ public with sharing class ServiceSelector {
                     FROM ProgramEngagement__c
                     WHERE Id = :programEngagementId
                 )
+            ORDER BY Name
         ];
 
         return Security.stripInaccessible(AccessType.READABLE, services).getRecords();

--- a/force-app/main/default/classes/ServiceSelector.cls
+++ b/force-app/main/default/classes/ServiceSelector.cls
@@ -19,9 +19,8 @@ public with sharing class ServiceSelector {
             SELECT Id, Name, Program__c
             FROM Service__c
             WHERE Program__c IN :programIds
-            ORDER BY Name
         ];
-
+        queriedServices.sort();
         return Security.stripInaccessible(AccessType.READABLE, queriedServices)
             .getRecords();
     }
@@ -40,9 +39,8 @@ public with sharing class ServiceSelector {
                     FROM ProgramEngagement__c
                     WHERE Id = :programEngagementId
                 )
-            ORDER BY Name
         ];
-
+        services.sort();
         return Security.stripInaccessible(AccessType.READABLE, services).getRecords();
     }
 


### PR DESCRIPTION
# Critical Changes

# Changes
Adds ORDER BY clauses for apex methods returning records for BSDT comboboxes.
- Cohorts
- Program Engagements
- Services

# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
- [ ] Any net new LWC work has Sa11y tests & 50% or above lines JEST test coverage  
- [ ] CRUD/FLS is enforced in Apex
- [ ] Permission sets are updated to account for CRUD|FLS|Tab|Classes
- [ ] Field sets are updated to account for new fields
- [ ] UX approval or UX not necessary
- [x] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: W-0000000: Work Name (https://github.com/SalesforceFoundation/PMM/pull/303)
- [x] All **acceptance criteria** have been met
    - [x] Developer
    - [ ] Code Reviewer
    - [x] QA
- [x] PR contains draft release notes
- [x] QE story level testing completed