### PR TITLE
W-12674462 - Update cumulusci.yml for static release notes

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -1,4 +1,4 @@
-minimum_cumulusci_version: "3.36.0"
+minimum_cumulusci_version: 3.74.0
 project:
     name: PMM
     package:
@@ -220,6 +220,11 @@ tasks:
         options:
             path: unpackaged/config/customer_profiles
 
+    github_release:
+        options:
+            release_content: |
+                Check out the Salesforce Release Notes on [Salesforce Help & Training](https://sfdc.co/bnL4Cb).
+
 flows:
     make_community:
         steps:
@@ -438,6 +443,11 @@ flows:
                 ui_options:
                     reports:
                         name: "Deploy Folder of Unmanaged Reports"
+
+    release_production:
+        steps:
+            3:
+                task: None
 
 plans:
     install:


### PR DESCRIPTION
Related WI: [W-12674462](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001Mz9NwYAJ/view)
Related TD: [TD-0127818](https://gus.lightning.force.com/lightning/r/a0nEE0000008Y2vYAE/view)

Update cumulusci.yml to use static release notes (instead of dynamic-generated ones) that redirect to the H&T SFDO release notes

# Critical Changes

# Changes

# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done
  Refer to [Asteroids DoD document](https://salesforce.quip.com/iq2mAy4i62oM) to see any additional details for the items below
- [ ] Any net new LWC work has Sa11y tests & 50% or above lines JEST test coverage  
- [ ] CRUD/FLS is enforced in Apex
- [ ] Permission sets are updated to account for CRUD|FLS|Tab|Classes
- [ ] Field sets are updated to account for new fields
- [ ] UX approval or UX not necessary
- [ ] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: W-0000000: Work Name (https://github.com/SalesforceFoundation/PMM/pull/303)
- [ ] All **acceptance criteria** have been met
    - [ ] Developer
    - [ ] Code Reviewer
    - [ ] QA
- [ ] PR contains draft release notes
- [ ] QE story level testing completed